### PR TITLE
 Enable installation of all required resources with helm install

### DIFF
--- a/helm/oci-native-ingress-controller/templates/_helpers.tpl
+++ b/helm/oci-native-ingress-controller/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 */}}
 {{- define "oci-native-ingress-controller.labels" -}}
 helm.sh/chart: {{ include "oci-native-ingress-controller.chart" . }}
+helm.sh/release-name: {{ .Release.Name }}
 {{ include "oci-native-ingress-controller.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/oci-native-ingress-controller/templates/crds.yaml
+++ b/helm/oci-native-ingress-controller/templates/crds.yaml
@@ -1,0 +1,32 @@
+#
+# OCI Native Ingress Controller
+#
+# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+{{if .Values.installCRDs }}
+{{if not (.Capabilities.APIVersions.Has "ingress.oraclecloud.com/v1beta1") }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{ end }}
+{{ end }}
+
+{{- if .Values.ingressParams}}
+---
+apiVersion: "ingress.oraclecloud.com/v1beta1"
+kind: IngressClassParameters
+metadata:
+  name: {{ include "oci-native-ingress-controller.fullname" . }}-params
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
+spec:
+  compartmentId: "{{ .Values.compartment_id }}"
+  subnetId: "{{ .Values.subnet_id }}"
+  loadBalancerName: "{{ include "oci-native-ingress-controller.fullname" . }}"
+  isPrivate: {{ .Values.ingressParams.isPrivate | default false }}
+  minBandwidthMbps: {{ .Values.ingressParams.minBandwidthMbps | default 10 }}
+  maxBandwidthMbps: {{ .Values.ingressParams.maxBandwidthMbps | default 10 }}
+{{- end }}

--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -4,16 +4,12 @@
 # Copyright (c) 2023 Oracle America, Inc. and its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.deploymentNamespace }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "oci-native-ingress-controller.fullname" . }}
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
 spec:

--- a/helm/oci-native-ingress-controller/templates/ingressclass.yaml
+++ b/helm/oci-native-ingress-controller/templates/ingressclass.yaml
@@ -1,0 +1,26 @@
+#
+# OCI Native Ingress Controller
+#
+# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+{{- if .Values.ingressClass }}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ .Values.ingressClass.name }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: {{ .Values.ingressClass.default | quote }}
+spec:
+  controller: oci.oraclecloud.com/native-ingress-controller
+  parameters:
+    scope: Namespace
+    namespace: {{ .Values.deploymentNamespace }}
+    apiGroup: ingress.oraclecloud.com
+    kind: ingressclassparameters
+    name: {{ include "oci-native-ingress-controller.fullname" . }}-params
+{{- end }}

--- a/helm/oci-native-ingress-controller/templates/pdb.yaml
+++ b/helm/oci-native-ingress-controller/templates/pdb.yaml
@@ -9,7 +9,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "oci-native-ingress-controller.fullname" . }}
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
 spec:

--- a/helm/oci-native-ingress-controller/templates/rbac.yaml
+++ b/helm/oci-native-ingress-controller/templates/rbac.yaml
@@ -82,5 +82,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "oci-native-ingress-controller.serviceAccountName" . }}
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
 {{- end }}

--- a/helm/oci-native-ingress-controller/templates/service.yaml
+++ b/helm/oci-native-ingress-controller/templates/service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "oci-native-ingress-controller.fullname" . }}
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
 spec:

--- a/helm/oci-native-ingress-controller/templates/serviceaccount.yaml
+++ b/helm/oci-native-ingress-controller/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "oci-native-ingress-controller.serviceAccountName" . }}
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/oci-native-ingress-controller/templates/webhook.yaml
+++ b/helm/oci-native-ingress-controller/templates/webhook.yaml
@@ -8,12 +8,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: oci-native-ingress-controller-webhook-serving-cert
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
 spec:
   dnsNames:
-  - oci-native-ingress-controller.{{ .Values.deploymentNamespace }}
-  - oci-native-ingress-controller.{{ .Values.deploymentNamespace }}.svc
-  - oci-native-ingress-controller.{{ .Values.deploymentNamespace }}.svc.cluster.local
+    - oci-native-ingress-controller.{{ .Values.namespaceOverride | default .Release.Namespace }}
+    - oci-native-ingress-controller.{{ .Values.namespaceOverride | default .Release.Namespace }}.svc
+    - oci-native-ingress-controller.{{ .Values.namespaceOverride | default .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: oci-native-ingress-controller-ca
@@ -23,7 +23,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: oci-native-ingress-controller-ca
-  namespace: {{ .Values.deploymentNamespace }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -34,12 +34,12 @@ metadata:
   labels:
     {{- include "oci-native-ingress-controller.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.deploymentNamespace }}/oci-native-ingress-controller-webhook-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Values.namespaceOverride | default .Release.Namespace }}/oci-native-ingress-controller-webhook-serving-cert
 webhooks:
 - clientConfig:
     service:
       name: {{ include "oci-native-ingress-controller.fullname" . }}
-      namespace: {{ .Values.deploymentNamespace }}
+      namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
       path: /mutate-v1-pod
   failurePolicy: Fail
   name: podreadiness.ingress.oraclecloud.com
@@ -78,4 +78,3 @@ webhooks:
     resources:
     - pods
   sideEffects: None
-

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -9,13 +9,25 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+installCRDs: true
+
 controller_class: oci.oraclecloud.com/native-ingress-controller
 lease_lock_name: oci-native-ingress-controller
 compartment_id: ""
 subnet_id: ""
 
-deploymentNamespace : native-ingress-controller-system
+# namespaceOverride: ""
+
 replicaCount: 1
+
+ingressParams:
+  isPrivate: false
+  minBandwidthMbps: 10
+  maxBandwidthMbps: 100
+
+ingressClass:
+  name: native-ic-ingress-class
+  default: true
 
 image:
   repository: ghcr.io/oracle/oci-native-ingress-controller


### PR DESCRIPTION
This update enables the installation of all required resources using the `helm install` command.

Added in `values.yaml`:

- installCRDs: parameter to automatically install CRDs (Custom Resource Definitions).
- ingressParams: parameters for the IngressClassParameters resource.
- ingressClass: parameters for the IngressClass resource.

Example usage:

```bash
helm upgrade --install oci-native-ingress-controller --set installCRDs=true
```

This change allows you to install all necessary resources when running the `helm install` command. You can set the `installCRDs` parameter to true to automatically install the CRDs. Additionally, you can use the `ingressParams` and `ingressClass` parameters to customize the configuration of the `IngressClassParameters` and `IngressClass` resources, respectively.

With this update, you can simplify the installation process and ensure that all required resources are properly configured.