### PR TITLE
Update lb resource tagging

### DIFF
--- a/pkg/controllers/ingressclass/ingressclass.go
+++ b/pkg/controllers/ingressclass/ingressclass.go
@@ -256,6 +256,7 @@ func (c *Controller) ensureLoadBalancer(ic *networkingv1.IngressClass) error {
 					},
 				},
 			},
+			FreeformTags: map[string]string{"oci-native-ingress-controller-resource": "loadbalancer"},
 		}
 
 		if icp.Spec.ReservedPublicAddressId != "" {


### PR DESCRIPTION
- Added resource tag for LB created via ingress controller
`oci-native-ingress-controller-resource: loadbalancer`