### PR TITLE
OKE-26958 Web application firewall integration

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,29 +7,29 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type Client struct {
+type ClientProvider struct {
 	kubernetesClient   kubernetes.Interface
 	wafClient          *waf.Client
 	lbClient           *loadbalancer.LoadBalancerClient
 	certificatesClient *certificate.CertificatesClient
 }
 
-func NewWrapperClient(kubernetesClient kubernetes.Interface, wafClient *waf.Client, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient) *Client {
-	return &Client{kubernetesClient: kubernetesClient, wafClient: wafClient, lbClient: lbClient, certificatesClient: certificatesClient}
+func NewWrapperClient(kubernetesClient kubernetes.Interface, wafClient *waf.Client, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient) *ClientProvider {
+	return &ClientProvider{kubernetesClient: kubernetesClient, wafClient: wafClient, lbClient: lbClient, certificatesClient: certificatesClient}
 }
 
-func (c Client) GetK8Client() kubernetes.Interface {
+func (c ClientProvider) GetK8Client() kubernetes.Interface {
 	return c.kubernetesClient
 }
 
-func (c Client) GetWafClient() *waf.Client {
+func (c ClientProvider) GetWafClient() *waf.Client {
 	return c.wafClient
 }
 
-func (c Client) GetLbClient() *loadbalancer.LoadBalancerClient {
+func (c ClientProvider) GetLbClient() *loadbalancer.LoadBalancerClient {
 	return c.lbClient
 }
 
-func (c Client) GetCertClient() *certificate.CertificatesClient {
+func (c ClientProvider) GetCertClient() *certificate.CertificatesClient {
 	return c.certificatesClient
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"github.com/oracle/oci-native-ingress-controller/pkg/certificate"
+	"github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/waf"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Client struct {
+	kubernetesClient   kubernetes.Interface
+	wafClient          *waf.Client
+	lbClient           *loadbalancer.LoadBalancerClient
+	certificatesClient *certificate.CertificatesClient
+}
+
+func NewWrapperClient(kubernetesClient kubernetes.Interface, wafClient *waf.Client, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient) *Client {
+	return &Client{kubernetesClient: kubernetesClient, wafClient: wafClient, lbClient: lbClient, certificatesClient: certificatesClient}
+}
+
+func (c Client) GetK8Client() kubernetes.Interface {
+	return c.kubernetesClient
+}
+
+func (c Client) GetWafClient() *waf.Client {
+	return c.wafClient
+}
+
+func (c Client) GetLbClient() *loadbalancer.LoadBalancerClient {
+	return c.lbClient
+}
+
+func (c Client) GetCertClient() *certificate.CertificatesClient {
+	return c.certificatesClient
+}

--- a/pkg/controllers/backend/backend.go
+++ b/pkg/controllers/backend/backend.go
@@ -53,7 +53,7 @@ type Controller struct {
 	endpointLister     corelisters.EndpointsLister
 
 	queue  workqueue.RateLimitingInterface
-	client *client.Client
+	client *client.ClientProvider
 }
 
 func NewController(
@@ -63,7 +63,7 @@ func NewController(
 	serviceLister corelisters.ServiceLister,
 	endpointLister corelisters.EndpointsLister,
 	podLister corelisters.PodLister,
-	client *client.Client,
+	client *client.ClientProvider,
 ) *Controller {
 
 	c := &Controller{

--- a/pkg/controllers/backend/backend.go
+++ b/pkg/controllers/backend/backend.go
@@ -16,8 +16,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/controllers/ingressclass"
-
 	"k8s.io/klog/v2"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -33,13 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	networkinginformers "k8s.io/client-go/informers/networking/v1"
-	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 )
 
@@ -54,11 +52,8 @@ type Controller struct {
 	podLister          corelisters.PodLister
 	endpointLister     corelisters.EndpointsLister
 
-	queue workqueue.RateLimitingInterface
-
-	clientset kubernetes.Interface
-
-	lbClient *loadbalancer.LoadBalancerClient
+	queue  workqueue.RateLimitingInterface
+	client *client.Client
 }
 
 func NewController(
@@ -68,8 +63,7 @@ func NewController(
 	serviceLister corelisters.ServiceLister,
 	endpointLister corelisters.EndpointsLister,
 	podLister corelisters.PodLister,
-	client kubernetes.Interface,
-	lbClient *loadbalancer.LoadBalancerClient,
+	client *client.Client,
 ) *Controller {
 
 	c := &Controller{
@@ -79,8 +73,7 @@ func NewController(
 		serviceLister:      serviceLister,
 		endpointLister:     endpointLister,
 		podLister:          podLister,
-		clientset:          client,
-		lbClient:           lbClient,
+		client:             client,
 		queue:              workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
 	}
 
@@ -207,12 +200,12 @@ func (c *Controller) ensureBackends(ingressClass *networkingv1.IngressClass, lbI
 				}
 
 				backendSetName := util.GenerateBackendSetName(ingress.Namespace, svcName, svcPort)
-				err = c.lbClient.UpdateBackends(context.TODO(), lbID, backendSetName, backends)
+				err = c.client.GetLbClient().UpdateBackends(context.TODO(), lbID, backendSetName, backends)
 				if err != nil {
 					return fmt.Errorf("unable to update backends for %s/%s: %w", ingressClass.Name, backendSetName, err)
 				}
 
-				backendSetHealth, err := c.lbClient.GetBackendSetHealth(context.TODO(), lbID, backendSetName)
+				backendSetHealth, err := c.client.GetLbClient().GetBackendSetHealth(context.TODO(), lbID, backendSetName)
 				if err != nil {
 					return fmt.Errorf("unable to fetch backendset health: %w", err)
 				}
@@ -249,7 +242,7 @@ func (c *Controller) syncDefaultBackend(lbID string, ingresses []*networkingv1.I
 		return nil
 	}
 
-	err = c.lbClient.UpdateBackends(context.TODO(), lbID, ingressclass.DefaultIngress, backends)
+	err = c.client.GetLbClient().UpdateBackends(context.TODO(), lbID, ingressclass.DefaultIngress, backends)
 	if err != nil {
 		return err
 	}
@@ -378,7 +371,7 @@ func (c *Controller) ensurePodReadinessCondition(pod *corev1.Pod, readinessGate 
 		return fmt.Errorf("unable to build pod condition for %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
 
-	_, err = c.clientset.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	_, err = c.client.GetK8Client().CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	if err != nil {
 		return fmt.Errorf("unable to remove readiness gate %s from pod %s/%s: %w", readinessGate, pod.Namespace, pod.Name, err)
 	}

--- a/pkg/controllers/backend/backend_test.go
+++ b/pkg/controllers/backend/backend_test.go
@@ -10,8 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -187,8 +188,9 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 		Cache:    map[string]*lb.LbCacheObj{},
 	}
 
-	ingressClassInformer, ingressInformer, serviceLister, endpointLister, podLister, client := setUp(ctx, ingressClassList, ingressList, testService, endpoints, pod)
-	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, serviceLister, endpointLister, podLister, client, loadBalancerClient)
+	ingressClassInformer, ingressInformer, serviceLister, endpointLister, podLister, k8client := setUp(ctx, ingressClassList, ingressList, testService, endpoints, pod)
+	client := client.NewWrapperClient(k8client, nil, loadBalancerClient, nil)
+	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, serviceLister, endpointLister, podLister, client)
 	return c
 }
 
@@ -238,7 +240,7 @@ func TestBuildPodConditionPatch(t *testing.T) {
 	Expect(bytes.Equal(patch, []byte("{\"status\":{\"conditions\":[{\"lastProbeTime\":null,\"lastTransitionTime\":null,\"status\":\"True\",\"type\":\"ContainersReady\"}]}}"))).Should(Equal(true))
 }
 
-func getLoadBalancerClient() client.LoadBalancerInterface {
+func getLoadBalancerClient() ociclient.LoadBalancerInterface {
 	return &MockLoadBalancerClient{}
 }
 

--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -57,7 +57,7 @@ type Controller struct {
 	serviceLister      corelisters.ServiceLister
 	queue              workqueue.RateLimitingInterface
 	informer           networkinginformers.IngressInformer
-	client             *client.Client
+	client             *client.ClientProvider
 	metricsCollector   *metric.IngressCollector
 }
 
@@ -65,7 +65,7 @@ type Controller struct {
 func NewController(controllerClass string, defaultCompartmentId string,
 	ingressClassInformer networkinginformers.IngressClassInformer, ingressInformer networkinginformers.IngressInformer,
 	serviceLister corelisters.ServiceLister,
-	client *client.Client,
+	client *client.ClientProvider,
 	reg *prometheus.Registry) *Controller {
 
 	c := &Controller{

--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/pkg/errors"
@@ -35,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	networkinginformers "k8s.io/client-go/informers/networking/v1"
-	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
@@ -57,10 +57,7 @@ type Controller struct {
 	serviceLister      corelisters.ServiceLister
 	queue              workqueue.RateLimitingInterface
 	informer           networkinginformers.IngressInformer
-	client             kubernetes.Interface
-
-	lbClient           *loadbalancer.LoadBalancerClient
-	certificatesClient *certificate.CertificatesClient
+	client             *client.Client
 	metricsCollector   *metric.IngressCollector
 }
 
@@ -68,7 +65,7 @@ type Controller struct {
 func NewController(controllerClass string, defaultCompartmentId string,
 	ingressClassInformer networkinginformers.IngressClassInformer, ingressInformer networkinginformers.IngressInformer,
 	serviceLister corelisters.ServiceLister,
-	client kubernetes.Interface, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient,
+	client *client.Client,
 	reg *prometheus.Registry) *Controller {
 
 	c := &Controller{
@@ -79,8 +76,6 @@ func NewController(controllerClass string, defaultCompartmentId string,
 		informer:             ingressInformer,
 		serviceLister:        serviceLister,
 		client:               client,
-		lbClient:             lbClient,
-		certificatesClient:   certificatesClient,
 		queue:                workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
 		metricsCollector:     metric.NewIngressCollector(controllerClass, reg),
 	}
@@ -248,7 +243,7 @@ func (c *Controller) sync(key string) error {
 
 func (c *Controller) ensureLoadBalancerIP(lbID string, ingress *networkingv1.Ingress) error {
 
-	lb, _, err := c.lbClient.GetLoadBalancer(context.TODO(), lbID)
+	lb, _, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbID)
 	if err != nil {
 		return errors.Wrapf(err, "unable to fetch ip from load balancer: %s", err.Error())
 	}
@@ -276,7 +271,7 @@ func (c *Controller) ensureLoadBalancerIP(lbID string, ingress *networkingv1.Ing
 	klog.V(2).InfoS("adding ip address to ingress", "ingress", klog.KObj(ingress), "ipAddress", ipAddress)
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		latest, err := c.client.NetworkingV1().Ingresses(ingress.Namespace).Get(context.TODO(), ingress.Name, metav1.GetOptions{})
+		latest, err := c.client.GetK8Client().NetworkingV1().Ingresses(ingress.Namespace).Get(context.TODO(), ingress.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -285,7 +280,7 @@ func (c *Controller) ensureLoadBalancerIP(lbID string, ingress *networkingv1.Ing
 			{IP: ipAddress},
 		}
 
-		_, err = c.client.NetworkingV1().Ingresses(ingress.Namespace).UpdateStatus(context.TODO(), latest, metav1.UpdateOptions{})
+		_, err = c.client.GetK8Client().NetworkingV1().Ingresses(ingress.Namespace).UpdateStatus(context.TODO(), latest, metav1.UpdateOptions{})
 		return err
 	})
 
@@ -316,7 +311,7 @@ func (c *Controller) ensureIngress(ingress *networkingv1.Ingress, ingressClass *
 
 	lbId := util.GetIngressClassLoadBalancerId(ingressClass)
 
-	lb, _, err := c.lbClient.GetLoadBalancer(context.TODO(), lbId)
+	lb, _, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbId)
 	if err != nil {
 		return err
 	}
@@ -337,14 +332,14 @@ func (c *Controller) ensureIngress(ingress *networkingv1.Ingress, ingressClass *
 		startBuildTime := util.GetCurrentTimeInUnixMillis()
 		klog.V(2).InfoS("creating backend set for ingress", "ingress", klog.KObj(ingress), "backendSetName", bsName)
 		artifact, artifactType := stateStore.GetTLSConfigForBackendSet(bsName)
-		backendSetSslConfig, err := certificate.GetSSLConfigForBackendSet(ingress.Namespace, artifactType, artifact, lb, bsName, c.defaultCompartmentId, c.certificatesClient, c.client)
+		backendSetSslConfig, err := certificate.GetSSLConfigForBackendSet(ingress.Namespace, artifactType, artifact, lb, bsName, c.defaultCompartmentId, c.client.GetCertClient(), c.client.GetK8Client())
 		if err != nil {
 			return err
 		}
 
 		healthChecker := stateStore.GetBackendSetHealthChecker(bsName)
 		policy := stateStore.GetBackendSetPolicy(bsName)
-		err = c.lbClient.CreateBackendSet(context.TODO(), lbId, bsName, policy, healthChecker, backendSetSslConfig)
+		err = c.client.GetLbClient().CreateBackendSet(context.TODO(), lbId, bsName, policy, healthChecker, backendSetSslConfig)
 		if err != nil {
 			return err
 		}
@@ -372,13 +367,13 @@ func (c *Controller) ensureIngress(ingress *networkingv1.Ingress, ingressClass *
 
 		var listenerSslConfig *ociloadbalancer.SslConfigurationDetails
 		artifact, artifactType := stateStore.GetTLSConfigForListener(port)
-		listenerSslConfig, err := certificate.GetSSLConfigForListener(ingress.Namespace, nil, artifactType, artifact, c.defaultCompartmentId, c.certificatesClient, c.client)
+		listenerSslConfig, err := certificate.GetSSLConfigForListener(ingress.Namespace, nil, artifactType, artifact, c.defaultCompartmentId, c.client.GetCertClient(), c.client.GetK8Client())
 		if err != nil {
 			return err
 		}
 
 		protocol := stateStore.GetListenerProtocol(port)
-		err = c.lbClient.CreateListener(context.TODO(), lbId, int(port), protocol, listenerSslConfig)
+		err = c.client.GetLbClient().CreateListener(context.TODO(), lbId, int(port), protocol, listenerSslConfig)
 		if err != nil {
 			return err
 		}
@@ -389,7 +384,7 @@ func (c *Controller) ensureIngress(ingress *networkingv1.Ingress, ingressClass *
 		return err
 	}
 
-	err = deleteBackendSets(actualBackendSets, desiredBackendSets, c.lbClient, lbId)
+	err = deleteBackendSets(actualBackendSets, desiredBackendSets, c.client.GetLbClient(), lbId)
 	if err != nil {
 		return err
 	}
@@ -399,7 +394,7 @@ func (c *Controller) ensureIngress(ingress *networkingv1.Ingress, ingressClass *
 		return err
 	}
 
-	return deleteListeners(actualListenerPorts, desiredListenerPorts, c.lbClient, lbId)
+	return deleteListeners(actualListenerPorts, desiredListenerPorts, c.client.GetLbClient(), lbId)
 }
 
 func handleIngressDelete(c *Controller, ingressClass *networkingv1.IngressClass) error {
@@ -412,7 +407,7 @@ func handleIngressDelete(c *Controller, ingressClass *networkingv1.IngressClass)
 
 	lbId := util.GetIngressClassLoadBalancerId(ingressClass)
 
-	lb, _, err := c.lbClient.GetLoadBalancer(context.TODO(), lbId)
+	lb, _, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbId)
 	if err != nil {
 		return err
 	}
@@ -422,7 +417,7 @@ func handleIngressDelete(c *Controller, ingressClass *networkingv1.IngressClass)
 		actualBackendSets.Insert(bsName)
 	}
 
-	err = deleteBackendSets(actualBackendSets, stateStore.GetAllBackendSetForIngressClass(), c.lbClient, lbId)
+	err = deleteBackendSets(actualBackendSets, stateStore.GetAllBackendSetForIngressClass(), c.client.GetLbClient(), lbId)
 	if err != nil {
 		return err
 	}
@@ -432,7 +427,7 @@ func handleIngressDelete(c *Controller, ingressClass *networkingv1.IngressClass)
 		actualListeners.Insert(int32(*listener.Port))
 	}
 
-	err = deleteListeners(actualListeners, stateStore.GetAllListenersForIngressClass(), c.lbClient, lbId)
+	err = deleteListeners(actualListeners, stateStore.GetAllListenersForIngressClass(), c.client.GetLbClient(), lbId)
 	if err != nil {
 		return err
 	}
@@ -474,7 +469,7 @@ func deleteListeners(actualListeners sets.Int32, desiredListeners sets.Int32, lb
 
 func syncListener(namespace string, stateStore *state.StateStore, lbId *string, listenerName string, c *Controller) error {
 	startTime := util.GetCurrentTimeInUnixMillis()
-	lb, etag, err := c.lbClient.GetLoadBalancer(context.TODO(), *lbId)
+	lb, etag, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), *lbId)
 	if err != nil {
 		return err
 	}
@@ -488,7 +483,7 @@ func syncListener(namespace string, stateStore *state.StateStore, lbId *string, 
 	artifact, artifactType := stateStore.GetTLSConfigForListener(int32(*listener.Port))
 	var sslConfig *ociloadbalancer.SslConfigurationDetails
 	if artifact != "" {
-		sslConfig, err = certificate.GetSSLConfigForListener(namespace, &listener, artifactType, artifact, c.defaultCompartmentId, c.certificatesClient, c.client)
+		sslConfig, err = certificate.GetSSLConfigForListener(namespace, &listener, artifactType, artifact, c.defaultCompartmentId, c.client.GetCertClient(), c.client.GetK8Client())
 		if err != nil {
 			return err
 		}
@@ -509,7 +504,7 @@ func syncListener(namespace string, stateStore *state.StateStore, lbId *string, 
 	}
 
 	if needsUpdate {
-		err := c.lbClient.UpdateListener(context.TODO(), lbId, etag, listener, listener.RoutingPolicyName, sslConfig, &protocol)
+		err := c.client.GetLbClient().UpdateListener(context.TODO(), lbId, etag, listener, listener.RoutingPolicyName, sslConfig, &protocol)
 		if err != nil {
 			return err
 		}
@@ -524,7 +519,7 @@ func syncListener(namespace string, stateStore *state.StateStore, lbId *string, 
 func syncBackendSet(ingress *networkingv1.Ingress, lbID string, backendSetName string, stateStore *state.StateStore, c *Controller) error {
 
 	startTime := util.GetCurrentTimeInUnixMillis()
-	lb, etag, err := c.lbClient.GetLoadBalancer(context.TODO(), lbID)
+	lb, etag, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbID)
 	if err != nil {
 		return err
 	}
@@ -536,7 +531,7 @@ func syncBackendSet(ingress *networkingv1.Ingress, lbID string, backendSetName s
 
 	needsUpdate := false
 	artifact, artifactType := stateStore.GetTLSConfigForBackendSet(*bs.Name)
-	sslConfig, err := certificate.GetSSLConfigForBackendSet(ingress.Namespace, artifactType, artifact, lb, *bs.Name, c.defaultCompartmentId, c.certificatesClient, c.client)
+	sslConfig, err := certificate.GetSSLConfigForBackendSet(ingress.Namespace, artifactType, artifact, lb, *bs.Name, c.defaultCompartmentId, c.client.GetCertClient(), c.client.GetK8Client())
 	if err != nil {
 		return err
 	}
@@ -562,7 +557,7 @@ func syncBackendSet(ingress *networkingv1.Ingress, lbID string, backendSetName s
 	}
 
 	if needsUpdate {
-		err = c.lbClient.UpdateBackendSet(context.TODO(), lb.Id, etag, bs, nil, sslConfig, healthChecker, &policy)
+		err = c.client.GetLbClient().UpdateBackendSet(context.TODO(), lb.Id, etag, bs, nil, sslConfig, healthChecker, &policy)
 		if err != nil {
 			return err
 		}
@@ -641,7 +636,7 @@ func (c *Controller) ensureFinalizer(ingress *networkingv1.Ingress) error {
 			return err
 		}
 
-		_, err = c.client.NetworkingV1().Ingresses(ingress.Namespace).Patch(context.TODO(), ingress.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = c.client.GetK8Client().NetworkingV1().Ingresses(ingress.Namespace).Patch(context.TODO(), ingress.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 		return err
 	})
 
@@ -671,7 +666,7 @@ func (c *Controller) deleteFinalizer(ingress *networkingv1.Ingress) error {
 			return err
 		}
 
-		_, err = c.client.NetworkingV1().Ingresses(ingress.Namespace).Patch(context.TODO(), ingress.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = c.client.GetK8Client().NetworkingV1().Ingresses(ingress.Namespace).Patch(context.TODO(), ingress.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 		return err
 	})
 

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/certificate"
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	. "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
@@ -78,9 +79,10 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 		CaBundleCache:      map[string]*CaBundleCacheObj{},
 	}
 
-	ingressClassInformer, ingressInformer, serviceLister, client := setUp(ctx, ingressClassList, ingressList, testService)
+	ingressClassInformer, ingressInformer, serviceLister, k8client := setUp(ctx, ingressClassList, ingressList, testService)
+	client := client.NewWrapperClient(k8client, nil, loadBalancerClient, certificatesClient)
 	c := NewController("oci.oraclecloud.com/native-ingress-controller", "", ingressClassInformer,
-		ingressInformer, serviceLister, client, loadBalancerClient, certificatesClient, nil)
+		ingressInformer, serviceLister, client, nil)
 	return c
 }
 

--- a/pkg/controllers/ingressclass/ingressclass_test.go
+++ b/pkg/controllers/ingressclass/ingressclass_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/waf"
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	WAF "github.com/oracle/oci-native-ingress-controller/pkg/waf"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -163,8 +164,9 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList)
 		Cache:     map[string]*WAF.CacheObj{},
 	}
 
-	ingressClassInformer, client := setUp(ctx, ingressClassList)
-	c := NewController("", "", "oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, client, loadBalancerClient, firewallClient, nil)
+	ingressClassInformer, k8client := setUp(ctx, ingressClassList)
+	client := client.NewWrapperClient(k8client, firewallClient, loadBalancerClient, nil)
+	c := NewController("", "", "oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, client, nil)
 	return c
 }
 
@@ -184,11 +186,11 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList)
 	return ingressClassInformer, client
 }
 
-func getLoadBalancerClient() client.LoadBalancerInterface {
+func getLoadBalancerClient() ociclient.LoadBalancerInterface {
 	return &MockLoadBalancerClient{}
 }
 
-func getWafClient() client.WafInterface {
+func getWafClient() ociclient.WafInterface {
 	return &MockWafClient{}
 }
 

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -15,10 +15,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
-	"github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -29,7 +29,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	networkinginformers "k8s.io/client-go/informers/networking/v1"
-	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
@@ -47,9 +46,7 @@ type Controller struct {
 	serviceLister      corelisters.ServiceLister
 	queue              workqueue.RateLimitingInterface
 	informer           networkinginformers.IngressInformer
-	client             kubernetes.Interface
-
-	lbClient *loadbalancer.LoadBalancerClient
+	client             *client.Client
 }
 
 // NewController creates a new Controller.
@@ -58,8 +55,7 @@ func NewController(
 	ingressClassInformer networkinginformers.IngressClassInformer,
 	ingressInformer networkinginformers.IngressInformer,
 	serviceLister corelisters.ServiceLister,
-	client kubernetes.Interface,
-	lbClient *loadbalancer.LoadBalancerClient,
+	client *client.Client,
 ) *Controller {
 
 	c := &Controller{
@@ -69,9 +65,8 @@ func NewController(
 		serviceLister:      serviceLister,
 		informer:           ingressInformer,
 
-		client:   client,
-		lbClient: lbClient,
-		queue:    workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
+		client: client,
+		queue:  workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
 	}
 
 	return c
@@ -187,7 +182,7 @@ func (c *Controller) ensureRoutingRules(ingressClass *networkingv1.IngressClass)
 			})
 		}
 
-		err = c.lbClient.EnsureRoutingPolicy(context.TODO(), lbID, listenerName, rules)
+		err = c.client.GetLbClient().EnsureRoutingPolicy(context.TODO(), lbID, listenerName, rules)
 		if err != nil {
 			// we purposefully only log here then return an error at the end, so we can attempt to sync all listeners.
 			klog.ErrorS(err, "unable to ensure route policy", "ingressClass", klog.KObj(ingressClass), "listenerName", listenerName)
@@ -196,7 +191,7 @@ func (c *Controller) ensureRoutingRules(ingressClass *networkingv1.IngressClass)
 		}
 	}
 
-	lb, _, err := c.lbClient.GetLoadBalancer(context.TODO(), lbID)
+	lb, _, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbID)
 	if err != nil {
 		return err
 	}
@@ -211,7 +206,7 @@ func (c *Controller) ensureRoutingRules(ingressClass *networkingv1.IngressClass)
 	if len(routingPoliciesToDelete) > 0 {
 		klog.Infof("Following routing policies are eligible for deletion: %s", util.PrettyPrint(routingPoliciesToDelete))
 		for routingPolicyToDelete := range routingPoliciesToDelete {
-			lb, etag, err := c.lbClient.GetLoadBalancer(context.TODO(), lbID)
+			lb, etag, err := c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbID)
 			if err != nil {
 				return err
 			}
@@ -219,20 +214,20 @@ func (c *Controller) ensureRoutingRules(ingressClass *networkingv1.IngressClass)
 			listener, listenerFound := lb.Listeners[routingPolicyToDelete]
 			if listenerFound {
 				klog.Infof("Detaching the routing policy %s from listener.", routingPolicyToDelete)
-				err = c.lbClient.UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol)
+				err = c.client.GetLbClient().UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol)
 				if err != nil {
 					return err
 				}
 			}
 
-			lb, etag, err = c.lbClient.GetLoadBalancer(context.TODO(), lbID)
+			lb, etag, err = c.client.GetLbClient().GetLoadBalancer(context.TODO(), lbID)
 			if err != nil {
 				return err
 			}
 
 			_, routingPolicyFound := lb.RoutingPolicies[routingPolicyToDelete]
 			if routingPolicyFound {
-				err = c.lbClient.DeleteRoutingPolicy(context.TODO(), lbID, routingPolicyToDelete)
+				err = c.client.GetLbClient().DeleteRoutingPolicy(context.TODO(), lbID, routingPolicyToDelete)
 				if err != nil {
 					return err
 				}

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -46,7 +46,7 @@ type Controller struct {
 	serviceLister      corelisters.ServiceLister
 	queue              workqueue.RateLimitingInterface
 	informer           networkinginformers.IngressInformer
-	client             *client.Client
+	client             *client.ClientProvider
 }
 
 // NewController creates a new Controller.
@@ -55,7 +55,7 @@ func NewController(
 	ingressClassInformer networkinginformers.IngressClassInformer,
 	ingressInformer networkinginformers.IngressInformer,
 	serviceLister corelisters.ServiceLister,
-	client *client.Client,
+	client *client.ClientProvider,
 ) *Controller {
 
 	c := &Controller{

--- a/pkg/controllers/routingpolicy/routingpolicy_test.go
+++ b/pkg/controllers/routingpolicy/routingpolicy_test.go
@@ -8,8 +8,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -151,9 +152,10 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 		Cache:    map[string]*lb.LbCacheObj{},
 	}
 
-	ingressClassInformer, ingressInformer, serviceLister, client := setUp(ctx, ingressClassList, ingressList, testService)
+	ingressClassInformer, ingressInformer, serviceLister, k8client := setUp(ctx, ingressClassList, ingressList, testService)
+	client := client.NewWrapperClient(k8client, nil, loadBalancerClient, nil)
 	c := NewController("oci.oraclecloud.com/native-ingress-controller",
-		ingressClassInformer, ingressInformer, serviceLister, client, loadBalancerClient)
+		ingressClassInformer, ingressInformer, serviceLister, client)
 	return c
 }
 
@@ -182,7 +184,7 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	return ingressClassInformer, ingressInformer, serviceLister, client
 }
 
-func getLoadBalancerClient() client.LoadBalancerInterface {
+func getLoadBalancerClient() ociclient.LoadBalancerInterface {
 	return &MockLoadBalancerClient{}
 }
 

--- a/pkg/controllers/routingpolicy/routingpolicy_test.go
+++ b/pkg/controllers/routingpolicy/routingpolicy_test.go
@@ -2,6 +2,7 @@ package routingpolicy
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"testing"
 
@@ -116,6 +117,14 @@ func TestProcessRoutingPolicy(t *testing.T) {
 	err := processRoutingPolicy(ingresses, c.serviceLister, listenerPaths, desiredRoutingPolicies)
 	Expect(err == nil).Should(Equal(true))
 	Expect(len(listenerPaths)).Should(Equal(3))
+	var pathss = sets.NewString()
+	for _, paths := range listenerPaths {
+		sort.Sort(ByPath(paths))
+		for _, path := range paths {
+			pathss.Insert(path.Path.Path)
+		}
+	}
+	Expect(len(pathss)).Should(Equal(3))
 	Expect(len(desiredRoutingPolicies)).Should(Equal(3))
 }
 

--- a/pkg/controllers/routingpolicy/util.go
+++ b/pkg/controllers/routingpolicy/util.go
@@ -81,11 +81,12 @@ func processRoutingPolicy(ingresses []*networkingv1.Ingress, serviceLister corel
 				if err != nil {
 					return err
 				}
+				rulePath := path
 				listenerName := util.GenerateListenerName(servicePort)
 				listenerPaths[listenerName] = append(listenerPaths[listenerName], &listenerPath{
 					IngressName:    ingress.Name,
 					Host:           rule.Host,
-					Path:           &path,
+					Path:           &rulePath,
 					BackendSetName: util.GenerateBackendSetName(ingress.Namespace, serviceName, servicePort),
 				})
 				desiredRoutingPolicies.Insert(listenerName)

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -40,6 +40,14 @@ func TestLoadBalancerClient_CreateLoadBalancer(t *testing.T) {
 	Expect(err).To(Not(BeNil()))
 }
 
+func TestLoadBalancerClient_GetBackendSetHealth(t *testing.T) {
+	RegisterTestingT(t)
+	loadBalancerClient := setupLBClient()
+	id := "id"
+	_, err := loadBalancerClient.GetBackendSetHealth(context.TODO(), id, "k8s_adb5485972")
+	Expect(err).To(BeNil())
+}
+
 func TestLoadBalancerClient_EnsureRoutingPolicy(t *testing.T) {
 	RegisterTestingT(t)
 	loadBalancerClient := setupLBClient()
@@ -272,8 +280,18 @@ func (m MockLoadBalancerClient) DeleteBackendSet(ctx context.Context, request oc
 }
 
 func (m MockLoadBalancerClient) GetBackendSetHealth(ctx context.Context, request ociloadbalancer.GetBackendSetHealthRequest) (ociloadbalancer.GetBackendSetHealthResponse, error) {
-	//TODO implement me
-	panic("implement me")
+	return ociloadbalancer.GetBackendSetHealthResponse{
+		RawResponse: nil,
+		BackendSetHealth: ociloadbalancer.BackendSetHealth{
+			Status:                    ociloadbalancer.BackendSetHealthStatusOk,
+			WarningStateBackendNames:  nil,
+			CriticalStateBackendNames: nil,
+			UnknownStateBackendNames:  nil,
+			TotalBackendCount:         nil,
+		},
+		OpcRequestId: nil,
+		ETag:         nil,
+	}, nil
 }
 
 func (m MockLoadBalancerClient) CreateRoutingPolicy(ctx context.Context, request ociloadbalancer.CreateRoutingPolicyRequest) (ociloadbalancer.CreateRoutingPolicyResponse, error) {

--- a/pkg/oci/client/waf.go
+++ b/pkg/oci/client/waf.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"context"
+
+	"github.com/oracle/oci-go-sdk/v65/waf"
+)
+
+type WafInterface interface {
+	GetWebAppFirewall(ctx context.Context, request waf.GetWebAppFirewallRequest) (response waf.GetWebAppFirewallResponse, err error)
+	CreateWebAppFirewall(ctx context.Context, request waf.CreateWebAppFirewallRequest) (response waf.CreateWebAppFirewallResponse, err error)
+	DeleteWebAppFirewall(ctx context.Context, request waf.DeleteWebAppFirewallRequest) (response waf.DeleteWebAppFirewallResponse, err error)
+}
+
+type WAFClient struct {
+	wafClient *waf.WafClient
+}
+
+func NewWafClient(wafClient *waf.WafClient) WAFClient {
+	return WAFClient{
+		wafClient: wafClient,
+	}
+}
+
+func (W WAFClient) GetWebAppFirewall(ctx context.Context, request waf.GetWebAppFirewallRequest) (response waf.GetWebAppFirewallResponse, err error) {
+	return W.wafClient.GetWebAppFirewall(ctx, request)
+}
+
+func (W WAFClient) CreateWebAppFirewall(ctx context.Context, request waf.CreateWebAppFirewallRequest) (response waf.CreateWebAppFirewallResponse, err error) {
+	return W.wafClient.CreateWebAppFirewall(ctx, request)
+}
+
+func (W WAFClient) DeleteWebAppFirewall(ctx context.Context, request waf.DeleteWebAppFirewallRequest) (response waf.DeleteWebAppFirewallResponse, err error) {
+	return W.wafClient.DeleteWebAppFirewall(ctx, request)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,9 +34,9 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/controllers/routingpolicy"
 	"github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
-	. "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/types"
-	w "github.com/oracle/oci-native-ingress-controller/pkg/waf"
+	"github.com/oracle/oci-native-ingress-controller/pkg/waf"
 	"github.com/prometheus/client_golang/prometheus"
 
 	v1 "k8s.io/client-go/informers/core/v1"
@@ -117,7 +117,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 	}
 }
 
-func setupClient(ctx context.Context, opts types.IngressOpts, k8client clientset.Interface) *client.Client {
+func setupClient(ctx context.Context, opts types.IngressOpts, k8client clientset.Interface) *client.ClientProvider {
 	configProvider, err := auth.GetConfigurationProvider(ctx, opts, k8client)
 	if err != nil {
 		klog.Fatalf("failed to load authentication configuration provider: %v", err)
@@ -145,9 +145,9 @@ func setupClient(ctx context.Context, opts types.IngressOpts, k8client clientset
 
 	lbClient := loadbalancer.New(&ociLBClient)
 
-	certificatesClient := certificate.New(&ociCertificatesMgmtClient, NewCertificateClient(&ociCertificatesClient))
+	certificatesClient := certificate.New(&ociCertificatesMgmtClient, ociclient.NewCertificateClient(&ociCertificatesClient))
 
-	wafClient := w.New(&ociWafClient)
+	wafClient := waf.New(&ociWafClient)
 
 	return client.NewWrapperClient(k8client, wafClient, lbClient, certificatesClient)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ociwaf "github.com/oracle/oci-go-sdk/v65/waf"
+	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/oracle/oci-go-sdk/v65/certificates"
@@ -64,42 +65,13 @@ func BuildConfig(kubeconfig string) (*rest.Config, error) {
 }
 
 func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginformers.IngressClassInformer,
-	ingressInformer networkinginformers.IngressInformer, client kubernetes.Interface,
+	ingressInformer networkinginformers.IngressInformer, k8client kubernetes.Interface,
 	serviceInformer v1.ServiceInformer, endpointInformer v1.EndpointsInformer, podInformer v1.PodInformer, c ctrcache.Cache,
 	reg *prometheus.Registry) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		klog.Info("Controller loop...")
 
-		configProvider, err := auth.GetConfigurationProvider(ctx, opts, client)
-		if err != nil {
-			klog.Fatalf("failed to load authentication configuration provider: %v", err)
-		}
-
-		ociLBClient, err := ociloadbalancer.NewLoadBalancerClientWithConfigurationProvider(configProvider)
-		if err != nil {
-			klog.Fatalf("unable to construct oci load balancer client: %v", err)
-		}
-
-		ociCertificatesClient, err := certificates.NewCertificatesClientWithConfigurationProvider(configProvider)
-		if err != nil {
-			klog.Fatalf("unable to construct oci certificate client: %v", err)
-		}
-
-		ociCertificatesMgmtClient, err := certificatesmanagement.NewCertificatesManagementClientWithConfigurationProvider(configProvider)
-		if err != nil {
-			klog.Fatalf("unable to construct oci certificate management client: %v", err)
-		}
-
-		ociWafClient, err := ociwaf.NewWafClientWithConfigurationProvider(configProvider)
-		if err != nil {
-			klog.Fatalf("unable to construct oci web application firewall client: %v", err)
-		}
-
-		lbClient := loadbalancer.New(&ociLBClient)
-
-		certificatesClient := certificate.New(&ociCertificatesMgmtClient, NewCertificateClient(&ociCertificatesClient))
-
-		wafClient := w.New(&ociWafClient)
+		client := setupClient(ctx, opts, k8client)
 
 		ingressController := ingress.NewController(
 			opts.ControllerClass,
@@ -108,8 +80,6 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			ingressInformer,
 			serviceInformer.Lister(),
 			client,
-			lbClient,
-			certificatesClient,
 			reg,
 		)
 
@@ -119,7 +89,6 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			ingressInformer,
 			serviceInformer.Lister(),
 			client,
-			lbClient,
 		)
 
 		backendController := backend.NewController(
@@ -130,7 +99,6 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			endpointInformer.Lister(),
 			podInformer.Lister(),
 			client,
-			lbClient,
 		)
 
 		ingressClassController := ingressclass.NewController(
@@ -139,8 +107,6 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			opts.ControllerClass,
 			ingressClassInformer,
 			client,
-			lbClient,
-			wafClient,
 			c,
 		)
 
@@ -149,6 +115,41 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 		go routingPolicyController.Run(3, ctx.Done())
 		go backendController.Run(3, ctx.Done())
 	}
+}
+
+func setupClient(ctx context.Context, opts types.IngressOpts, k8client clientset.Interface) *client.Client {
+	configProvider, err := auth.GetConfigurationProvider(ctx, opts, k8client)
+	if err != nil {
+		klog.Fatalf("failed to load authentication configuration provider: %v", err)
+	}
+
+	ociLBClient, err := ociloadbalancer.NewLoadBalancerClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		klog.Fatalf("unable to construct oci load balancer client: %v", err)
+	}
+
+	ociCertificatesClient, err := certificates.NewCertificatesClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		klog.Fatalf("unable to construct oci certificate client: %v", err)
+	}
+
+	ociCertificatesMgmtClient, err := certificatesmanagement.NewCertificatesManagementClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		klog.Fatalf("unable to construct oci certificate management client: %v", err)
+	}
+
+	ociWafClient, err := ociwaf.NewWafClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		klog.Fatalf("unable to construct oci web application firewall client: %v", err)
+	}
+
+	lbClient := loadbalancer.New(&ociLBClient)
+
+	certificatesClient := certificate.New(&ociCertificatesMgmtClient, NewCertificateClient(&ociCertificatesClient))
+
+	wafClient := w.New(&ociWafClient)
+
+	return client.NewWrapperClient(k8client, wafClient, lbClient, certificatesClient)
 }
 
 func SetupWebhookServer(ingressInformer networkinginformers.IngressInformer, serviceInformer v1.ServiceInformer, client *clientset.Clientset, ctx context.Context) {

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -146,6 +146,23 @@ func GetIngressClassResource(name string, isDefault bool, controller string) *ne
 	}
 }
 
+func GetIngressClassResourceWithAnnotation(name string, annotation map[string]string, controller string) *networkingv1.IngressClassList {
+	ingressClass := GetIngressClassResource("default-ingress-class", true, "oci.oraclecloud.com/native-ingress-controller")
+	ic := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotation,
+		},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: controller,
+		},
+	}
+	ingressClassList := &networkingv1.IngressClassList{
+		Items: []networkingv1.IngressClass{*ic, *ingressClass},
+	}
+	return ingressClassList
+}
+
 func GetIngressClassResourceWithLbId(name string, isDefault bool, controller string, lbid string) *networkingv1.IngressClass {
 	return &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -1,0 +1,158 @@
+package waf
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/waf"
+	"github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+type CacheObj struct {
+	WAF  *waf.WebAppFirewall
+	Age  time.Time
+	ETag string
+}
+
+type Client struct {
+	WafClient client.WafInterface
+	Mu        sync.Mutex
+	Cache     map[string]*CacheObj
+}
+
+func New(wafClient *waf.WafClient) *Client {
+	return &Client{
+		WafClient: client.NewWafClient(wafClient),
+		Cache:     map[string]*CacheObj{},
+	}
+}
+
+// CreateFirewall Creates the firewall from loadBalancerId, CompartmentId, PolicyId and ingressClassName
+func (W Client) CreateFirewall(lbId *string, compartmentID *string, policyId *string, ingressClassName string) (waf.CreateWebAppFirewallResponse, error) {
+	req := waf.CreateWebAppFirewallRequest{CreateWebAppFirewallDetails: waf.CreateWebAppFirewallLoadBalancerDetails{
+		FreeformTags:           map[string]string{"oci-native-ingress-controller-resource": "firewall"},
+		LoadBalancerId:         lbId,
+		WebAppFirewallPolicyId: policyId,
+		CompartmentId:          compartmentID,
+		DisplayName:            common.String(ingressClassName)},
+	}
+	// Send the request using the service client
+	r, err := W.CreateWebAppFirewall(context.Background(), req)
+	if err != nil {
+		klog.Infof("Error creating firewall for ingressClass %s %s", ingressClassName, err)
+	}
+	return r, err
+}
+
+func (W Client) GetFireWallId(kubeClient kubernetes.Interface, ic *networkingv1.IngressClass, compartmentId *string, lbId *string) (waf.CreateWebAppFirewallResponse, error, error, bool) {
+	policyId := util.GetIngressClassWafPolicy(ic)
+	fireWallId := util.GetIngressClassFireWallId(ic)
+	if policyId == "" {
+		if fireWallId != "" {
+			// cleanup firewall
+			W.DeleteWebAppFirewallWithId(fireWallId)
+			util.PatchIngressClassWithAnnotation(kubeClient, ic, util.IngressClassFireWallIdAnnotation, "")
+			klog.Infof("Web Firewall cleaned up %s", fireWallId)
+		}
+		return waf.CreateWebAppFirewallResponse{}, nil, nil, true
+	}
+	if fireWallId != "" {
+		// check policy ocid for the existing firewall == policy in ingressclass
+		firewallPolicyId, err := W.GetWebAppFirewallWithId(fireWallId)
+		if err == nil && firewallPolicyId == policyId {
+			return waf.CreateWebAppFirewallResponse{}, nil, nil, true
+		}
+
+	}
+	// create firewall
+	firewall, err := W.CreateFirewall(lbId, compartmentId, common.String(policyId), ic.Name)
+	if err != nil && !apierrors.IsConflict(err) {
+		klog.Error("Unable to create web app firewall", err)
+		return waf.CreateWebAppFirewallResponse{}, nil, err, true
+	}
+	return firewall, err, nil, false
+}
+
+func (W Client) GetWebAppFirewall(ctx context.Context, request waf.GetWebAppFirewallRequest) (response waf.GetWebAppFirewallResponse, err error) {
+	return W.WafClient.GetWebAppFirewall(ctx, request)
+}
+
+func (W Client) CreateWebAppFirewall(ctx context.Context, request waf.CreateWebAppFirewallRequest) (response waf.CreateWebAppFirewallResponse, err error) {
+	return W.WafClient.CreateWebAppFirewall(ctx, request)
+}
+
+func (W Client) GetWebAppFirewallWithId(id string) (string, error) {
+	// fetch from cache, if not available then burst
+	firewallCache := W.getFromCache(id)
+
+	if firewallCache != nil {
+		// Get new waf state if cache value is older than WAFCacheMaxAgeInMinutes, else use from cache
+		now := time.Now()
+		if now.Sub(firewallCache.Age).Minutes() < util.WAFCacheMaxAgeInMinutes {
+			firewall := *firewallCache.WAF
+			return *firewall.GetWebAppFirewallPolicyId(), nil
+		}
+		klog.Infof("Refreshing WAF cache for waf %s ", id)
+	}
+
+	resp, err := W.GetWebAppFirewallWithIdBurstCache(id)
+	if err != nil {
+		return "", err
+	}
+	return resp, nil
+}
+
+func (W Client) setCache(waf waf.WebAppFirewall, etag string) {
+	W.Mu.Lock()
+	W.Cache[*waf.GetId()] = &CacheObj{&waf, time.Now(), etag}
+	W.Mu.Unlock()
+}
+
+func (W Client) getFromCache(wafId string) *CacheObj {
+	W.Mu.Lock()
+	defer W.Mu.Unlock()
+	return W.Cache[wafId]
+}
+
+func (W Client) removeFromCache(wafId string) *CacheObj {
+	W.Mu.Lock()
+	defer W.Mu.Unlock()
+	return W.Cache[wafId]
+}
+
+func (W Client) GetWebAppFirewallWithIdBurstCache(id string) (string, error) {
+	req := waf.GetWebAppFirewallRequest{
+		WebAppFirewallId: common.String(id),
+	}
+
+	// Send the request using the service client
+	resp, err := W.GetWebAppFirewall(context.Background(), req)
+	if err != nil {
+		klog.Errorf("Error fetching web app firewall for %s %s", id, err.Error())
+		return "", err
+	}
+	W.setCache(resp.WebAppFirewall, *resp.Etag)
+
+	return *resp.GetWebAppFirewallPolicyId(), nil
+}
+
+func (W Client) DeleteWebAppFirewall(ctx context.Context, request waf.DeleteWebAppFirewallRequest) (response waf.DeleteWebAppFirewallResponse, err error) {
+	return W.WafClient.DeleteWebAppFirewall(ctx, request)
+}
+
+func (W Client) DeleteWebAppFirewallWithId(id string) {
+	req := waf.DeleteWebAppFirewallRequest{
+		WebAppFirewallId: common.String(id),
+	}
+	_, err := W.DeleteWebAppFirewall(context.TODO(), req)
+	if err != nil {
+		klog.Infof("Error deleting web app firewall for %s %s", id, err.Error())
+	}
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/access_control_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/access_control_rule.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AccessControlRule Rule that represents Request/Response Access Control.
+// Only actions of the following types are allowed to be referenced in this rule:
+//  * CHECK
+//  * ALLOW
+//  * RETURN_HTTP_RESPONSE
+type AccessControlRule struct {
+
+	// Rule name. Must be unique within the module.
+	Name *string `mandatory:"true" json:"name"`
+
+	// References action by name from actions defined in WebAppFirewallPolicy.
+	ActionName *string `mandatory:"true" json:"actionName"`
+
+	// An expression that determines whether or not the rule action should be executed.
+	Condition *string `mandatory:"false" json:"condition"`
+
+	// The language used to parse condition from field `condition`. Available languages:
+	// * **JMESPATH** an extended JMESPath language syntax.
+	ConditionLanguage WebAppFirewallPolicyRuleConditionLanguageEnum `mandatory:"false" json:"conditionLanguage,omitempty"`
+}
+
+//GetName returns Name
+func (m AccessControlRule) GetName() *string {
+	return m.Name
+}
+
+//GetConditionLanguage returns ConditionLanguage
+func (m AccessControlRule) GetConditionLanguage() WebAppFirewallPolicyRuleConditionLanguageEnum {
+	return m.ConditionLanguage
+}
+
+//GetCondition returns Condition
+func (m AccessControlRule) GetCondition() *string {
+	return m.Condition
+}
+
+//GetActionName returns ActionName
+func (m AccessControlRule) GetActionName() *string {
+	return m.ActionName
+}
+
+func (m AccessControlRule) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AccessControlRule) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum(string(m.ConditionLanguage)); !ok && m.ConditionLanguage != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ConditionLanguage: %s. Supported values are: %s.", m.ConditionLanguage, strings.Join(GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m AccessControlRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAccessControlRule AccessControlRule
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeAccessControlRule
+	}{
+		"ACCESS_CONTROL",
+		(MarshalTypeAccessControlRule)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/action.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Action An object that represents action and its options.
+// The action can be terminating, if it stops further execution of rules and modules.
+// And non-terminating, if it does not interrupt execution flow.
+type Action interface {
+
+	// Action name. Can be used to reference the action.
+	GetName() *string
+}
+
+type action struct {
+	JsonData []byte
+	Name     *string `mandatory:"true" json:"name"`
+	Type     string  `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *action) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshaleraction action
+	s := struct {
+		Model Unmarshaleraction
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *action) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "RETURN_HTTP_RESPONSE":
+		mm := ReturnHttpResponseAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ALLOW":
+		mm := AllowAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "CHECK":
+		mm := CheckAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m action) GetName() *string {
+	return m.Name
+}
+
+func (m action) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m action) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ActionTypeEnum Enum with underlying type: string
+type ActionTypeEnum string
+
+// Set of constants representing the allowable values for ActionTypeEnum
+const (
+	ActionTypeCheck              ActionTypeEnum = "CHECK"
+	ActionTypeAllow              ActionTypeEnum = "ALLOW"
+	ActionTypeReturnHttpResponse ActionTypeEnum = "RETURN_HTTP_RESPONSE"
+)
+
+var mappingActionTypeEnum = map[string]ActionTypeEnum{
+	"CHECK":                ActionTypeCheck,
+	"ALLOW":                ActionTypeAllow,
+	"RETURN_HTTP_RESPONSE": ActionTypeReturnHttpResponse,
+}
+
+var mappingActionTypeEnumLowerCase = map[string]ActionTypeEnum{
+	"check":                ActionTypeCheck,
+	"allow":                ActionTypeAllow,
+	"return_http_response": ActionTypeReturnHttpResponse,
+}
+
+// GetActionTypeEnumValues Enumerates the set of values for ActionTypeEnum
+func GetActionTypeEnumValues() []ActionTypeEnum {
+	values := make([]ActionTypeEnum, 0)
+	for _, v := range mappingActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetActionTypeEnumStringValues Enumerates the set of values in String for ActionTypeEnum
+func GetActionTypeEnumStringValues() []string {
+	return []string{
+		"CHECK",
+		"ALLOW",
+		"RETURN_HTTP_RESPONSE",
+	}
+}
+
+// GetMappingActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingActionTypeEnum(val string) (ActionTypeEnum, bool) {
+	enum, ok := mappingActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/allow_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/allow_action.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AllowAction An object that represents an action which upon matching rule skips all remaining rules in the current module.
+type AllowAction struct {
+
+	// Action name. Can be used to reference the action.
+	Name *string `mandatory:"true" json:"name"`
+}
+
+//GetName returns Name
+func (m AllowAction) GetName() *string {
+	return m.Name
+}
+
+func (m AllowAction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AllowAction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m AllowAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAllowAction AllowAction
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeAllowAction
+	}{
+		"ALLOW",
+		(MarshalTypeAllowAction)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/backend_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/backend_type.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"strings"
+)
+
+// BackendTypeEnum Enum with underlying type: string
+type BackendTypeEnum string
+
+// Set of constants representing the allowable values for BackendTypeEnum
+const (
+	BackendTypeLoadBalancer BackendTypeEnum = "LOAD_BALANCER"
+)
+
+var mappingBackendTypeEnum = map[string]BackendTypeEnum{
+	"LOAD_BALANCER": BackendTypeLoadBalancer,
+}
+
+var mappingBackendTypeEnumLowerCase = map[string]BackendTypeEnum{
+	"load_balancer": BackendTypeLoadBalancer,
+}
+
+// GetBackendTypeEnumValues Enumerates the set of values for BackendTypeEnum
+func GetBackendTypeEnumValues() []BackendTypeEnum {
+	values := make([]BackendTypeEnum, 0)
+	for _, v := range mappingBackendTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetBackendTypeEnumStringValues Enumerates the set of values in String for BackendTypeEnum
+func GetBackendTypeEnumStringValues() []string {
+	return []string{
+		"LOAD_BALANCER",
+	}
+}
+
+// GetMappingBackendTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingBackendTypeEnum(val string) (BackendTypeEnum, bool) {
+	enum, ok := mappingBackendTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_network_address_list_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_network_address_list_compartment_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ChangeNetworkAddressListCompartmentDetails Updates compartmentId of resource.
+type ChangeNetworkAddressListCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+	// into which the resource should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeNetworkAddressListCompartmentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ChangeNetworkAddressListCompartmentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_network_address_list_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_network_address_list_compartment_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ChangeNetworkAddressListCompartmentRequest wrapper for the ChangeNetworkAddressListCompartment operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeNetworkAddressListCompartment.go.html to see an example of how to use ChangeNetworkAddressListCompartmentRequest.
+type ChangeNetworkAddressListCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	NetworkAddressListId *string `mandatory:"true" contributesTo:"path" name:"networkAddressListId"`
+
+	// The information to be updated.
+	ChangeNetworkAddressListCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeNetworkAddressListCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeNetworkAddressListCompartmentRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ChangeNetworkAddressListCompartmentRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeNetworkAddressListCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ChangeNetworkAddressListCompartmentRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ChangeNetworkAddressListCompartmentResponse wrapper for the ChangeNetworkAddressListCompartment operation
+type ChangeNetworkAddressListCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeNetworkAddressListCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeNetworkAddressListCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_resource_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_resource_compartment_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ChangeResourceCompartmentDetails Updates compartmentId of resource.
+type ChangeResourceCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+	// into which the resource should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeResourceCompartmentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ChangeResourceCompartmentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_compartment_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ChangeWebAppFirewallCompartmentDetails Updates compartmentId of resource.
+type ChangeWebAppFirewallCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+	// into which the resource should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeWebAppFirewallCompartmentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ChangeWebAppFirewallCompartmentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_compartment_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ChangeWebAppFirewallCompartmentRequest wrapper for the ChangeWebAppFirewallCompartment operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeWebAppFirewallCompartment.go.html to see an example of how to use ChangeWebAppFirewallCompartmentRequest.
+type ChangeWebAppFirewallCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	WebAppFirewallId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallId"`
+
+	// The information to be updated.
+	ChangeWebAppFirewallCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeWebAppFirewallCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeWebAppFirewallCompartmentRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ChangeWebAppFirewallCompartmentRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeWebAppFirewallCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ChangeWebAppFirewallCompartmentRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ChangeWebAppFirewallCompartmentResponse wrapper for the ChangeWebAppFirewallCompartment operation
+type ChangeWebAppFirewallCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeWebAppFirewallCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeWebAppFirewallCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_policy_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_policy_compartment_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ChangeWebAppFirewallPolicyCompartmentDetails Updates compartmentId of resource.
+type ChangeWebAppFirewallPolicyCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+	// into which the resource should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeWebAppFirewallPolicyCompartmentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ChangeWebAppFirewallPolicyCompartmentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_policy_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/change_web_app_firewall_policy_compartment_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ChangeWebAppFirewallPolicyCompartmentRequest wrapper for the ChangeWebAppFirewallPolicyCompartment operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeWebAppFirewallPolicyCompartment.go.html to see an example of how to use ChangeWebAppFirewallPolicyCompartmentRequest.
+type ChangeWebAppFirewallPolicyCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	WebAppFirewallPolicyId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallPolicyId"`
+
+	// The information to be updated.
+	ChangeWebAppFirewallPolicyCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeWebAppFirewallPolicyCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeWebAppFirewallPolicyCompartmentRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ChangeWebAppFirewallPolicyCompartmentRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeWebAppFirewallPolicyCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ChangeWebAppFirewallPolicyCompartmentRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ChangeWebAppFirewallPolicyCompartmentResponse wrapper for the ChangeWebAppFirewallPolicyCompartment operation
+type ChangeWebAppFirewallPolicyCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeWebAppFirewallPolicyCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeWebAppFirewallPolicyCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/check_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/check_action.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CheckAction An object that represents an action which does not stop the execution of rules in current module,
+// just emits a log message documenting result of rule execution.
+type CheckAction struct {
+
+	// Action name. Can be used to reference the action.
+	Name *string `mandatory:"true" json:"name"`
+}
+
+//GetName returns Name
+func (m CheckAction) GetName() *string {
+	return m.Name
+}
+
+func (m CheckAction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CheckAction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m CheckAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCheckAction CheckAction
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeCheckAction
+	}{
+		"CHECK",
+		(MarshalTypeCheckAction)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/collaborative_capability_weight.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/collaborative_capability_weight.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CollaborativeCapabilityWeight Defines how much a contributing capability contributes towards the action threshold of a collaborative protection capability.
+type CollaborativeCapabilityWeight struct {
+
+	// Unique key of contributing protection capability.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The display name of contributing protection capability.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The weight of contributing protection capability.
+	Weight *int `mandatory:"true" json:"weight"`
+}
+
+func (m CollaborativeCapabilityWeight) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CollaborativeCapabilityWeight) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/collaborative_capability_weight_override.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/collaborative_capability_weight_override.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CollaborativeCapabilityWeightOverride Collaborative capability key and overriding weight.
+type CollaborativeCapabilityWeightOverride struct {
+
+	// Unique key of collaborative capability for which weight will be overridden.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The value of weight to set.
+	Weight *int `mandatory:"true" json:"weight"`
+}
+
+func (m CollaborativeCapabilityWeightOverride) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CollaborativeCapabilityWeightOverride) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_addresses_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_addresses_details.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNetworkAddressListAddressesDetails The information about new NetworkAddressListAddresses.
+type CreateNetworkAddressListAddressesDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// A list of IP address prefixes in CIDR notation.
+	// To specify all addresses, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	Addresses []string `mandatory:"true" json:"addresses"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateNetworkAddressListAddressesDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m CreateNetworkAddressListAddressesDetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateNetworkAddressListAddressesDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateNetworkAddressListAddressesDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m CreateNetworkAddressListAddressesDetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m CreateNetworkAddressListAddressesDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNetworkAddressListAddressesDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateNetworkAddressListAddressesDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateNetworkAddressListAddressesDetails CreateNetworkAddressListAddressesDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeCreateNetworkAddressListAddressesDetails
+	}{
+		"ADDRESSES",
+		(MarshalTypeCreateNetworkAddressListAddressesDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_details.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNetworkAddressListDetails The information about new NetworkAddressList.
+type CreateNetworkAddressListDetails interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// NetworkAddressList display name, can be renamed.
+	GetDisplayName() *string
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+}
+
+type createnetworkaddresslistdetails struct {
+	JsonData      []byte
+	CompartmentId *string                           `mandatory:"true" json:"compartmentId"`
+	DisplayName   *string                           `mandatory:"false" json:"displayName"`
+	FreeformTags  map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags   map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	SystemTags    map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+	Type          string                            `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createnetworkaddresslistdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatenetworkaddresslistdetails createnetworkaddresslistdetails
+	s := struct {
+		Model Unmarshalercreatenetworkaddresslistdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CompartmentId = s.Model.CompartmentId
+	m.DisplayName = s.Model.DisplayName
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createnetworkaddresslistdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "VCN_ADDRESSES":
+		mm := CreateNetworkAddressListVcnAddressesDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ADDRESSES":
+		mm := CreateNetworkAddressListAddressesDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetCompartmentId returns CompartmentId
+func (m createnetworkaddresslistdetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetDisplayName returns DisplayName
+func (m createnetworkaddresslistdetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m createnetworkaddresslistdetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m createnetworkaddresslistdetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m createnetworkaddresslistdetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m createnetworkaddresslistdetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m createnetworkaddresslistdetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateNetworkAddressListDetailsTypeEnum Enum with underlying type: string
+type CreateNetworkAddressListDetailsTypeEnum string
+
+// Set of constants representing the allowable values for CreateNetworkAddressListDetailsTypeEnum
+const (
+	CreateNetworkAddressListDetailsTypeAddresses    CreateNetworkAddressListDetailsTypeEnum = "ADDRESSES"
+	CreateNetworkAddressListDetailsTypeVcnAddresses CreateNetworkAddressListDetailsTypeEnum = "VCN_ADDRESSES"
+)
+
+var mappingCreateNetworkAddressListDetailsTypeEnum = map[string]CreateNetworkAddressListDetailsTypeEnum{
+	"ADDRESSES":     CreateNetworkAddressListDetailsTypeAddresses,
+	"VCN_ADDRESSES": CreateNetworkAddressListDetailsTypeVcnAddresses,
+}
+
+var mappingCreateNetworkAddressListDetailsTypeEnumLowerCase = map[string]CreateNetworkAddressListDetailsTypeEnum{
+	"addresses":     CreateNetworkAddressListDetailsTypeAddresses,
+	"vcn_addresses": CreateNetworkAddressListDetailsTypeVcnAddresses,
+}
+
+// GetCreateNetworkAddressListDetailsTypeEnumValues Enumerates the set of values for CreateNetworkAddressListDetailsTypeEnum
+func GetCreateNetworkAddressListDetailsTypeEnumValues() []CreateNetworkAddressListDetailsTypeEnum {
+	values := make([]CreateNetworkAddressListDetailsTypeEnum, 0)
+	for _, v := range mappingCreateNetworkAddressListDetailsTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCreateNetworkAddressListDetailsTypeEnumStringValues Enumerates the set of values in String for CreateNetworkAddressListDetailsTypeEnum
+func GetCreateNetworkAddressListDetailsTypeEnumStringValues() []string {
+	return []string{
+		"ADDRESSES",
+		"VCN_ADDRESSES",
+	}
+}
+
+// GetMappingCreateNetworkAddressListDetailsTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCreateNetworkAddressListDetailsTypeEnum(val string) (CreateNetworkAddressListDetailsTypeEnum, bool) {
+	enum, ok := mappingCreateNetworkAddressListDetailsTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateNetworkAddressListRequest wrapper for the CreateNetworkAddressList operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateNetworkAddressList.go.html to see an example of how to use CreateNetworkAddressListRequest.
+type CreateNetworkAddressListRequest struct {
+
+	// Details for the new NetworkAddressList.
+	CreateNetworkAddressListDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateNetworkAddressListRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateNetworkAddressListRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateNetworkAddressListRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateNetworkAddressListRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateNetworkAddressListRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateNetworkAddressListResponse wrapper for the CreateNetworkAddressList operation
+type CreateNetworkAddressListResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NetworkAddressList instance
+	NetworkAddressList `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+
+	// Content Location of the resource.
+	ContentLocation *string `presentIn:"header" name:"content-location"`
+}
+
+func (response CreateNetworkAddressListResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateNetworkAddressListResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_vcn_addresses_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_network_address_list_vcn_addresses_details.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNetworkAddressListVcnAddressesDetails The information about new NetworkAddressListVcnAddresses.
+type CreateNetworkAddressListVcnAddressesDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// A list of private address prefixes, each associated with a particular VCN.
+	// To specify all addresses in a VCN, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	VcnAddresses []PrivateAddresses `mandatory:"true" json:"vcnAddresses"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateNetworkAddressListVcnAddressesDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m CreateNetworkAddressListVcnAddressesDetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateNetworkAddressListVcnAddressesDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateNetworkAddressListVcnAddressesDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m CreateNetworkAddressListVcnAddressesDetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m CreateNetworkAddressListVcnAddressesDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNetworkAddressListVcnAddressesDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateNetworkAddressListVcnAddressesDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateNetworkAddressListVcnAddressesDetails CreateNetworkAddressListVcnAddressesDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeCreateNetworkAddressListVcnAddressesDetails
+	}{
+		"VCN_ADDRESSES",
+		(MarshalTypeCreateNetworkAddressListVcnAddressesDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_details.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateWebAppFirewallDetails The information about new Web App Firewall.
+type CreateWebAppFirewallDetails interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	GetWebAppFirewallPolicyId() *string
+
+	// WebAppFirewall display name, can be renamed.
+	GetDisplayName() *string
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+}
+
+type createwebappfirewalldetails struct {
+	JsonData               []byte
+	CompartmentId          *string                           `mandatory:"true" json:"compartmentId"`
+	WebAppFirewallPolicyId *string                           `mandatory:"true" json:"webAppFirewallPolicyId"`
+	DisplayName            *string                           `mandatory:"false" json:"displayName"`
+	FreeformTags           map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags            map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	SystemTags             map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+	BackendType            string                            `json:"backendType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createwebappfirewalldetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatewebappfirewalldetails createwebappfirewalldetails
+	s := struct {
+		Model Unmarshalercreatewebappfirewalldetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CompartmentId = s.Model.CompartmentId
+	m.WebAppFirewallPolicyId = s.Model.WebAppFirewallPolicyId
+	m.DisplayName = s.Model.DisplayName
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.BackendType = s.Model.BackendType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createwebappfirewalldetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.BackendType {
+	case "LOAD_BALANCER":
+		mm := CreateWebAppFirewallLoadBalancerDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetCompartmentId returns CompartmentId
+func (m createwebappfirewalldetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m createwebappfirewalldetails) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetDisplayName returns DisplayName
+func (m createwebappfirewalldetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m createwebappfirewalldetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m createwebappfirewalldetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m createwebappfirewalldetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m createwebappfirewalldetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m createwebappfirewalldetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_load_balancer_details.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateWebAppFirewallLoadBalancerDetails The information about new WebAppFirewallLoadBalancer.
+type CreateWebAppFirewallLoadBalancerDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	WebAppFirewallPolicyId *string `mandatory:"true" json:"webAppFirewallPolicyId"`
+
+	// LoadBalancer OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to which the WebAppFirewallPolicy is attached to.
+	LoadBalancerId *string `mandatory:"true" json:"loadBalancerId"`
+
+	// WebAppFirewall display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateWebAppFirewallLoadBalancerDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m CreateWebAppFirewallLoadBalancerDetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m CreateWebAppFirewallLoadBalancerDetails) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateWebAppFirewallLoadBalancerDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateWebAppFirewallLoadBalancerDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m CreateWebAppFirewallLoadBalancerDetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m CreateWebAppFirewallLoadBalancerDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateWebAppFirewallLoadBalancerDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateWebAppFirewallLoadBalancerDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateWebAppFirewallLoadBalancerDetails CreateWebAppFirewallLoadBalancerDetails
+	s := struct {
+		DiscriminatorParam string `json:"backendType"`
+		MarshalTypeCreateWebAppFirewallLoadBalancerDetails
+	}{
+		"LOAD_BALANCER",
+		(MarshalTypeCreateWebAppFirewallLoadBalancerDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_policy_details.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateWebAppFirewallPolicyDetails The information about new WebAppFirewallPolicy.
+type CreateWebAppFirewallPolicyDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// WebAppFirewallPolicy display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Predefined actions for use in multiple different rules. Not all actions are supported in every module.
+	// Some actions terminate further execution of modules and rules in a module and some do not.
+	// Actions names must be unique within this array.
+	Actions []Action `mandatory:"false" json:"actions"`
+
+	RequestAccessControl *RequestAccessControl `mandatory:"false" json:"requestAccessControl"`
+
+	RequestRateLimiting *RequestRateLimiting `mandatory:"false" json:"requestRateLimiting"`
+
+	RequestProtection *RequestProtection `mandatory:"false" json:"requestProtection"`
+
+	ResponseAccessControl *ResponseAccessControl `mandatory:"false" json:"responseAccessControl"`
+
+	ResponseProtection *ResponseProtection `mandatory:"false" json:"responseProtection"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m CreateWebAppFirewallPolicyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateWebAppFirewallPolicyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateWebAppFirewallPolicyDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName           *string                           `json:"displayName"`
+		Actions               []action                          `json:"actions"`
+		RequestAccessControl  *RequestAccessControl             `json:"requestAccessControl"`
+		RequestRateLimiting   *RequestRateLimiting              `json:"requestRateLimiting"`
+		RequestProtection     *RequestProtection                `json:"requestProtection"`
+		ResponseAccessControl *ResponseAccessControl            `json:"responseAccessControl"`
+		ResponseProtection    *ResponseProtection               `json:"responseProtection"`
+		FreeformTags          map[string]string                 `json:"freeformTags"`
+		DefinedTags           map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags            map[string]map[string]interface{} `json:"systemTags"`
+		CompartmentId         *string                           `json:"compartmentId"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.Actions = make([]Action, len(model.Actions))
+	for i, n := range model.Actions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Actions[i] = nn.(Action)
+		} else {
+			m.Actions[i] = nil
+		}
+	}
+
+	m.RequestAccessControl = model.RequestAccessControl
+
+	m.RequestRateLimiting = model.RequestRateLimiting
+
+	m.RequestProtection = model.RequestProtection
+
+	m.ResponseAccessControl = model.ResponseAccessControl
+
+	m.ResponseProtection = model.ResponseProtection
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.CompartmentId = model.CompartmentId
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_policy_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateWebAppFirewallPolicyRequest wrapper for the CreateWebAppFirewallPolicy operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateWebAppFirewallPolicy.go.html to see an example of how to use CreateWebAppFirewallPolicyRequest.
+type CreateWebAppFirewallPolicyRequest struct {
+
+	// Details for the new WebAppFirewallPolicy.
+	CreateWebAppFirewallPolicyDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateWebAppFirewallPolicyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateWebAppFirewallPolicyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateWebAppFirewallPolicyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateWebAppFirewallPolicyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateWebAppFirewallPolicyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateWebAppFirewallPolicyResponse wrapper for the CreateWebAppFirewallPolicy operation
+type CreateWebAppFirewallPolicyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WebAppFirewallPolicy instance
+	WebAppFirewallPolicy `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+
+	// Content Location of the resource.
+	ContentLocation *string `presentIn:"header" name:"content-location"`
+}
+
+func (response CreateWebAppFirewallPolicyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateWebAppFirewallPolicyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/create_web_app_firewall_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateWebAppFirewallRequest wrapper for the CreateWebAppFirewall operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateWebAppFirewall.go.html to see an example of how to use CreateWebAppFirewallRequest.
+type CreateWebAppFirewallRequest struct {
+
+	// Details for the new Web App Firewall.
+	CreateWebAppFirewallDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateWebAppFirewallRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateWebAppFirewallRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateWebAppFirewallRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateWebAppFirewallRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateWebAppFirewallRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateWebAppFirewallResponse wrapper for the CreateWebAppFirewall operation
+type CreateWebAppFirewallResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WebAppFirewall instance
+	WebAppFirewall `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+
+	// Content Location of the resource.
+	ContentLocation *string `presentIn:"header" name:"content-location"`
+}
+
+func (response CreateWebAppFirewallResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateWebAppFirewallResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_network_address_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_network_address_list_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteNetworkAddressListRequest wrapper for the DeleteNetworkAddressList operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteNetworkAddressList.go.html to see an example of how to use DeleteNetworkAddressListRequest.
+type DeleteNetworkAddressListRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	NetworkAddressListId *string `mandatory:"true" contributesTo:"path" name:"networkAddressListId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteNetworkAddressListRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteNetworkAddressListRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteNetworkAddressListRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteNetworkAddressListRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteNetworkAddressListRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteNetworkAddressListResponse wrapper for the DeleteNetworkAddressList operation
+type DeleteNetworkAddressListResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteNetworkAddressListResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteNetworkAddressListResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_web_app_firewall_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_web_app_firewall_policy_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteWebAppFirewallPolicyRequest wrapper for the DeleteWebAppFirewallPolicy operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteWebAppFirewallPolicy.go.html to see an example of how to use DeleteWebAppFirewallPolicyRequest.
+type DeleteWebAppFirewallPolicyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	WebAppFirewallPolicyId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallPolicyId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWebAppFirewallPolicyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWebAppFirewallPolicyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteWebAppFirewallPolicyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWebAppFirewallPolicyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteWebAppFirewallPolicyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteWebAppFirewallPolicyResponse wrapper for the DeleteWebAppFirewallPolicy operation
+type DeleteWebAppFirewallPolicyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteWebAppFirewallPolicyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWebAppFirewallPolicyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_web_app_firewall_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/delete_web_app_firewall_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteWebAppFirewallRequest wrapper for the DeleteWebAppFirewall operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteWebAppFirewall.go.html to see an example of how to use DeleteWebAppFirewallRequest.
+type DeleteWebAppFirewallRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	WebAppFirewallId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWebAppFirewallRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWebAppFirewallRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteWebAppFirewallRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWebAppFirewallRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteWebAppFirewallRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteWebAppFirewallResponse wrapper for the DeleteWebAppFirewall operation
+type DeleteWebAppFirewallResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteWebAppFirewallResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWebAppFirewallResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_network_address_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_network_address_list_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetNetworkAddressListRequest wrapper for the GetNetworkAddressList operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetNetworkAddressList.go.html to see an example of how to use GetNetworkAddressListRequest.
+type GetNetworkAddressListRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	NetworkAddressListId *string `mandatory:"true" contributesTo:"path" name:"networkAddressListId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetNetworkAddressListRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetNetworkAddressListRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetNetworkAddressListRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetNetworkAddressListRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetNetworkAddressListRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetNetworkAddressListResponse wrapper for the GetNetworkAddressList operation
+type GetNetworkAddressListResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NetworkAddressList instance
+	NetworkAddressList `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetNetworkAddressListResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetNetworkAddressListResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_web_app_firewall_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_web_app_firewall_policy_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWebAppFirewallPolicyRequest wrapper for the GetWebAppFirewallPolicy operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWebAppFirewallPolicy.go.html to see an example of how to use GetWebAppFirewallPolicyRequest.
+type GetWebAppFirewallPolicyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	WebAppFirewallPolicyId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallPolicyId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWebAppFirewallPolicyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWebAppFirewallPolicyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWebAppFirewallPolicyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWebAppFirewallPolicyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWebAppFirewallPolicyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWebAppFirewallPolicyResponse wrapper for the GetWebAppFirewallPolicy operation
+type GetWebAppFirewallPolicyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WebAppFirewallPolicy instance
+	WebAppFirewallPolicy `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetWebAppFirewallPolicyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWebAppFirewallPolicyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_web_app_firewall_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_web_app_firewall_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWebAppFirewallRequest wrapper for the GetWebAppFirewall operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWebAppFirewall.go.html to see an example of how to use GetWebAppFirewallRequest.
+type GetWebAppFirewallRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	WebAppFirewallId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWebAppFirewallRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWebAppFirewallRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWebAppFirewallRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWebAppFirewallRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWebAppFirewallRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWebAppFirewallResponse wrapper for the GetWebAppFirewall operation
+type GetWebAppFirewallResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WebAppFirewall instance
+	WebAppFirewall `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetWebAppFirewallResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWebAppFirewallResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/get_work_request_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWorkRequestRequest wrapper for the GetWorkRequest operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWorkRequest.go.html to see an example of how to use GetWorkRequestRequest.
+type GetWorkRequestRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkRequestRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWorkRequestRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWorkRequestRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWorkRequestResponse wrapper for the GetWorkRequest operation
+type GetWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkRequest instance
+	WorkRequest `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// A decimal number representing the number of seconds the client should wait before polling this endpoint again.
+	RetryAfter *int `presentIn:"header" name:"retry-after"`
+}
+
+func (response GetWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/http_response_body.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/http_response_body.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// HttpResponseBody Type of returned HTTP response body.
+type HttpResponseBody interface {
+}
+
+type httpresponsebody struct {
+	JsonData []byte
+	Type     string `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *httpresponsebody) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerhttpresponsebody httpresponsebody
+	s := struct {
+		Model Unmarshalerhttpresponsebody
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *httpresponsebody) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "STATIC_TEXT":
+		mm := StaticTextHttpResponseBody{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m httpresponsebody) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m httpresponsebody) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// HttpResponseBodyTypeEnum Enum with underlying type: string
+type HttpResponseBodyTypeEnum string
+
+// Set of constants representing the allowable values for HttpResponseBodyTypeEnum
+const (
+	HttpResponseBodyTypeStaticText HttpResponseBodyTypeEnum = "STATIC_TEXT"
+)
+
+var mappingHttpResponseBodyTypeEnum = map[string]HttpResponseBodyTypeEnum{
+	"STATIC_TEXT": HttpResponseBodyTypeStaticText,
+}
+
+var mappingHttpResponseBodyTypeEnumLowerCase = map[string]HttpResponseBodyTypeEnum{
+	"static_text": HttpResponseBodyTypeStaticText,
+}
+
+// GetHttpResponseBodyTypeEnumValues Enumerates the set of values for HttpResponseBodyTypeEnum
+func GetHttpResponseBodyTypeEnumValues() []HttpResponseBodyTypeEnum {
+	values := make([]HttpResponseBodyTypeEnum, 0)
+	for _, v := range mappingHttpResponseBodyTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetHttpResponseBodyTypeEnumStringValues Enumerates the set of values in String for HttpResponseBodyTypeEnum
+func GetHttpResponseBodyTypeEnumStringValues() []string {
+	return []string{
+		"STATIC_TEXT",
+	}
+}
+
+// GetMappingHttpResponseBodyTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingHttpResponseBodyTypeEnum(val string) (HttpResponseBodyTypeEnum, bool) {
+	enum, ok := mappingHttpResponseBodyTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_network_address_lists_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_network_address_lists_request_response.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListNetworkAddressListsRequest wrapper for the ListNetworkAddressLists operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListNetworkAddressLists.go.html to see an example of how to use ListNetworkAddressListsRequest.
+type ListNetworkAddressListsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the given lifecycleState.
+	LifecycleState []NetworkAddressListLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// A filter to return only resources that match the entire display name given.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// A filter to return only the NetworkAddressList with the given OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"false" contributesTo:"query" name:"id"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'ASC' or 'DESC'.
+	SortOrder ListNetworkAddressListsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided.
+	// Default order for timeCreated is descending.
+	// Default order for displayName is ascending.
+	// If no value is specified timeCreated is default.
+	SortBy ListNetworkAddressListsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListNetworkAddressListsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListNetworkAddressListsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListNetworkAddressListsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListNetworkAddressListsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListNetworkAddressListsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if _, ok := GetMappingListNetworkAddressListsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListNetworkAddressListsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListNetworkAddressListsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListNetworkAddressListsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListNetworkAddressListsResponse wrapper for the ListNetworkAddressLists operation
+type ListNetworkAddressListsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of NetworkAddressListCollection instances
+	NetworkAddressListCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListNetworkAddressListsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListNetworkAddressListsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListNetworkAddressListsSortOrderEnum Enum with underlying type: string
+type ListNetworkAddressListsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListNetworkAddressListsSortOrderEnum
+const (
+	ListNetworkAddressListsSortOrderAsc  ListNetworkAddressListsSortOrderEnum = "ASC"
+	ListNetworkAddressListsSortOrderDesc ListNetworkAddressListsSortOrderEnum = "DESC"
+)
+
+var mappingListNetworkAddressListsSortOrderEnum = map[string]ListNetworkAddressListsSortOrderEnum{
+	"ASC":  ListNetworkAddressListsSortOrderAsc,
+	"DESC": ListNetworkAddressListsSortOrderDesc,
+}
+
+var mappingListNetworkAddressListsSortOrderEnumLowerCase = map[string]ListNetworkAddressListsSortOrderEnum{
+	"asc":  ListNetworkAddressListsSortOrderAsc,
+	"desc": ListNetworkAddressListsSortOrderDesc,
+}
+
+// GetListNetworkAddressListsSortOrderEnumValues Enumerates the set of values for ListNetworkAddressListsSortOrderEnum
+func GetListNetworkAddressListsSortOrderEnumValues() []ListNetworkAddressListsSortOrderEnum {
+	values := make([]ListNetworkAddressListsSortOrderEnum, 0)
+	for _, v := range mappingListNetworkAddressListsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNetworkAddressListsSortOrderEnumStringValues Enumerates the set of values in String for ListNetworkAddressListsSortOrderEnum
+func GetListNetworkAddressListsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListNetworkAddressListsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNetworkAddressListsSortOrderEnum(val string) (ListNetworkAddressListsSortOrderEnum, bool) {
+	enum, ok := mappingListNetworkAddressListsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListNetworkAddressListsSortByEnum Enum with underlying type: string
+type ListNetworkAddressListsSortByEnum string
+
+// Set of constants representing the allowable values for ListNetworkAddressListsSortByEnum
+const (
+	ListNetworkAddressListsSortByTimecreated ListNetworkAddressListsSortByEnum = "timeCreated"
+	ListNetworkAddressListsSortByDisplayname ListNetworkAddressListsSortByEnum = "displayName"
+)
+
+var mappingListNetworkAddressListsSortByEnum = map[string]ListNetworkAddressListsSortByEnum{
+	"timeCreated": ListNetworkAddressListsSortByTimecreated,
+	"displayName": ListNetworkAddressListsSortByDisplayname,
+}
+
+var mappingListNetworkAddressListsSortByEnumLowerCase = map[string]ListNetworkAddressListsSortByEnum{
+	"timecreated": ListNetworkAddressListsSortByTimecreated,
+	"displayname": ListNetworkAddressListsSortByDisplayname,
+}
+
+// GetListNetworkAddressListsSortByEnumValues Enumerates the set of values for ListNetworkAddressListsSortByEnum
+func GetListNetworkAddressListsSortByEnumValues() []ListNetworkAddressListsSortByEnum {
+	values := make([]ListNetworkAddressListsSortByEnum, 0)
+	for _, v := range mappingListNetworkAddressListsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNetworkAddressListsSortByEnumStringValues Enumerates the set of values in String for ListNetworkAddressListsSortByEnum
+func GetListNetworkAddressListsSortByEnumStringValues() []string {
+	return []string{
+		"timeCreated",
+		"displayName",
+	}
+}
+
+// GetMappingListNetworkAddressListsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNetworkAddressListsSortByEnum(val string) (ListNetworkAddressListsSortByEnum, bool) {
+	enum, ok := mappingListNetworkAddressListsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_protection_capabilities_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_protection_capabilities_request_response.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListProtectionCapabilitiesRequest wrapper for the ListProtectionCapabilities operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListProtectionCapabilities.go.html to see an example of how to use ListProtectionCapabilitiesRequest.
+type ListProtectionCapabilitiesRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The unique key of protection capability to filter by.
+	Key *string `mandatory:"false" contributesTo:"query" name:"key"`
+
+	// A filter to return only resources that matches given isLatestVersion.
+	IsLatestVersion []bool `contributesTo:"query" name:"isLatestVersion" collectionFormat:"multi"`
+
+	// A filter to return only resources that matches given type.
+	Type ProtectionCapabilitySummaryTypeEnum `mandatory:"false" contributesTo:"query" name:"type" omitEmpty:"true"`
+
+	// A filter to return only resources that are accociated given group tag.
+	GroupTag []string `contributesTo:"query" name:"groupTag" collectionFormat:"multi"`
+
+	// A filter to return only resources that match the entire display name given.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The sort order to use, either 'ASC' or 'DESC'.
+	SortOrder ListProtectionCapabilitiesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided.
+	// Default order for key is descending.
+	// Default order for type is descending.
+	// Default order for displayName is ascending.
+	// If no value is specified key is default.
+	SortBy ListProtectionCapabilitiesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListProtectionCapabilitiesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListProtectionCapabilitiesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListProtectionCapabilitiesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListProtectionCapabilitiesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListProtectionCapabilitiesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingProtectionCapabilitySummaryTypeEnum(string(request.Type)); !ok && request.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", request.Type, strings.Join(GetProtectionCapabilitySummaryTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListProtectionCapabilitiesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListProtectionCapabilitiesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListProtectionCapabilitiesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListProtectionCapabilitiesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListProtectionCapabilitiesResponse wrapper for the ListProtectionCapabilities operation
+type ListProtectionCapabilitiesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ProtectionCapabilityCollection instances
+	ProtectionCapabilityCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListProtectionCapabilitiesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListProtectionCapabilitiesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListProtectionCapabilitiesSortOrderEnum Enum with underlying type: string
+type ListProtectionCapabilitiesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListProtectionCapabilitiesSortOrderEnum
+const (
+	ListProtectionCapabilitiesSortOrderAsc  ListProtectionCapabilitiesSortOrderEnum = "ASC"
+	ListProtectionCapabilitiesSortOrderDesc ListProtectionCapabilitiesSortOrderEnum = "DESC"
+)
+
+var mappingListProtectionCapabilitiesSortOrderEnum = map[string]ListProtectionCapabilitiesSortOrderEnum{
+	"ASC":  ListProtectionCapabilitiesSortOrderAsc,
+	"DESC": ListProtectionCapabilitiesSortOrderDesc,
+}
+
+var mappingListProtectionCapabilitiesSortOrderEnumLowerCase = map[string]ListProtectionCapabilitiesSortOrderEnum{
+	"asc":  ListProtectionCapabilitiesSortOrderAsc,
+	"desc": ListProtectionCapabilitiesSortOrderDesc,
+}
+
+// GetListProtectionCapabilitiesSortOrderEnumValues Enumerates the set of values for ListProtectionCapabilitiesSortOrderEnum
+func GetListProtectionCapabilitiesSortOrderEnumValues() []ListProtectionCapabilitiesSortOrderEnum {
+	values := make([]ListProtectionCapabilitiesSortOrderEnum, 0)
+	for _, v := range mappingListProtectionCapabilitiesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListProtectionCapabilitiesSortOrderEnumStringValues Enumerates the set of values in String for ListProtectionCapabilitiesSortOrderEnum
+func GetListProtectionCapabilitiesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListProtectionCapabilitiesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListProtectionCapabilitiesSortOrderEnum(val string) (ListProtectionCapabilitiesSortOrderEnum, bool) {
+	enum, ok := mappingListProtectionCapabilitiesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListProtectionCapabilitiesSortByEnum Enum with underlying type: string
+type ListProtectionCapabilitiesSortByEnum string
+
+// Set of constants representing the allowable values for ListProtectionCapabilitiesSortByEnum
+const (
+	ListProtectionCapabilitiesSortByKey         ListProtectionCapabilitiesSortByEnum = "key"
+	ListProtectionCapabilitiesSortByType        ListProtectionCapabilitiesSortByEnum = "type"
+	ListProtectionCapabilitiesSortByDisplayname ListProtectionCapabilitiesSortByEnum = "displayName"
+)
+
+var mappingListProtectionCapabilitiesSortByEnum = map[string]ListProtectionCapabilitiesSortByEnum{
+	"key":         ListProtectionCapabilitiesSortByKey,
+	"type":        ListProtectionCapabilitiesSortByType,
+	"displayName": ListProtectionCapabilitiesSortByDisplayname,
+}
+
+var mappingListProtectionCapabilitiesSortByEnumLowerCase = map[string]ListProtectionCapabilitiesSortByEnum{
+	"key":         ListProtectionCapabilitiesSortByKey,
+	"type":        ListProtectionCapabilitiesSortByType,
+	"displayname": ListProtectionCapabilitiesSortByDisplayname,
+}
+
+// GetListProtectionCapabilitiesSortByEnumValues Enumerates the set of values for ListProtectionCapabilitiesSortByEnum
+func GetListProtectionCapabilitiesSortByEnumValues() []ListProtectionCapabilitiesSortByEnum {
+	values := make([]ListProtectionCapabilitiesSortByEnum, 0)
+	for _, v := range mappingListProtectionCapabilitiesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListProtectionCapabilitiesSortByEnumStringValues Enumerates the set of values in String for ListProtectionCapabilitiesSortByEnum
+func GetListProtectionCapabilitiesSortByEnumStringValues() []string {
+	return []string{
+		"key",
+		"type",
+		"displayName",
+	}
+}
+
+// GetMappingListProtectionCapabilitiesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListProtectionCapabilitiesSortByEnum(val string) (ListProtectionCapabilitiesSortByEnum, bool) {
+	enum, ok := mappingListProtectionCapabilitiesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_protection_capability_group_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_protection_capability_group_tags_request_response.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListProtectionCapabilityGroupTagsRequest wrapper for the ListProtectionCapabilityGroupTags operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListProtectionCapabilityGroupTags.go.html to see an example of how to use ListProtectionCapabilityGroupTagsRequest.
+type ListProtectionCapabilityGroupTagsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// A filter to return only resources that matches given type.
+	Type ProtectionCapabilitySummaryTypeEnum `mandatory:"false" contributesTo:"query" name:"type" omitEmpty:"true"`
+
+	// The sort order to use, either 'ASC' or 'DESC'.
+	SortOrder ListProtectionCapabilityGroupTagsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided.
+	// Default order for name is ascending.
+	// If no value is specified name is default.
+	SortBy ListProtectionCapabilityGroupTagsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire name given.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListProtectionCapabilityGroupTagsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListProtectionCapabilityGroupTagsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListProtectionCapabilityGroupTagsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListProtectionCapabilityGroupTagsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListProtectionCapabilityGroupTagsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingProtectionCapabilitySummaryTypeEnum(string(request.Type)); !ok && request.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", request.Type, strings.Join(GetProtectionCapabilitySummaryTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListProtectionCapabilityGroupTagsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListProtectionCapabilityGroupTagsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListProtectionCapabilityGroupTagsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListProtectionCapabilityGroupTagsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListProtectionCapabilityGroupTagsResponse wrapper for the ListProtectionCapabilityGroupTags operation
+type ListProtectionCapabilityGroupTagsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ProtectionCapabilityGroupTagCollection instances
+	ProtectionCapabilityGroupTagCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListProtectionCapabilityGroupTagsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListProtectionCapabilityGroupTagsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListProtectionCapabilityGroupTagsSortOrderEnum Enum with underlying type: string
+type ListProtectionCapabilityGroupTagsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListProtectionCapabilityGroupTagsSortOrderEnum
+const (
+	ListProtectionCapabilityGroupTagsSortOrderAsc  ListProtectionCapabilityGroupTagsSortOrderEnum = "ASC"
+	ListProtectionCapabilityGroupTagsSortOrderDesc ListProtectionCapabilityGroupTagsSortOrderEnum = "DESC"
+)
+
+var mappingListProtectionCapabilityGroupTagsSortOrderEnum = map[string]ListProtectionCapabilityGroupTagsSortOrderEnum{
+	"ASC":  ListProtectionCapabilityGroupTagsSortOrderAsc,
+	"DESC": ListProtectionCapabilityGroupTagsSortOrderDesc,
+}
+
+var mappingListProtectionCapabilityGroupTagsSortOrderEnumLowerCase = map[string]ListProtectionCapabilityGroupTagsSortOrderEnum{
+	"asc":  ListProtectionCapabilityGroupTagsSortOrderAsc,
+	"desc": ListProtectionCapabilityGroupTagsSortOrderDesc,
+}
+
+// GetListProtectionCapabilityGroupTagsSortOrderEnumValues Enumerates the set of values for ListProtectionCapabilityGroupTagsSortOrderEnum
+func GetListProtectionCapabilityGroupTagsSortOrderEnumValues() []ListProtectionCapabilityGroupTagsSortOrderEnum {
+	values := make([]ListProtectionCapabilityGroupTagsSortOrderEnum, 0)
+	for _, v := range mappingListProtectionCapabilityGroupTagsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListProtectionCapabilityGroupTagsSortOrderEnumStringValues Enumerates the set of values in String for ListProtectionCapabilityGroupTagsSortOrderEnum
+func GetListProtectionCapabilityGroupTagsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListProtectionCapabilityGroupTagsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListProtectionCapabilityGroupTagsSortOrderEnum(val string) (ListProtectionCapabilityGroupTagsSortOrderEnum, bool) {
+	enum, ok := mappingListProtectionCapabilityGroupTagsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListProtectionCapabilityGroupTagsSortByEnum Enum with underlying type: string
+type ListProtectionCapabilityGroupTagsSortByEnum string
+
+// Set of constants representing the allowable values for ListProtectionCapabilityGroupTagsSortByEnum
+const (
+	ListProtectionCapabilityGroupTagsSortByName ListProtectionCapabilityGroupTagsSortByEnum = "name"
+)
+
+var mappingListProtectionCapabilityGroupTagsSortByEnum = map[string]ListProtectionCapabilityGroupTagsSortByEnum{
+	"name": ListProtectionCapabilityGroupTagsSortByName,
+}
+
+var mappingListProtectionCapabilityGroupTagsSortByEnumLowerCase = map[string]ListProtectionCapabilityGroupTagsSortByEnum{
+	"name": ListProtectionCapabilityGroupTagsSortByName,
+}
+
+// GetListProtectionCapabilityGroupTagsSortByEnumValues Enumerates the set of values for ListProtectionCapabilityGroupTagsSortByEnum
+func GetListProtectionCapabilityGroupTagsSortByEnumValues() []ListProtectionCapabilityGroupTagsSortByEnum {
+	values := make([]ListProtectionCapabilityGroupTagsSortByEnum, 0)
+	for _, v := range mappingListProtectionCapabilityGroupTagsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListProtectionCapabilityGroupTagsSortByEnumStringValues Enumerates the set of values in String for ListProtectionCapabilityGroupTagsSortByEnum
+func GetListProtectionCapabilityGroupTagsSortByEnumStringValues() []string {
+	return []string{
+		"name",
+	}
+}
+
+// GetMappingListProtectionCapabilityGroupTagsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListProtectionCapabilityGroupTagsSortByEnum(val string) (ListProtectionCapabilityGroupTagsSortByEnum, bool) {
+	enum, ok := mappingListProtectionCapabilityGroupTagsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_web_app_firewall_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_web_app_firewall_policies_request_response.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWebAppFirewallPoliciesRequest wrapper for the ListWebAppFirewallPolicies operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWebAppFirewallPolicies.go.html to see an example of how to use ListWebAppFirewallPoliciesRequest.
+type ListWebAppFirewallPoliciesRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the given lifecycleState.
+	LifecycleState []WebAppFirewallPolicyLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// A filter to return only resources that match the entire display name given.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// A filter to return only the WebAppFirewallPolicy with the given OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"false" contributesTo:"query" name:"id"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'ASC' or 'DESC'.
+	SortOrder ListWebAppFirewallPoliciesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided.
+	// Default order for timeCreated is descending.
+	// Default order for displayName is ascending.
+	// If no value is specified timeCreated is default.
+	SortBy ListWebAppFirewallPoliciesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWebAppFirewallPoliciesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWebAppFirewallPoliciesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWebAppFirewallPoliciesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWebAppFirewallPoliciesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWebAppFirewallPoliciesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingWebAppFirewallPolicyLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetWebAppFirewallPolicyLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if _, ok := GetMappingListWebAppFirewallPoliciesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListWebAppFirewallPoliciesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWebAppFirewallPoliciesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListWebAppFirewallPoliciesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWebAppFirewallPoliciesResponse wrapper for the ListWebAppFirewallPolicies operation
+type ListWebAppFirewallPoliciesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of WebAppFirewallPolicyCollection instances
+	WebAppFirewallPolicyCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWebAppFirewallPoliciesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWebAppFirewallPoliciesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWebAppFirewallPoliciesSortOrderEnum Enum with underlying type: string
+type ListWebAppFirewallPoliciesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWebAppFirewallPoliciesSortOrderEnum
+const (
+	ListWebAppFirewallPoliciesSortOrderAsc  ListWebAppFirewallPoliciesSortOrderEnum = "ASC"
+	ListWebAppFirewallPoliciesSortOrderDesc ListWebAppFirewallPoliciesSortOrderEnum = "DESC"
+)
+
+var mappingListWebAppFirewallPoliciesSortOrderEnum = map[string]ListWebAppFirewallPoliciesSortOrderEnum{
+	"ASC":  ListWebAppFirewallPoliciesSortOrderAsc,
+	"DESC": ListWebAppFirewallPoliciesSortOrderDesc,
+}
+
+var mappingListWebAppFirewallPoliciesSortOrderEnumLowerCase = map[string]ListWebAppFirewallPoliciesSortOrderEnum{
+	"asc":  ListWebAppFirewallPoliciesSortOrderAsc,
+	"desc": ListWebAppFirewallPoliciesSortOrderDesc,
+}
+
+// GetListWebAppFirewallPoliciesSortOrderEnumValues Enumerates the set of values for ListWebAppFirewallPoliciesSortOrderEnum
+func GetListWebAppFirewallPoliciesSortOrderEnumValues() []ListWebAppFirewallPoliciesSortOrderEnum {
+	values := make([]ListWebAppFirewallPoliciesSortOrderEnum, 0)
+	for _, v := range mappingListWebAppFirewallPoliciesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWebAppFirewallPoliciesSortOrderEnumStringValues Enumerates the set of values in String for ListWebAppFirewallPoliciesSortOrderEnum
+func GetListWebAppFirewallPoliciesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListWebAppFirewallPoliciesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWebAppFirewallPoliciesSortOrderEnum(val string) (ListWebAppFirewallPoliciesSortOrderEnum, bool) {
+	enum, ok := mappingListWebAppFirewallPoliciesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWebAppFirewallPoliciesSortByEnum Enum with underlying type: string
+type ListWebAppFirewallPoliciesSortByEnum string
+
+// Set of constants representing the allowable values for ListWebAppFirewallPoliciesSortByEnum
+const (
+	ListWebAppFirewallPoliciesSortByTimecreated ListWebAppFirewallPoliciesSortByEnum = "timeCreated"
+	ListWebAppFirewallPoliciesSortByDisplayname ListWebAppFirewallPoliciesSortByEnum = "displayName"
+)
+
+var mappingListWebAppFirewallPoliciesSortByEnum = map[string]ListWebAppFirewallPoliciesSortByEnum{
+	"timeCreated": ListWebAppFirewallPoliciesSortByTimecreated,
+	"displayName": ListWebAppFirewallPoliciesSortByDisplayname,
+}
+
+var mappingListWebAppFirewallPoliciesSortByEnumLowerCase = map[string]ListWebAppFirewallPoliciesSortByEnum{
+	"timecreated": ListWebAppFirewallPoliciesSortByTimecreated,
+	"displayname": ListWebAppFirewallPoliciesSortByDisplayname,
+}
+
+// GetListWebAppFirewallPoliciesSortByEnumValues Enumerates the set of values for ListWebAppFirewallPoliciesSortByEnum
+func GetListWebAppFirewallPoliciesSortByEnumValues() []ListWebAppFirewallPoliciesSortByEnum {
+	values := make([]ListWebAppFirewallPoliciesSortByEnum, 0)
+	for _, v := range mappingListWebAppFirewallPoliciesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWebAppFirewallPoliciesSortByEnumStringValues Enumerates the set of values in String for ListWebAppFirewallPoliciesSortByEnum
+func GetListWebAppFirewallPoliciesSortByEnumStringValues() []string {
+	return []string{
+		"timeCreated",
+		"displayName",
+	}
+}
+
+// GetMappingListWebAppFirewallPoliciesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWebAppFirewallPoliciesSortByEnum(val string) (ListWebAppFirewallPoliciesSortByEnum, bool) {
+	enum, ok := mappingListWebAppFirewallPoliciesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_web_app_firewalls_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_web_app_firewalls_request_response.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWebAppFirewallsRequest wrapper for the ListWebAppFirewalls operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWebAppFirewalls.go.html to see an example of how to use ListWebAppFirewallsRequest.
+type ListWebAppFirewallsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only the WebAppFirewall with the given OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"false" contributesTo:"query" name:"id"`
+
+	// A filter to return only the WebAppFirewall with the given OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of related WebAppFirewallPolicy.
+	WebAppFirewallPolicyId *string `mandatory:"false" contributesTo:"query" name:"webAppFirewallPolicyId"`
+
+	// A filter to return only resources that match the given lifecycleState.
+	LifecycleState []WebAppFirewallLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// A filter to return only resources that match the entire display name given.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'ASC' or 'DESC'.
+	SortOrder ListWebAppFirewallsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided.
+	// Default order for timeCreated is descending.
+	// Default order for displayName is ascending.
+	// If no value is specified timeCreated is default.
+	SortBy ListWebAppFirewallsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWebAppFirewallsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWebAppFirewallsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWebAppFirewallsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWebAppFirewallsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWebAppFirewallsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingWebAppFirewallLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetWebAppFirewallLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if _, ok := GetMappingListWebAppFirewallsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListWebAppFirewallsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWebAppFirewallsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListWebAppFirewallsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWebAppFirewallsResponse wrapper for the ListWebAppFirewalls operation
+type ListWebAppFirewallsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of WebAppFirewallCollection instances
+	WebAppFirewallCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWebAppFirewallsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWebAppFirewallsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWebAppFirewallsSortOrderEnum Enum with underlying type: string
+type ListWebAppFirewallsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWebAppFirewallsSortOrderEnum
+const (
+	ListWebAppFirewallsSortOrderAsc  ListWebAppFirewallsSortOrderEnum = "ASC"
+	ListWebAppFirewallsSortOrderDesc ListWebAppFirewallsSortOrderEnum = "DESC"
+)
+
+var mappingListWebAppFirewallsSortOrderEnum = map[string]ListWebAppFirewallsSortOrderEnum{
+	"ASC":  ListWebAppFirewallsSortOrderAsc,
+	"DESC": ListWebAppFirewallsSortOrderDesc,
+}
+
+var mappingListWebAppFirewallsSortOrderEnumLowerCase = map[string]ListWebAppFirewallsSortOrderEnum{
+	"asc":  ListWebAppFirewallsSortOrderAsc,
+	"desc": ListWebAppFirewallsSortOrderDesc,
+}
+
+// GetListWebAppFirewallsSortOrderEnumValues Enumerates the set of values for ListWebAppFirewallsSortOrderEnum
+func GetListWebAppFirewallsSortOrderEnumValues() []ListWebAppFirewallsSortOrderEnum {
+	values := make([]ListWebAppFirewallsSortOrderEnum, 0)
+	for _, v := range mappingListWebAppFirewallsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWebAppFirewallsSortOrderEnumStringValues Enumerates the set of values in String for ListWebAppFirewallsSortOrderEnum
+func GetListWebAppFirewallsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListWebAppFirewallsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWebAppFirewallsSortOrderEnum(val string) (ListWebAppFirewallsSortOrderEnum, bool) {
+	enum, ok := mappingListWebAppFirewallsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWebAppFirewallsSortByEnum Enum with underlying type: string
+type ListWebAppFirewallsSortByEnum string
+
+// Set of constants representing the allowable values for ListWebAppFirewallsSortByEnum
+const (
+	ListWebAppFirewallsSortByTimecreated ListWebAppFirewallsSortByEnum = "timeCreated"
+	ListWebAppFirewallsSortByDisplayname ListWebAppFirewallsSortByEnum = "displayName"
+)
+
+var mappingListWebAppFirewallsSortByEnum = map[string]ListWebAppFirewallsSortByEnum{
+	"timeCreated": ListWebAppFirewallsSortByTimecreated,
+	"displayName": ListWebAppFirewallsSortByDisplayname,
+}
+
+var mappingListWebAppFirewallsSortByEnumLowerCase = map[string]ListWebAppFirewallsSortByEnum{
+	"timecreated": ListWebAppFirewallsSortByTimecreated,
+	"displayname": ListWebAppFirewallsSortByDisplayname,
+}
+
+// GetListWebAppFirewallsSortByEnumValues Enumerates the set of values for ListWebAppFirewallsSortByEnum
+func GetListWebAppFirewallsSortByEnumValues() []ListWebAppFirewallsSortByEnum {
+	values := make([]ListWebAppFirewallsSortByEnum, 0)
+	for _, v := range mappingListWebAppFirewallsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWebAppFirewallsSortByEnumStringValues Enumerates the set of values in String for ListWebAppFirewallsSortByEnum
+func GetListWebAppFirewallsSortByEnumStringValues() []string {
+	return []string{
+		"timeCreated",
+		"displayName",
+	}
+}
+
+// GetMappingListWebAppFirewallsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWebAppFirewallsSortByEnum(val string) (ListWebAppFirewallsSortByEnum, bool) {
+	enum, ok := mappingListWebAppFirewallsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_request_errors_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestErrorsRequest wrapper for the ListWorkRequestErrors operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrorsRequest.
+type ListWorkRequestErrorsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestErrorsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestErrorsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestErrorsResponse wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of WorkRequestErrorCollection instances
+	WorkRequestErrorCollection `presentIn:"body"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestErrorsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestErrorsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_request_logs_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestLogsRequest wrapper for the ListWorkRequestLogs operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogsRequest.
+type ListWorkRequestLogsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestLogsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestLogsResponse wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of WorkRequestLogEntryCollection instances
+	WorkRequestLogEntryCollection `presentIn:"body"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/list_work_requests_request_response.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestsRequest wrapper for the ListWorkRequests operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequests.go.html to see an example of how to use ListWorkRequestsRequest.
+type ListWorkRequestsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the asynchronous work request.
+	WorkRequestId *string `mandatory:"false" contributesTo:"query" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token representing the position at which to start retrieving results.
+	// This must come from the `opc-next-page` header field of a previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestsResponse wrapper for the ListWorkRequests operation
+type ListWorkRequestsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of WorkRequestCollection instances
+	WorkRequestCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkRequestsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressList IP addresses that can be used between different WebAppFirewallPolicies.
+type NetworkAddressList interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	GetId() *string
+
+	// NetworkAddressList display name, can be renamed.
+	GetDisplayName() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	GetTimeCreated() *common.SDKTime
+
+	// The current state of the NetworkAddressList.
+	GetLifecycleState() NetworkAddressListLifecycleStateEnum
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	GetTimeUpdated() *common.SDKTime
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	GetLifecycleDetails() *string
+}
+
+type networkaddresslist struct {
+	JsonData         []byte
+	Id               *string                              `mandatory:"true" json:"id"`
+	DisplayName      *string                              `mandatory:"true" json:"displayName"`
+	CompartmentId    *string                              `mandatory:"true" json:"compartmentId"`
+	TimeCreated      *common.SDKTime                      `mandatory:"true" json:"timeCreated"`
+	LifecycleState   NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+	FreeformTags     map[string]string                    `mandatory:"true" json:"freeformTags"`
+	DefinedTags      map[string]map[string]interface{}    `mandatory:"true" json:"definedTags"`
+	SystemTags       map[string]map[string]interface{}    `mandatory:"true" json:"systemTags"`
+	TimeUpdated      *common.SDKTime                      `mandatory:"false" json:"timeUpdated"`
+	LifecycleDetails *string                              `mandatory:"false" json:"lifecycleDetails"`
+	Type             string                               `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *networkaddresslist) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernetworkaddresslist networkaddresslist
+	s := struct {
+		Model Unmarshalernetworkaddresslist
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Id = s.Model.Id
+	m.DisplayName = s.Model.DisplayName
+	m.CompartmentId = s.Model.CompartmentId
+	m.TimeCreated = s.Model.TimeCreated
+	m.LifecycleState = s.Model.LifecycleState
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.TimeUpdated = s.Model.TimeUpdated
+	m.LifecycleDetails = s.Model.LifecycleDetails
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *networkaddresslist) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "ADDRESSES":
+		mm := NetworkAddressListAddresses{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VCN_ADDRESSES":
+		mm := NetworkAddressListVcnAddresses{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetId returns Id
+func (m networkaddresslist) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m networkaddresslist) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m networkaddresslist) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m networkaddresslist) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m networkaddresslist) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetFreeformTags returns FreeformTags
+func (m networkaddresslist) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m networkaddresslist) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m networkaddresslist) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m networkaddresslist) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m networkaddresslist) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+func (m networkaddresslist) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m networkaddresslist) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NetworkAddressListLifecycleStateEnum Enum with underlying type: string
+type NetworkAddressListLifecycleStateEnum string
+
+// Set of constants representing the allowable values for NetworkAddressListLifecycleStateEnum
+const (
+	NetworkAddressListLifecycleStateCreating NetworkAddressListLifecycleStateEnum = "CREATING"
+	NetworkAddressListLifecycleStateUpdating NetworkAddressListLifecycleStateEnum = "UPDATING"
+	NetworkAddressListLifecycleStateActive   NetworkAddressListLifecycleStateEnum = "ACTIVE"
+	NetworkAddressListLifecycleStateDeleting NetworkAddressListLifecycleStateEnum = "DELETING"
+	NetworkAddressListLifecycleStateDeleted  NetworkAddressListLifecycleStateEnum = "DELETED"
+	NetworkAddressListLifecycleStateFailed   NetworkAddressListLifecycleStateEnum = "FAILED"
+)
+
+var mappingNetworkAddressListLifecycleStateEnum = map[string]NetworkAddressListLifecycleStateEnum{
+	"CREATING": NetworkAddressListLifecycleStateCreating,
+	"UPDATING": NetworkAddressListLifecycleStateUpdating,
+	"ACTIVE":   NetworkAddressListLifecycleStateActive,
+	"DELETING": NetworkAddressListLifecycleStateDeleting,
+	"DELETED":  NetworkAddressListLifecycleStateDeleted,
+	"FAILED":   NetworkAddressListLifecycleStateFailed,
+}
+
+var mappingNetworkAddressListLifecycleStateEnumLowerCase = map[string]NetworkAddressListLifecycleStateEnum{
+	"creating": NetworkAddressListLifecycleStateCreating,
+	"updating": NetworkAddressListLifecycleStateUpdating,
+	"active":   NetworkAddressListLifecycleStateActive,
+	"deleting": NetworkAddressListLifecycleStateDeleting,
+	"deleted":  NetworkAddressListLifecycleStateDeleted,
+	"failed":   NetworkAddressListLifecycleStateFailed,
+}
+
+// GetNetworkAddressListLifecycleStateEnumValues Enumerates the set of values for NetworkAddressListLifecycleStateEnum
+func GetNetworkAddressListLifecycleStateEnumValues() []NetworkAddressListLifecycleStateEnum {
+	values := make([]NetworkAddressListLifecycleStateEnum, 0)
+	for _, v := range mappingNetworkAddressListLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNetworkAddressListLifecycleStateEnumStringValues Enumerates the set of values in String for NetworkAddressListLifecycleStateEnum
+func GetNetworkAddressListLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"UPDATING",
+		"ACTIVE",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+	}
+}
+
+// GetMappingNetworkAddressListLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNetworkAddressListLifecycleStateEnum(val string) (NetworkAddressListLifecycleStateEnum, bool) {
+	enum, ok := mappingNetworkAddressListLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// NetworkAddressListTypeEnum Enum with underlying type: string
+type NetworkAddressListTypeEnum string
+
+// Set of constants representing the allowable values for NetworkAddressListTypeEnum
+const (
+	NetworkAddressListTypeAddresses    NetworkAddressListTypeEnum = "ADDRESSES"
+	NetworkAddressListTypeVcnAddresses NetworkAddressListTypeEnum = "VCN_ADDRESSES"
+)
+
+var mappingNetworkAddressListTypeEnum = map[string]NetworkAddressListTypeEnum{
+	"ADDRESSES":     NetworkAddressListTypeAddresses,
+	"VCN_ADDRESSES": NetworkAddressListTypeVcnAddresses,
+}
+
+var mappingNetworkAddressListTypeEnumLowerCase = map[string]NetworkAddressListTypeEnum{
+	"addresses":     NetworkAddressListTypeAddresses,
+	"vcn_addresses": NetworkAddressListTypeVcnAddresses,
+}
+
+// GetNetworkAddressListTypeEnumValues Enumerates the set of values for NetworkAddressListTypeEnum
+func GetNetworkAddressListTypeEnumValues() []NetworkAddressListTypeEnum {
+	values := make([]NetworkAddressListTypeEnum, 0)
+	for _, v := range mappingNetworkAddressListTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNetworkAddressListTypeEnumStringValues Enumerates the set of values in String for NetworkAddressListTypeEnum
+func GetNetworkAddressListTypeEnumStringValues() []string {
+	return []string{
+		"ADDRESSES",
+		"VCN_ADDRESSES",
+	}
+}
+
+// GetMappingNetworkAddressListTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNetworkAddressListTypeEnum(val string) (NetworkAddressListTypeEnum, bool) {
+	enum, ok := mappingNetworkAddressListTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_addresses.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_addresses.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListAddresses A NetworkAddressList that contains addresses.
+type NetworkAddressListAddresses struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	Id *string `mandatory:"true" json:"id"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// A list of IP address prefixes in CIDR notation.
+	// To specify all addresses, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	Addresses []string `mandatory:"true" json:"addresses"`
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the NetworkAddressList.
+	LifecycleState NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m NetworkAddressListAddresses) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m NetworkAddressListAddresses) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m NetworkAddressListAddresses) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m NetworkAddressListAddresses) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m NetworkAddressListAddresses) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m NetworkAddressListAddresses) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m NetworkAddressListAddresses) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m NetworkAddressListAddresses) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m NetworkAddressListAddresses) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m NetworkAddressListAddresses) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m NetworkAddressListAddresses) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NetworkAddressListAddresses) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NetworkAddressListAddresses) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNetworkAddressListAddresses NetworkAddressListAddresses
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeNetworkAddressListAddresses
+	}{
+		"ADDRESSES",
+		(MarshalTypeNetworkAddressListAddresses)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_addresses_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_addresses_summary.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListAddressesSummary Summary of NetworkAddressListAddresses.
+type NetworkAddressListAddressesSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	Id *string `mandatory:"true" json:"id"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// A list of IP address prefixes in CIDR notation.
+	// To specify all addresses, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	Addresses []string `mandatory:"true" json:"addresses"`
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the NetworkAddress List.
+	LifecycleState NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m NetworkAddressListAddressesSummary) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m NetworkAddressListAddressesSummary) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m NetworkAddressListAddressesSummary) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m NetworkAddressListAddressesSummary) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m NetworkAddressListAddressesSummary) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m NetworkAddressListAddressesSummary) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m NetworkAddressListAddressesSummary) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m NetworkAddressListAddressesSummary) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m NetworkAddressListAddressesSummary) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m NetworkAddressListAddressesSummary) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m NetworkAddressListAddressesSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NetworkAddressListAddressesSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NetworkAddressListAddressesSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNetworkAddressListAddressesSummary NetworkAddressListAddressesSummary
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeNetworkAddressListAddressesSummary
+	}{
+		"ADDRESSES",
+		(MarshalTypeNetworkAddressListAddressesSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_collection.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListCollection Contains NetworkAddressListSummary items.
+type NetworkAddressListCollection struct {
+
+	// A list of NetworkAddressListSummary objects.
+	Items []NetworkAddressListSummary `mandatory:"true" json:"items"`
+}
+
+func (m NetworkAddressListCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NetworkAddressListCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NetworkAddressListCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []networkaddresslistsummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]NetworkAddressListSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(NetworkAddressListSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_summary.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListSummary Summary of NetworkAddressList.
+type NetworkAddressListSummary interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	GetId() *string
+
+	// NetworkAddressList display name, can be renamed.
+	GetDisplayName() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	GetTimeCreated() *common.SDKTime
+
+	// The current state of the NetworkAddress List.
+	GetLifecycleState() NetworkAddressListLifecycleStateEnum
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	GetTimeUpdated() *common.SDKTime
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	GetLifecycleDetails() *string
+}
+
+type networkaddresslistsummary struct {
+	JsonData         []byte
+	Id               *string                              `mandatory:"true" json:"id"`
+	DisplayName      *string                              `mandatory:"true" json:"displayName"`
+	CompartmentId    *string                              `mandatory:"true" json:"compartmentId"`
+	TimeCreated      *common.SDKTime                      `mandatory:"true" json:"timeCreated"`
+	LifecycleState   NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+	FreeformTags     map[string]string                    `mandatory:"true" json:"freeformTags"`
+	DefinedTags      map[string]map[string]interface{}    `mandatory:"true" json:"definedTags"`
+	SystemTags       map[string]map[string]interface{}    `mandatory:"true" json:"systemTags"`
+	TimeUpdated      *common.SDKTime                      `mandatory:"false" json:"timeUpdated"`
+	LifecycleDetails *string                              `mandatory:"false" json:"lifecycleDetails"`
+	Type             string                               `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *networkaddresslistsummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernetworkaddresslistsummary networkaddresslistsummary
+	s := struct {
+		Model Unmarshalernetworkaddresslistsummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Id = s.Model.Id
+	m.DisplayName = s.Model.DisplayName
+	m.CompartmentId = s.Model.CompartmentId
+	m.TimeCreated = s.Model.TimeCreated
+	m.LifecycleState = s.Model.LifecycleState
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.TimeUpdated = s.Model.TimeUpdated
+	m.LifecycleDetails = s.Model.LifecycleDetails
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *networkaddresslistsummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "VCN_ADDRESSES":
+		mm := NetworkAddressListVcnAddressesSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ADDRESSES":
+		mm := NetworkAddressListAddressesSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetId returns Id
+func (m networkaddresslistsummary) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m networkaddresslistsummary) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m networkaddresslistsummary) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m networkaddresslistsummary) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m networkaddresslistsummary) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetFreeformTags returns FreeformTags
+func (m networkaddresslistsummary) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m networkaddresslistsummary) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m networkaddresslistsummary) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m networkaddresslistsummary) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m networkaddresslistsummary) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+func (m networkaddresslistsummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m networkaddresslistsummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NetworkAddressListSummaryTypeEnum Enum with underlying type: string
+type NetworkAddressListSummaryTypeEnum string
+
+// Set of constants representing the allowable values for NetworkAddressListSummaryTypeEnum
+const (
+	NetworkAddressListSummaryTypeAddresses    NetworkAddressListSummaryTypeEnum = "ADDRESSES"
+	NetworkAddressListSummaryTypeVcnAddresses NetworkAddressListSummaryTypeEnum = "VCN_ADDRESSES"
+)
+
+var mappingNetworkAddressListSummaryTypeEnum = map[string]NetworkAddressListSummaryTypeEnum{
+	"ADDRESSES":     NetworkAddressListSummaryTypeAddresses,
+	"VCN_ADDRESSES": NetworkAddressListSummaryTypeVcnAddresses,
+}
+
+var mappingNetworkAddressListSummaryTypeEnumLowerCase = map[string]NetworkAddressListSummaryTypeEnum{
+	"addresses":     NetworkAddressListSummaryTypeAddresses,
+	"vcn_addresses": NetworkAddressListSummaryTypeVcnAddresses,
+}
+
+// GetNetworkAddressListSummaryTypeEnumValues Enumerates the set of values for NetworkAddressListSummaryTypeEnum
+func GetNetworkAddressListSummaryTypeEnumValues() []NetworkAddressListSummaryTypeEnum {
+	values := make([]NetworkAddressListSummaryTypeEnum, 0)
+	for _, v := range mappingNetworkAddressListSummaryTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNetworkAddressListSummaryTypeEnumStringValues Enumerates the set of values in String for NetworkAddressListSummaryTypeEnum
+func GetNetworkAddressListSummaryTypeEnumStringValues() []string {
+	return []string{
+		"ADDRESSES",
+		"VCN_ADDRESSES",
+	}
+}
+
+// GetMappingNetworkAddressListSummaryTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNetworkAddressListSummaryTypeEnum(val string) (NetworkAddressListSummaryTypeEnum, bool) {
+	enum, ok := mappingNetworkAddressListSummaryTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_vcn_addresses.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_vcn_addresses.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListVcnAddresses A NetworkAddressList that contains VCN addresses.
+type NetworkAddressListVcnAddresses struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	Id *string `mandatory:"true" json:"id"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// A list of private address prefixes, each associated with a particular VCN.
+	// To specify all addresses in a VCN, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	VcnAddresses []PrivateAddresses `mandatory:"true" json:"vcnAddresses"`
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the NetworkAddressList.
+	LifecycleState NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m NetworkAddressListVcnAddresses) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m NetworkAddressListVcnAddresses) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m NetworkAddressListVcnAddresses) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m NetworkAddressListVcnAddresses) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m NetworkAddressListVcnAddresses) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m NetworkAddressListVcnAddresses) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m NetworkAddressListVcnAddresses) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m NetworkAddressListVcnAddresses) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m NetworkAddressListVcnAddresses) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m NetworkAddressListVcnAddresses) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m NetworkAddressListVcnAddresses) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NetworkAddressListVcnAddresses) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NetworkAddressListVcnAddresses) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNetworkAddressListVcnAddresses NetworkAddressListVcnAddresses
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeNetworkAddressListVcnAddresses
+	}{
+		"VCN_ADDRESSES",
+		(MarshalTypeNetworkAddressListVcnAddresses)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_vcn_addresses_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/network_address_list_vcn_addresses_summary.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NetworkAddressListVcnAddressesSummary Summary of NetworkAddressListVcnAddresses.
+type NetworkAddressListVcnAddressesSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	Id *string `mandatory:"true" json:"id"`
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the NetworkAddressList was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// A list of private address prefixes, each associated with a particular VCN.
+	// To specify all addresses in a VCN, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	VcnAddresses []PrivateAddresses `mandatory:"true" json:"vcnAddresses"`
+
+	// The time the NetworkAddressList was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the NetworkAddress List.
+	LifecycleState NetworkAddressListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m NetworkAddressListVcnAddressesSummary) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m NetworkAddressListVcnAddressesSummary) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m NetworkAddressListVcnAddressesSummary) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m NetworkAddressListVcnAddressesSummary) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m NetworkAddressListVcnAddressesSummary) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m NetworkAddressListVcnAddressesSummary) GetLifecycleState() NetworkAddressListLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m NetworkAddressListVcnAddressesSummary) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m NetworkAddressListVcnAddressesSummary) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m NetworkAddressListVcnAddressesSummary) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m NetworkAddressListVcnAddressesSummary) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m NetworkAddressListVcnAddressesSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NetworkAddressListVcnAddressesSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNetworkAddressListLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNetworkAddressListLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NetworkAddressListVcnAddressesSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNetworkAddressListVcnAddressesSummary NetworkAddressListVcnAddressesSummary
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeNetworkAddressListVcnAddressesSummary
+	}{
+		"VCN_ADDRESSES",
+		(MarshalTypeNetworkAddressListVcnAddressesSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/private_addresses.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/private_addresses.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PrivateAddresses A pair of VCN OCID and private IP address prefix in CIDR notation.
+type PrivateAddresses struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"true" json:"vcnId"`
+
+	// A private IP address or CIDR IP address range.
+	Addresses *string `mandatory:"true" json:"addresses"`
+}
+
+func (m PrivateAddresses) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PrivateAddresses) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapability References an OCI-managed protection capability. Checks if HTTP requests/responses are malicious.
+type ProtectionCapability struct {
+
+	// Unique key of referenced protection capability.
+	Key *string `mandatory:"true" json:"key"`
+
+	// Version of referenced protection capability.
+	Version *int `mandatory:"true" json:"version"`
+
+	Exclusions *ProtectionCapabilityExclusions `mandatory:"false" json:"exclusions"`
+
+	// Override action to take if capability was triggered, defined in Protection Rule for this capability.
+	// Only actions of type CHECK are allowed.
+	ActionName *string `mandatory:"false" json:"actionName"`
+
+	// The minimum sum of weights of associated collaborative protection capabilities that have triggered which
+	// must be reached in order for _this_ capability to trigger.
+	// This field is ignored for non-collaborative capabilities.
+	CollaborativeActionThreshold *int `mandatory:"false" json:"collaborativeActionThreshold"`
+
+	// Explicit weight values to use for associated collaborative protection capabilities.
+	CollaborativeWeights []CollaborativeCapabilityWeightOverride `mandatory:"false" json:"collaborativeWeights"`
+}
+
+func (m ProtectionCapability) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapability) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilityCollection Result of a protection capabilities search.
+type ProtectionCapabilityCollection struct {
+
+	// List of protection capabilities.
+	Items []ProtectionCapabilitySummary `mandatory:"true" json:"items"`
+}
+
+func (m ProtectionCapabilityCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilityCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_exclusions.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_exclusions.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilityExclusions Identifies specific HTTP message parameters to exclude from inspection by a protection capability.
+type ProtectionCapabilityExclusions struct {
+
+	// List of HTTP request cookie values (by cookie name) to exclude from inspecting.
+	// Example: If we have cookie 'cookieName=cookieValue' and requestCookies=['cookieName'], both 'cookieName' and 'cookieValue' will not be inspected.
+	RequestCookies []string `mandatory:"false" json:"requestCookies"`
+
+	// List of URL query parameter values from form-urlencoded XML, JSON, AMP, or POST payloads to exclude from inspecting.
+	// Example: If we have query parameter 'argumentName=argumentValue' and args=['argumentName'], both 'argumentName' and 'argumentValue' will not be inspected.
+	Args []string `mandatory:"false" json:"args"`
+}
+
+func (m ProtectionCapabilityExclusions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilityExclusions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_group_tag_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_group_tag_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilityGroupTagCollection Result of a protection capabilities group tags search.
+type ProtectionCapabilityGroupTagCollection struct {
+
+	// List of protection capabilities group tags.
+	Items []ProtectionCapabilityGroupTagSummary `mandatory:"true" json:"items"`
+}
+
+func (m ProtectionCapabilityGroupTagCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilityGroupTagCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_group_tag_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_group_tag_summary.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilityGroupTagSummary Object representing protection cabapility group tag and its metadata.
+type ProtectionCapabilityGroupTagSummary struct {
+
+	// Unique name of protection capability group tag.
+	Name *string `mandatory:"true" json:"name"`
+}
+
+func (m ProtectionCapabilityGroupTagSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilityGroupTagSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_settings.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_settings.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilitySettings Settings for protection capabilities
+type ProtectionCapabilitySettings struct {
+
+	// Maximum number of arguments allowed. Used in protection capability 920380: Number of Arguments Limits.
+	MaxNumberOfArguments *int `mandatory:"false" json:"maxNumberOfArguments"`
+
+	// Maximum allowed length of a single argument. Used in protection capability 920370: Limit argument value length.
+	MaxSingleArgumentLength *int `mandatory:"false" json:"maxSingleArgumentLength"`
+
+	// Maximum allowed total length of all arguments. Used in protection capability 920390: Limit arguments total length.
+	MaxTotalArgumentLength *int `mandatory:"false" json:"maxTotalArgumentLength"`
+
+	// Maximum number of headers allowed in an HTTP request. Used in protection capability 9200014: Limit Number of Request Headers.
+	MaxHttpRequestHeaders *int `mandatory:"false" json:"maxHttpRequestHeaders"`
+
+	// Maximum allowed length of headers in an HTTP request. Used in protection capability: 9200024: Limit length of request header size.
+	MaxHttpRequestHeaderLength *int `mandatory:"false" json:"maxHttpRequestHeaderLength"`
+
+	// List of allowed HTTP methods. Each value as a RFC7230 formated token string.
+	// Used in protection capability 911100: Restrict HTTP Request Methods.
+	AllowedHttpMethods []string `mandatory:"false" json:"allowedHttpMethods"`
+}
+
+func (m ProtectionCapabilitySettings) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilitySettings) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_capability_summary.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionCapabilitySummary A summary of available OCI-managed protection capabilities in WebAppFirewallPolicy.
+// Protection capabilies checks HTTP requests/responses if they are malicious.
+type ProtectionCapabilitySummary struct {
+
+	// Unique key of protection capability.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The display name of protection capability.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The description of protection capability.
+	Description *string `mandatory:"true" json:"description"`
+
+	// The version of protection capability.
+	Version *int `mandatory:"true" json:"version"`
+
+	// The field that shows if this is the latest version of protection capability.
+	IsLatestVersion *bool `mandatory:"true" json:"isLatestVersion"`
+
+	// The type of protection capability.
+	// * **REQUEST_PROTECTION_CAPABILITY** can only be used in `requestProtection` module of WebAppFirewallPolicy.
+	// * **RESPONSE_PROTECTION_CAPABILITY** can only be used in `responseProtection` module of WebAppFirewallPolicy.
+	Type ProtectionCapabilitySummaryTypeEnum `mandatory:"true" json:"type"`
+
+	// The list of unique names protection capability group tags that are associated with this capability.
+	// Example: ["PCI", "Recommended"]
+	GroupTags []string `mandatory:"false" json:"groupTags"`
+
+	// The default collaborative action threshold for OCI-managed collaborative protection capability.
+	// Collaborative protection capabilities are made of several simple, non-collaborative protection capabilities
+	// (referred to as `contributing capabilities` later on) which have weights assigned to them. These weights can
+	// be found in the `collaborativeWeights` array.
+	// For incoming/outgoing HTTP messages, all contributing capabilities are executed and the sum of all triggered
+	// contributing capabilities weights is calculated. Only if this sum is greater than or equal to
+	// `collaborativeActionThreshold` is the incoming/outgoing HTTP message marked as malicious.
+	// This field is ignored for non-collaborative capabilities.
+	CollaborativeActionThreshold *int `mandatory:"false" json:"collaborativeActionThreshold"`
+
+	// The weights of contributing capabilities.
+	// Defines how much each contributing capability contributes towards the action threshold of a collaborative protection capability.
+	// This field is ignored for non-collaborative capabilities.
+	CollaborativeWeights []CollaborativeCapabilityWeight `mandatory:"false" json:"collaborativeWeights"`
+}
+
+func (m ProtectionCapabilitySummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionCapabilitySummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingProtectionCapabilitySummaryTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetProtectionCapabilitySummaryTypeEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ProtectionCapabilitySummaryTypeEnum Enum with underlying type: string
+type ProtectionCapabilitySummaryTypeEnum string
+
+// Set of constants representing the allowable values for ProtectionCapabilitySummaryTypeEnum
+const (
+	ProtectionCapabilitySummaryTypeRequestProtectionCapability  ProtectionCapabilitySummaryTypeEnum = "REQUEST_PROTECTION_CAPABILITY"
+	ProtectionCapabilitySummaryTypeResponseProtectionCapability ProtectionCapabilitySummaryTypeEnum = "RESPONSE_PROTECTION_CAPABILITY"
+)
+
+var mappingProtectionCapabilitySummaryTypeEnum = map[string]ProtectionCapabilitySummaryTypeEnum{
+	"REQUEST_PROTECTION_CAPABILITY":  ProtectionCapabilitySummaryTypeRequestProtectionCapability,
+	"RESPONSE_PROTECTION_CAPABILITY": ProtectionCapabilitySummaryTypeResponseProtectionCapability,
+}
+
+var mappingProtectionCapabilitySummaryTypeEnumLowerCase = map[string]ProtectionCapabilitySummaryTypeEnum{
+	"request_protection_capability":  ProtectionCapabilitySummaryTypeRequestProtectionCapability,
+	"response_protection_capability": ProtectionCapabilitySummaryTypeResponseProtectionCapability,
+}
+
+// GetProtectionCapabilitySummaryTypeEnumValues Enumerates the set of values for ProtectionCapabilitySummaryTypeEnum
+func GetProtectionCapabilitySummaryTypeEnumValues() []ProtectionCapabilitySummaryTypeEnum {
+	values := make([]ProtectionCapabilitySummaryTypeEnum, 0)
+	for _, v := range mappingProtectionCapabilitySummaryTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetProtectionCapabilitySummaryTypeEnumStringValues Enumerates the set of values in String for ProtectionCapabilitySummaryTypeEnum
+func GetProtectionCapabilitySummaryTypeEnumStringValues() []string {
+	return []string{
+		"REQUEST_PROTECTION_CAPABILITY",
+		"RESPONSE_PROTECTION_CAPABILITY",
+	}
+}
+
+// GetMappingProtectionCapabilitySummaryTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingProtectionCapabilitySummaryTypeEnum(val string) (ProtectionCapabilitySummaryTypeEnum, bool) {
+	enum, ok := mappingProtectionCapabilitySummaryTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/protection_rule.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ProtectionRule Rule that represents Request/Response Protection.
+// Only actions of the following types are allowed to be referenced in this rule:
+//  * CHECK
+//  * RETURN_HTTP_RESPONSE
+type ProtectionRule struct {
+
+	// Rule name. Must be unique within the module.
+	Name *string `mandatory:"true" json:"name"`
+
+	// References action by name from actions defined in WebAppFirewallPolicy.
+	ActionName *string `mandatory:"true" json:"actionName"`
+
+	// An ordered list that references OCI-managed protection capabilities.
+	// Referenced protection capabilities are not necessarily executed in order of appearance. Their execution order
+	// is decided at runtime for improved performance.
+	// The array cannot contain entries with the same pair of capability key and version more than once.
+	ProtectionCapabilities []ProtectionCapability `mandatory:"true" json:"protectionCapabilities"`
+
+	// An expression that determines whether or not the rule action should be executed.
+	Condition *string `mandatory:"false" json:"condition"`
+
+	ProtectionCapabilitySettings *ProtectionCapabilitySettings `mandatory:"false" json:"protectionCapabilitySettings"`
+
+	// Enables/disables body inspection for this protection rule.
+	// Only Protection Rules in RequestProtection can have this option enabled. Response body inspection will
+	// be available at a later date.
+	IsBodyInspectionEnabled *bool `mandatory:"false" json:"isBodyInspectionEnabled"`
+
+	// The language used to parse condition from field `condition`. Available languages:
+	// * **JMESPATH** an extended JMESPath language syntax.
+	ConditionLanguage WebAppFirewallPolicyRuleConditionLanguageEnum `mandatory:"false" json:"conditionLanguage,omitempty"`
+}
+
+//GetName returns Name
+func (m ProtectionRule) GetName() *string {
+	return m.Name
+}
+
+//GetConditionLanguage returns ConditionLanguage
+func (m ProtectionRule) GetConditionLanguage() WebAppFirewallPolicyRuleConditionLanguageEnum {
+	return m.ConditionLanguage
+}
+
+//GetCondition returns Condition
+func (m ProtectionRule) GetCondition() *string {
+	return m.Condition
+}
+
+//GetActionName returns ActionName
+func (m ProtectionRule) GetActionName() *string {
+	return m.ActionName
+}
+
+func (m ProtectionRule) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ProtectionRule) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum(string(m.ConditionLanguage)); !ok && m.ConditionLanguage != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ConditionLanguage: %s. Supported values are: %s.", m.ConditionLanguage, strings.Join(GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m ProtectionRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeProtectionRule ProtectionRule
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeProtectionRule
+	}{
+		"PROTECTION",
+		(MarshalTypeProtectionRule)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_access_control.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_access_control.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// RequestAccessControl Module that allows inspection of HTTP request properties and to return a defined HTTP response.
+// In this module, rules with the name 'Default Action' are not allowed, since this name is reserved for default action logs.
+type RequestAccessControl struct {
+
+	// References an default Action to take if no AccessControlRule was matched. Allowed action types:
+	// * **ALLOW** continues execution of other modules and their rules.
+	// * **RETURN_HTTP_RESPONSE** terminates further execution of modules and rules and returns defined HTTP response.
+	DefaultActionName *string `mandatory:"true" json:"defaultActionName"`
+
+	// Ordered list of AccessControlRules. Rules are executed in order of appearance in this array.
+	Rules []AccessControlRule `mandatory:"false" json:"rules"`
+}
+
+func (m RequestAccessControl) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m RequestAccessControl) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_protection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_protection.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// RequestProtection Module that allows to enable OCI-managed protection capabilities for incoming HTTP requests.
+type RequestProtection struct {
+
+	// Ordered list of ProtectionRules. Rules are executed in order of appearance in this array.
+	// ProtectionRules in this array can only use protection Capabilities of REQUEST_PROTECTION_CAPABILITY type.
+	Rules []ProtectionRule `mandatory:"false" json:"rules"`
+
+	// Maximum size of inspected HTTP message body in bytes. Actions to take if this limit is exceeded are defined in `bodyInspectionSizeLimitExceededActionName`.
+	// Body inspection maximum size allowed is defined with per-tenancy limit: 8192 bytes.
+	BodyInspectionSizeLimitInBytes *int `mandatory:"false" json:"bodyInspectionSizeLimitInBytes"`
+
+	// References action by name from actions defined in WebAppFirewallPolicy. Executed if HTTP message
+	// body size exceeds limit set in field `bodyInspectionSizeLimitInBytes`.
+	// If this field is `null` HTTP message body will inspected up to `bodyInspectionSizeLimitInBytes` and the rest
+	// will not be inspected by Protection Capabilities.
+	// Allowed action types:
+	// * **RETURN_HTTP_RESPONSE** terminates further execution of modules and rules and returns defined HTTP response.
+	BodyInspectionSizeLimitExceededActionName *string `mandatory:"false" json:"bodyInspectionSizeLimitExceededActionName"`
+}
+
+func (m RequestProtection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m RequestProtection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// RequestRateLimiting Module that allows inspection of HTTP connection properties and to limit requests frequency for a given key.
+type RequestRateLimiting struct {
+
+	// Ordered list of RequestRateLimitingRules. Rules are executed in order of appearance in this array.
+	Rules []RequestRateLimitingRule `mandatory:"false" json:"rules"`
+}
+
+func (m RequestRateLimiting) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m RequestRateLimiting) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting_configuration.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// RequestRateLimitingConfiguration Rate limiting configuration.
+type RequestRateLimitingConfiguration struct {
+
+	// Evaluation period in seconds.
+	PeriodInSeconds *int `mandatory:"true" json:"periodInSeconds"`
+
+	// Requests allowed per evaluation period.
+	RequestsLimit *int `mandatory:"true" json:"requestsLimit"`
+
+	// Duration of block action application in seconds when `requestsLimit` is reached. Optional and can be 0 (no block duration).
+	ActionDurationInSeconds *int `mandatory:"false" json:"actionDurationInSeconds"`
+}
+
+func (m RequestRateLimitingConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m RequestRateLimitingConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/request_rate_limiting_rule.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// RequestRateLimitingRule Rule that represents RequestRateLimitingConfigurations.
+// Only actions of the following types are allowed to be referenced in this rule:
+//  * CHECK
+//  * RETURN_HTTP_RESPONSE
+type RequestRateLimitingRule struct {
+
+	// Rule name. Must be unique within the module.
+	Name *string `mandatory:"true" json:"name"`
+
+	// References action by name from actions defined in WebAppFirewallPolicy.
+	ActionName *string `mandatory:"true" json:"actionName"`
+
+	// Rate Limiting Configurations.
+	// Each configuration counts requests towards its own `requestsLimit`.
+	Configurations []RequestRateLimitingConfiguration `mandatory:"true" json:"configurations"`
+
+	// An expression that determines whether or not the rule action should be executed.
+	Condition *string `mandatory:"false" json:"condition"`
+
+	// The language used to parse condition from field `condition`. Available languages:
+	// * **JMESPATH** an extended JMESPath language syntax.
+	ConditionLanguage WebAppFirewallPolicyRuleConditionLanguageEnum `mandatory:"false" json:"conditionLanguage,omitempty"`
+}
+
+//GetName returns Name
+func (m RequestRateLimitingRule) GetName() *string {
+	return m.Name
+}
+
+//GetConditionLanguage returns ConditionLanguage
+func (m RequestRateLimitingRule) GetConditionLanguage() WebAppFirewallPolicyRuleConditionLanguageEnum {
+	return m.ConditionLanguage
+}
+
+//GetCondition returns Condition
+func (m RequestRateLimitingRule) GetCondition() *string {
+	return m.Condition
+}
+
+//GetActionName returns ActionName
+func (m RequestRateLimitingRule) GetActionName() *string {
+	return m.ActionName
+}
+
+func (m RequestRateLimitingRule) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m RequestRateLimitingRule) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum(string(m.ConditionLanguage)); !ok && m.ConditionLanguage != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ConditionLanguage: %s. Supported values are: %s.", m.ConditionLanguage, strings.Join(GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m RequestRateLimitingRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeRequestRateLimitingRule RequestRateLimitingRule
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeRequestRateLimitingRule
+	}{
+		"REQUEST_RATE_LIMITING",
+		(MarshalTypeRequestRateLimitingRule)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_access_control.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_access_control.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ResponseAccessControl Module that allows inspection of HTTP response properties and to return a defined HTTP response.
+type ResponseAccessControl struct {
+
+	// Ordered list of AccessControlRules. Rules are executed in order of appearance in this array.
+	Rules []AccessControlRule `mandatory:"false" json:"rules"`
+}
+
+func (m ResponseAccessControl) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ResponseAccessControl) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_header.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_header.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ResponseHeader A header field to add to a response.
+type ResponseHeader struct {
+
+	// The name of the header field.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The value of the header field.
+	Value *string `mandatory:"true" json:"value"`
+}
+
+func (m ResponseHeader) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ResponseHeader) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_protection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/response_protection.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ResponseProtection Module that allows to enable OCI-managed protection capabilities for HTTP responses.
+type ResponseProtection struct {
+
+	// Ordered list of ProtectionRules. Rules are executed in order of appearance in this array.
+	// ProtectionRules in this array can only use protection capabilities of RESPONSE_PROTECTION_CAPABILITY type.
+	Rules []ProtectionRule `mandatory:"false" json:"rules"`
+}
+
+func (m ResponseProtection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ResponseProtection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/return_http_response_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/return_http_response_action.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ReturnHttpResponseAction An object that represents an action which returns a defined HTTP response.
+type ReturnHttpResponseAction struct {
+
+	// Action name. Can be used to reference the action.
+	Name *string `mandatory:"true" json:"name"`
+
+	// Response code.
+	// The following response codes are valid values for this property:
+	// * 2xx
+	//   200 OK
+	//   201 Created
+	//   202 Accepted
+	//   206 Partial Content
+	// * 3xx
+	//   300 Multiple Choices
+	//   301 Moved Permanently
+	//   302 Found
+	//   303 See Other
+	//   307 Temporary Redirect
+	// * 4xx
+	//   400 Bad Request
+	//   401 Unauthorized
+	//   403 Forbidden
+	//   404 Not Found
+	//   405 Method Not Allowed
+	//   408 Request Timeout
+	//   409 Conflict
+	//   411 Length Required
+	//   412 Precondition Failed
+	//   413 Payload Too Large
+	//   414 URI Too Long
+	//   415 Unsupported Media Type
+	//   416 Range Not Satisfiable
+	//   422 Unprocessable Entity
+	//   429 Too Many Requests
+	//   494 Request Header Too Large
+	//   495 Cert Error
+	//   496 No Cert
+	//   497 HTTP to HTTPS
+	// * 5xx
+	//   500 Internal Server Error
+	//   501 Not Implemented
+	//   502 Bad Gateway
+	//   503 Service Unavailable
+	//   504 Gateway Timeout
+	//   507 Insufficient Storage
+	// Example: `200`
+	Code *int `mandatory:"true" json:"code"`
+
+	// Adds headers defined in this array for HTTP response.
+	// Hop-by-hop headers are not allowed to be set:
+	// * Connection
+	// * Keep-Alive
+	// * Proxy-Authenticate
+	// * Proxy-Authorization
+	// * TE
+	// * Trailer
+	// * Transfer-Encoding
+	// * Upgrade
+	Headers []ResponseHeader `mandatory:"false" json:"headers"`
+
+	Body HttpResponseBody `mandatory:"false" json:"body"`
+}
+
+//GetName returns Name
+func (m ReturnHttpResponseAction) GetName() *string {
+	return m.Name
+}
+
+func (m ReturnHttpResponseAction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ReturnHttpResponseAction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m ReturnHttpResponseAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeReturnHttpResponseAction ReturnHttpResponseAction
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeReturnHttpResponseAction
+	}{
+		"RETURN_HTTP_RESPONSE",
+		(MarshalTypeReturnHttpResponseAction)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ReturnHttpResponseAction) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Headers []ResponseHeader `json:"headers"`
+		Body    httpresponsebody `json:"body"`
+		Name    *string          `json:"name"`
+		Code    *int             `json:"code"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Headers = make([]ResponseHeader, len(model.Headers))
+	for i, n := range model.Headers {
+		m.Headers[i] = n
+	}
+
+	nn, e = model.Body.UnmarshalPolymorphicJSON(model.Body.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Body = nn.(HttpResponseBody)
+	} else {
+		m.Body = nil
+	}
+
+	m.Name = model.Name
+
+	m.Code = model.Code
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/sort_order.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/sort_order.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"strings"
+)
+
+// SortOrderEnum Enum with underlying type: string
+type SortOrderEnum string
+
+// Set of constants representing the allowable values for SortOrderEnum
+const (
+	SortOrderAsc  SortOrderEnum = "ASC"
+	SortOrderDesc SortOrderEnum = "DESC"
+)
+
+var mappingSortOrderEnum = map[string]SortOrderEnum{
+	"ASC":  SortOrderAsc,
+	"DESC": SortOrderDesc,
+}
+
+var mappingSortOrderEnumLowerCase = map[string]SortOrderEnum{
+	"asc":  SortOrderAsc,
+	"desc": SortOrderDesc,
+}
+
+// GetSortOrderEnumValues Enumerates the set of values for SortOrderEnum
+func GetSortOrderEnumValues() []SortOrderEnum {
+	values := make([]SortOrderEnum, 0)
+	for _, v := range mappingSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetSortOrderEnumStringValues Enumerates the set of values in String for SortOrderEnum
+func GetSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingSortOrderEnum(val string) (SortOrderEnum, bool) {
+	enum, ok := mappingSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/static_text_http_response_body.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/static_text_http_response_body.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// StaticTextHttpResponseBody Allows returning static text as HTTP response body.
+// Example:
+// {
+//   "type": "STATIC_TEXT",
+//   "text": "{\n  \"code\": 403,\n  \"message\":\"Unauthorised\"\n}"
+// }
+type StaticTextHttpResponseBody struct {
+
+	// Static response body text.
+	Text *string `mandatory:"true" json:"text"`
+}
+
+func (m StaticTextHttpResponseBody) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m StaticTextHttpResponseBody) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m StaticTextHttpResponseBody) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeStaticTextHttpResponseBody StaticTextHttpResponseBody
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeStaticTextHttpResponseBody
+	}{
+		"STATIC_TEXT",
+		(MarshalTypeStaticTextHttpResponseBody)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_addresses_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_addresses_details.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNetworkAddressListAddressesDetails The information to be updated for NetworkAddressListAddresses.
+type UpdateNetworkAddressListAddressesDetails struct {
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// A list of IP address prefixes in CIDR notation.
+	// To specify all addresses, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	Addresses []string `mandatory:"false" json:"addresses"`
+}
+
+//GetDisplayName returns DisplayName
+func (m UpdateNetworkAddressListAddressesDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m UpdateNetworkAddressListAddressesDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m UpdateNetworkAddressListAddressesDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m UpdateNetworkAddressListAddressesDetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m UpdateNetworkAddressListAddressesDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNetworkAddressListAddressesDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateNetworkAddressListAddressesDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateNetworkAddressListAddressesDetails UpdateNetworkAddressListAddressesDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeUpdateNetworkAddressListAddressesDetails
+	}{
+		"ADDRESSES",
+		(MarshalTypeUpdateNetworkAddressListAddressesDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_details.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNetworkAddressListDetails The information to be updated.
+type UpdateNetworkAddressListDetails interface {
+
+	// NetworkAddressList display name, can be renamed.
+	GetDisplayName() *string
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+}
+
+type updatenetworkaddresslistdetails struct {
+	JsonData     []byte
+	DisplayName  *string                           `mandatory:"false" json:"displayName"`
+	FreeformTags map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags  map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	SystemTags   map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+	Type         string                            `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *updatenetworkaddresslistdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerupdatenetworkaddresslistdetails updatenetworkaddresslistdetails
+	s := struct {
+		Model Unmarshalerupdatenetworkaddresslistdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.DisplayName = s.Model.DisplayName
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *updatenetworkaddresslistdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "ADDRESSES":
+		mm := UpdateNetworkAddressListAddressesDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VCN_ADDRESSES":
+		mm := UpdateNetworkAddressListVcnAddressesDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetDisplayName returns DisplayName
+func (m updatenetworkaddresslistdetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m updatenetworkaddresslistdetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m updatenetworkaddresslistdetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m updatenetworkaddresslistdetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m updatenetworkaddresslistdetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m updatenetworkaddresslistdetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateNetworkAddressListDetailsTypeEnum Enum with underlying type: string
+type UpdateNetworkAddressListDetailsTypeEnum string
+
+// Set of constants representing the allowable values for UpdateNetworkAddressListDetailsTypeEnum
+const (
+	UpdateNetworkAddressListDetailsTypeAddresses    UpdateNetworkAddressListDetailsTypeEnum = "ADDRESSES"
+	UpdateNetworkAddressListDetailsTypeVcnAddresses UpdateNetworkAddressListDetailsTypeEnum = "VCN_ADDRESSES"
+)
+
+var mappingUpdateNetworkAddressListDetailsTypeEnum = map[string]UpdateNetworkAddressListDetailsTypeEnum{
+	"ADDRESSES":     UpdateNetworkAddressListDetailsTypeAddresses,
+	"VCN_ADDRESSES": UpdateNetworkAddressListDetailsTypeVcnAddresses,
+}
+
+var mappingUpdateNetworkAddressListDetailsTypeEnumLowerCase = map[string]UpdateNetworkAddressListDetailsTypeEnum{
+	"addresses":     UpdateNetworkAddressListDetailsTypeAddresses,
+	"vcn_addresses": UpdateNetworkAddressListDetailsTypeVcnAddresses,
+}
+
+// GetUpdateNetworkAddressListDetailsTypeEnumValues Enumerates the set of values for UpdateNetworkAddressListDetailsTypeEnum
+func GetUpdateNetworkAddressListDetailsTypeEnumValues() []UpdateNetworkAddressListDetailsTypeEnum {
+	values := make([]UpdateNetworkAddressListDetailsTypeEnum, 0)
+	for _, v := range mappingUpdateNetworkAddressListDetailsTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetUpdateNetworkAddressListDetailsTypeEnumStringValues Enumerates the set of values in String for UpdateNetworkAddressListDetailsTypeEnum
+func GetUpdateNetworkAddressListDetailsTypeEnumStringValues() []string {
+	return []string{
+		"ADDRESSES",
+		"VCN_ADDRESSES",
+	}
+}
+
+// GetMappingUpdateNetworkAddressListDetailsTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingUpdateNetworkAddressListDetailsTypeEnum(val string) (UpdateNetworkAddressListDetailsTypeEnum, bool) {
+	enum, ok := mappingUpdateNetworkAddressListDetailsTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateNetworkAddressListRequest wrapper for the UpdateNetworkAddressList operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateNetworkAddressList.go.html to see an example of how to use UpdateNetworkAddressListRequest.
+type UpdateNetworkAddressListRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the NetworkAddressList.
+	NetworkAddressListId *string `mandatory:"true" contributesTo:"path" name:"networkAddressListId"`
+
+	// The information to be updated.
+	UpdateNetworkAddressListDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateNetworkAddressListRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateNetworkAddressListRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateNetworkAddressListRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateNetworkAddressListRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateNetworkAddressListRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateNetworkAddressListResponse wrapper for the UpdateNetworkAddressList operation
+type UpdateNetworkAddressListResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateNetworkAddressListResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateNetworkAddressListResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_vcn_addresses_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_network_address_list_vcn_addresses_details.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNetworkAddressListVcnAddressesDetails The information to be updated for NetworkAddressListVcnAddresses.
+type UpdateNetworkAddressListVcnAddressesDetails struct {
+
+	// NetworkAddressList display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// A list of private address prefixes, each associated with a particular VCN.
+	// To specify all addresses in a VCN, use "0.0.0.0/0" for IPv4 and "::/0" for IPv6.
+	VcnAddresses []PrivateAddresses `mandatory:"false" json:"vcnAddresses"`
+}
+
+//GetDisplayName returns DisplayName
+func (m UpdateNetworkAddressListVcnAddressesDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m UpdateNetworkAddressListVcnAddressesDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m UpdateNetworkAddressListVcnAddressesDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m UpdateNetworkAddressListVcnAddressesDetails) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m UpdateNetworkAddressListVcnAddressesDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNetworkAddressListVcnAddressesDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateNetworkAddressListVcnAddressesDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateNetworkAddressListVcnAddressesDetails UpdateNetworkAddressListVcnAddressesDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeUpdateNetworkAddressListVcnAddressesDetails
+	}{
+		"VCN_ADDRESSES",
+		(MarshalTypeUpdateNetworkAddressListVcnAddressesDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_details.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateWebAppFirewallDetails The information to be updated for WebAppFirewall.
+type UpdateWebAppFirewallDetails struct {
+
+	// WebAppFirewall display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	// This update guarantees that the resource always has WebAppFirewallPolicy attached at any time.
+	WebAppFirewallPolicyId *string `mandatory:"false" json:"webAppFirewallPolicyId"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m UpdateWebAppFirewallDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateWebAppFirewallDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_policy_details.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateWebAppFirewallPolicyDetails The information to be updated.
+// When updating WebAppFirewallPolicy, shallow merge is used for all top-level fields,
+// meaning that top-level fields with defined values are completely overwritten and
+// top-level fields without defined values are unchanged.
+type UpdateWebAppFirewallPolicyDetails struct {
+
+	// WebAppFirewallPolicy display name, can be renamed.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Predefined actions for use in multiple different rules. Not all actions are supported in every module.
+	// Some actions terminate further execution of modules and rules in a module and some do not.
+	// Actions names must be unique within this array.
+	Actions []Action `mandatory:"false" json:"actions"`
+
+	RequestAccessControl *RequestAccessControl `mandatory:"false" json:"requestAccessControl"`
+
+	RequestRateLimiting *RequestRateLimiting `mandatory:"false" json:"requestRateLimiting"`
+
+	RequestProtection *RequestProtection `mandatory:"false" json:"requestProtection"`
+
+	ResponseAccessControl *ResponseAccessControl `mandatory:"false" json:"responseAccessControl"`
+
+	ResponseProtection *ResponseProtection `mandatory:"false" json:"responseProtection"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m UpdateWebAppFirewallPolicyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateWebAppFirewallPolicyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateWebAppFirewallPolicyDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName           *string                           `json:"displayName"`
+		Actions               []action                          `json:"actions"`
+		RequestAccessControl  *RequestAccessControl             `json:"requestAccessControl"`
+		RequestRateLimiting   *RequestRateLimiting              `json:"requestRateLimiting"`
+		RequestProtection     *RequestProtection                `json:"requestProtection"`
+		ResponseAccessControl *ResponseAccessControl            `json:"responseAccessControl"`
+		ResponseProtection    *ResponseProtection               `json:"responseProtection"`
+		FreeformTags          map[string]string                 `json:"freeformTags"`
+		DefinedTags           map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags            map[string]map[string]interface{} `json:"systemTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.Actions = make([]Action, len(model.Actions))
+	for i, n := range model.Actions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Actions[i] = nn.(Action)
+		} else {
+			m.Actions[i] = nil
+		}
+	}
+
+	m.RequestAccessControl = model.RequestAccessControl
+
+	m.RequestRateLimiting = model.RequestRateLimiting
+
+	m.RequestProtection = model.RequestProtection
+
+	m.ResponseAccessControl = model.ResponseAccessControl
+
+	m.ResponseProtection = model.ResponseProtection
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_policy_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateWebAppFirewallPolicyRequest wrapper for the UpdateWebAppFirewallPolicy operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateWebAppFirewallPolicy.go.html to see an example of how to use UpdateWebAppFirewallPolicyRequest.
+type UpdateWebAppFirewallPolicyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	WebAppFirewallPolicyId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallPolicyId"`
+
+	// The information to be updated.
+	UpdateWebAppFirewallPolicyDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateWebAppFirewallPolicyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateWebAppFirewallPolicyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateWebAppFirewallPolicyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateWebAppFirewallPolicyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateWebAppFirewallPolicyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateWebAppFirewallPolicyResponse wrapper for the UpdateWebAppFirewallPolicy operation
+type UpdateWebAppFirewallPolicyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateWebAppFirewallPolicyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateWebAppFirewallPolicyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/update_web_app_firewall_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateWebAppFirewallRequest wrapper for the UpdateWebAppFirewall operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateWebAppFirewall.go.html to see an example of how to use UpdateWebAppFirewallRequest.
+type UpdateWebAppFirewallRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	WebAppFirewallId *string `mandatory:"true" contributesTo:"path" name:"webAppFirewallId"`
+
+	// The information to be updated.
+	UpdateWebAppFirewallDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource,
+	// set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateWebAppFirewallRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateWebAppFirewallRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateWebAppFirewallRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateWebAppFirewallRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateWebAppFirewallRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateWebAppFirewallResponse wrapper for the UpdateWebAppFirewall operation
+type UpdateWebAppFirewallResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateWebAppFirewallResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateWebAppFirewallResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/waf_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/waf_client.go
@@ -1,0 +1,1499 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+	"net/http"
+)
+
+//WafClient a client for Waf
+type WafClient struct {
+	common.BaseClient
+	config *common.ConfigurationProvider
+}
+
+// NewWafClientWithConfigurationProvider Creates a new default Waf client with the given configuration provider.
+// the configuration provider will be used for the default signer as well as reading the region
+func NewWafClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client WafClient, err error) {
+	provider, err := auth.GetGenericConfigurationProvider(configProvider)
+	if err != nil {
+		return client, err
+	}
+	baseClient, e := common.NewClientWithConfig(provider)
+	if e != nil {
+		return client, e
+	}
+	return newWafClientFromBaseClient(baseClient, provider)
+}
+
+// NewWafClientWithOboToken Creates a new default Waf client with the given configuration provider.
+// The obotoken will be added to default headers and signed; the configuration provider will be used for the signer
+//  as well as reading the region
+func NewWafClientWithOboToken(configProvider common.ConfigurationProvider, oboToken string) (client WafClient, err error) {
+	baseClient, err := common.NewClientWithOboToken(configProvider, oboToken)
+	if err != nil {
+		return client, err
+	}
+
+	return newWafClientFromBaseClient(baseClient, configProvider)
+}
+
+func newWafClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WafClient, err error) {
+	// Waf service default circuit breaker is enabled
+	baseClient.Configuration.CircuitBreaker = common.NewCircuitBreaker(common.DefaultCircuitBreakerSettingWithServiceName("Waf"))
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
+	client = WafClient{BaseClient: baseClient}
+	client.BasePath = "20210930"
+	err = client.setConfigurationProvider(configProvider)
+	return
+}
+
+// SetRegion overrides the region of this client.
+func (client *WafClient) SetRegion(region string) {
+	client.Host = common.StringToRegion(region).EndpointForTemplate("waf", "https://waf.{region}.oci.{secondLevelDomain}")
+}
+
+// SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
+func (client *WafClient) setConfigurationProvider(configProvider common.ConfigurationProvider) error {
+	if ok, err := common.IsConfigurationProviderValid(configProvider); !ok {
+		return err
+	}
+
+	// Error has been checked already
+	region, _ := configProvider.Region()
+	client.SetRegion(region)
+	if client.Host == "" {
+		return fmt.Errorf("Invalid region or Host. Endpoint cannot be constructed without endpointServiceName or serviceEndpointTemplate for a dotted region")
+	}
+	client.config = &configProvider
+	return nil
+}
+
+// ConfigurationProvider the ConfigurationProvider used in this client, or null if none set
+func (client *WafClient) ConfigurationProvider() *common.ConfigurationProvider {
+	return client.config
+}
+
+// ChangeNetworkAddressListCompartment Moves a NetworkAddressList resource from one compartment to another.
+// When provided, If-Match is checked against ETag values of the resource.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeNetworkAddressListCompartment.go.html to see an example of how to use ChangeNetworkAddressListCompartment API.
+// A default retry strategy applies to this operation ChangeNetworkAddressListCompartment()
+func (client WafClient) ChangeNetworkAddressListCompartment(ctx context.Context, request ChangeNetworkAddressListCompartmentRequest) (response ChangeNetworkAddressListCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.changeNetworkAddressListCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeNetworkAddressListCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeNetworkAddressListCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeNetworkAddressListCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeNetworkAddressListCompartmentResponse")
+	}
+	return
+}
+
+// changeNetworkAddressListCompartment implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) changeNetworkAddressListCompartment(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/networkAddressLists/{networkAddressListId}/actions/changeCompartment", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeNetworkAddressListCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/ChangeNetworkAddressListCompartment"
+		err = common.PostProcessServiceError(err, "Waf", "ChangeNetworkAddressListCompartment", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeWebAppFirewallCompartment Moves a Web App Firewall resource from one compartment to another.
+// When provided, If-Match is checked against ETag values of the resource.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeWebAppFirewallCompartment.go.html to see an example of how to use ChangeWebAppFirewallCompartment API.
+// A default retry strategy applies to this operation ChangeWebAppFirewallCompartment()
+func (client WafClient) ChangeWebAppFirewallCompartment(ctx context.Context, request ChangeWebAppFirewallCompartmentRequest) (response ChangeWebAppFirewallCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.changeWebAppFirewallCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeWebAppFirewallCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeWebAppFirewallCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeWebAppFirewallCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeWebAppFirewallCompartmentResponse")
+	}
+	return
+}
+
+// changeWebAppFirewallCompartment implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) changeWebAppFirewallCompartment(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/webAppFirewalls/{webAppFirewallId}/actions/changeCompartment", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeWebAppFirewallCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/ChangeWebAppFirewallCompartment"
+		err = common.PostProcessServiceError(err, "Waf", "ChangeWebAppFirewallCompartment", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeWebAppFirewallPolicyCompartment Moves a WebAppFirewallfPolicy resource from one compartment to another.
+// When provided, If-Match is checked against ETag values of the resource.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ChangeWebAppFirewallPolicyCompartment.go.html to see an example of how to use ChangeWebAppFirewallPolicyCompartment API.
+// A default retry strategy applies to this operation ChangeWebAppFirewallPolicyCompartment()
+func (client WafClient) ChangeWebAppFirewallPolicyCompartment(ctx context.Context, request ChangeWebAppFirewallPolicyCompartmentRequest) (response ChangeWebAppFirewallPolicyCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.changeWebAppFirewallPolicyCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeWebAppFirewallPolicyCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeWebAppFirewallPolicyCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeWebAppFirewallPolicyCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeWebAppFirewallPolicyCompartmentResponse")
+	}
+	return
+}
+
+// changeWebAppFirewallPolicyCompartment implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) changeWebAppFirewallPolicyCompartment(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/webAppFirewallPolicies/{webAppFirewallPolicyId}/actions/changeCompartment", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeWebAppFirewallPolicyCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/ChangeWebAppFirewallPolicyCompartment"
+		err = common.PostProcessServiceError(err, "Waf", "ChangeWebAppFirewallPolicyCompartment", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateNetworkAddressList Creates a new NetworkAddressList.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateNetworkAddressList.go.html to see an example of how to use CreateNetworkAddressList API.
+// A default retry strategy applies to this operation CreateNetworkAddressList()
+func (client WafClient) CreateNetworkAddressList(ctx context.Context, request CreateNetworkAddressListRequest) (response CreateNetworkAddressListResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createNetworkAddressList, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateNetworkAddressListResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateNetworkAddressListResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateNetworkAddressListResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateNetworkAddressListResponse")
+	}
+	return
+}
+
+// createNetworkAddressList implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) createNetworkAddressList(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/networkAddressLists", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateNetworkAddressListResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/CreateNetworkAddressList"
+		err = common.PostProcessServiceError(err, "Waf", "CreateNetworkAddressList", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &networkaddresslist{})
+	return response, err
+}
+
+// CreateWebAppFirewall Creates a new WebAppFirewall.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateWebAppFirewall.go.html to see an example of how to use CreateWebAppFirewall API.
+// A default retry strategy applies to this operation CreateWebAppFirewall()
+func (client WafClient) CreateWebAppFirewall(ctx context.Context, request CreateWebAppFirewallRequest) (response CreateWebAppFirewallResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createWebAppFirewall, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateWebAppFirewallResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateWebAppFirewallResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateWebAppFirewallResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateWebAppFirewallResponse")
+	}
+	return
+}
+
+// createWebAppFirewall implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) createWebAppFirewall(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/webAppFirewalls", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateWebAppFirewallResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/CreateWebAppFirewall"
+		err = common.PostProcessServiceError(err, "Waf", "CreateWebAppFirewall", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &webappfirewall{})
+	return response, err
+}
+
+// CreateWebAppFirewallPolicy Creates a new WebAppFirewallPolicy.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/CreateWebAppFirewallPolicy.go.html to see an example of how to use CreateWebAppFirewallPolicy API.
+// A default retry strategy applies to this operation CreateWebAppFirewallPolicy()
+func (client WafClient) CreateWebAppFirewallPolicy(ctx context.Context, request CreateWebAppFirewallPolicyRequest) (response CreateWebAppFirewallPolicyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createWebAppFirewallPolicy, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateWebAppFirewallPolicyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateWebAppFirewallPolicyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateWebAppFirewallPolicyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateWebAppFirewallPolicyResponse")
+	}
+	return
+}
+
+// createWebAppFirewallPolicy implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) createWebAppFirewallPolicy(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/webAppFirewallPolicies", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateWebAppFirewallPolicyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/CreateWebAppFirewallPolicy"
+		err = common.PostProcessServiceError(err, "Waf", "CreateWebAppFirewallPolicy", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteNetworkAddressList Deletes a NetworkAddressList resource identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteNetworkAddressList.go.html to see an example of how to use DeleteNetworkAddressList API.
+// A default retry strategy applies to this operation DeleteNetworkAddressList()
+func (client WafClient) DeleteNetworkAddressList(ctx context.Context, request DeleteNetworkAddressListRequest) (response DeleteNetworkAddressListResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteNetworkAddressList, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteNetworkAddressListResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteNetworkAddressListResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteNetworkAddressListResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteNetworkAddressListResponse")
+	}
+	return
+}
+
+// deleteNetworkAddressList implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) deleteNetworkAddressList(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/networkAddressLists/{networkAddressListId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteNetworkAddressListResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/DeleteNetworkAddressList"
+		err = common.PostProcessServiceError(err, "Waf", "DeleteNetworkAddressList", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWebAppFirewall Deletes a WebAppFirewall resource identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteWebAppFirewall.go.html to see an example of how to use DeleteWebAppFirewall API.
+// A default retry strategy applies to this operation DeleteWebAppFirewall()
+func (client WafClient) DeleteWebAppFirewall(ctx context.Context, request DeleteWebAppFirewallRequest) (response DeleteWebAppFirewallResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWebAppFirewall, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWebAppFirewallResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWebAppFirewallResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWebAppFirewallResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWebAppFirewallResponse")
+	}
+	return
+}
+
+// deleteWebAppFirewall implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) deleteWebAppFirewall(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/webAppFirewalls/{webAppFirewallId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWebAppFirewallResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/DeleteWebAppFirewall"
+		err = common.PostProcessServiceError(err, "Waf", "DeleteWebAppFirewall", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWebAppFirewallPolicy Deletes a WebAppFirewallPolicy resource identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/DeleteWebAppFirewallPolicy.go.html to see an example of how to use DeleteWebAppFirewallPolicy API.
+// A default retry strategy applies to this operation DeleteWebAppFirewallPolicy()
+func (client WafClient) DeleteWebAppFirewallPolicy(ctx context.Context, request DeleteWebAppFirewallPolicyRequest) (response DeleteWebAppFirewallPolicyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWebAppFirewallPolicy, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWebAppFirewallPolicyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWebAppFirewallPolicyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWebAppFirewallPolicyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWebAppFirewallPolicyResponse")
+	}
+	return
+}
+
+// deleteWebAppFirewallPolicy implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) deleteWebAppFirewallPolicy(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/webAppFirewallPolicies/{webAppFirewallPolicyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWebAppFirewallPolicyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/DeleteWebAppFirewallPolicy"
+		err = common.PostProcessServiceError(err, "Waf", "DeleteWebAppFirewallPolicy", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetNetworkAddressList Gets a NetworkAddressList by OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetNetworkAddressList.go.html to see an example of how to use GetNetworkAddressList API.
+// A default retry strategy applies to this operation GetNetworkAddressList()
+func (client WafClient) GetNetworkAddressList(ctx context.Context, request GetNetworkAddressListRequest) (response GetNetworkAddressListResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getNetworkAddressList, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetNetworkAddressListResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetNetworkAddressListResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetNetworkAddressListResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetNetworkAddressListResponse")
+	}
+	return
+}
+
+// getNetworkAddressList implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) getNetworkAddressList(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/networkAddressLists/{networkAddressListId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetNetworkAddressListResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/GetNetworkAddressList"
+		err = common.PostProcessServiceError(err, "Waf", "GetNetworkAddressList", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &networkaddresslist{})
+	return response, err
+}
+
+// GetWebAppFirewall Gets a WebAppFirewall by OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWebAppFirewall.go.html to see an example of how to use GetWebAppFirewall API.
+// A default retry strategy applies to this operation GetWebAppFirewall()
+func (client WafClient) GetWebAppFirewall(ctx context.Context, request GetWebAppFirewallRequest) (response GetWebAppFirewallResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWebAppFirewall, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWebAppFirewallResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWebAppFirewallResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWebAppFirewallResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWebAppFirewallResponse")
+	}
+	return
+}
+
+// getWebAppFirewall implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) getWebAppFirewall(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/webAppFirewalls/{webAppFirewallId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWebAppFirewallResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/GetWebAppFirewall"
+		err = common.PostProcessServiceError(err, "Waf", "GetWebAppFirewall", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &webappfirewall{})
+	return response, err
+}
+
+// GetWebAppFirewallPolicy Gets a WebAppFirewallPolicy with the given OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWebAppFirewallPolicy.go.html to see an example of how to use GetWebAppFirewallPolicy API.
+// A default retry strategy applies to this operation GetWebAppFirewallPolicy()
+func (client WafClient) GetWebAppFirewallPolicy(ctx context.Context, request GetWebAppFirewallPolicyRequest) (response GetWebAppFirewallPolicyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWebAppFirewallPolicy, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWebAppFirewallPolicyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWebAppFirewallPolicyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWebAppFirewallPolicyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWebAppFirewallPolicyResponse")
+	}
+	return
+}
+
+// getWebAppFirewallPolicy implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) getWebAppFirewallPolicy(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/webAppFirewallPolicies/{webAppFirewallPolicyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWebAppFirewallPolicyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/GetWebAppFirewallPolicy"
+		err = common.PostProcessServiceError(err, "Waf", "GetWebAppFirewallPolicy", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkRequest Gets the status of the WorkRequest with the given OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/GetWorkRequest.go.html to see an example of how to use GetWorkRequest API.
+// A default retry strategy applies to this operation GetWorkRequest()
+func (client WafClient) GetWorkRequest(ctx context.Context, request GetWorkRequestRequest) (response GetWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkRequestResponse")
+	}
+	return
+}
+
+// getWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) getWorkRequest(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WorkRequest/GetWorkRequest"
+		err = common.PostProcessServiceError(err, "Waf", "GetWorkRequest", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListNetworkAddressLists Gets a list of all NetworkAddressLists in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListNetworkAddressLists.go.html to see an example of how to use ListNetworkAddressLists API.
+// A default retry strategy applies to this operation ListNetworkAddressLists()
+func (client WafClient) ListNetworkAddressLists(ctx context.Context, request ListNetworkAddressListsRequest) (response ListNetworkAddressListsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listNetworkAddressLists, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListNetworkAddressListsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListNetworkAddressListsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListNetworkAddressListsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListNetworkAddressListsResponse")
+	}
+	return
+}
+
+// listNetworkAddressLists implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listNetworkAddressLists(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/networkAddressLists", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListNetworkAddressListsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/ListNetworkAddressLists"
+		err = common.PostProcessServiceError(err, "Waf", "ListNetworkAddressLists", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListProtectionCapabilities Lists of protection capabilities filtered by query parameters.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListProtectionCapabilities.go.html to see an example of how to use ListProtectionCapabilities API.
+// A default retry strategy applies to this operation ListProtectionCapabilities()
+func (client WafClient) ListProtectionCapabilities(ctx context.Context, request ListProtectionCapabilitiesRequest) (response ListProtectionCapabilitiesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listProtectionCapabilities, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListProtectionCapabilitiesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListProtectionCapabilitiesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListProtectionCapabilitiesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListProtectionCapabilitiesResponse")
+	}
+	return
+}
+
+// listProtectionCapabilities implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listProtectionCapabilities(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/protectionCapabilities", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListProtectionCapabilitiesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/ProtectionCapability/ListProtectionCapabilities"
+		err = common.PostProcessServiceError(err, "Waf", "ListProtectionCapabilities", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListProtectionCapabilityGroupTags Lists of available group tags filtered by query parameters.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListProtectionCapabilityGroupTags.go.html to see an example of how to use ListProtectionCapabilityGroupTags API.
+// A default retry strategy applies to this operation ListProtectionCapabilityGroupTags()
+func (client WafClient) ListProtectionCapabilityGroupTags(ctx context.Context, request ListProtectionCapabilityGroupTagsRequest) (response ListProtectionCapabilityGroupTagsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listProtectionCapabilityGroupTags, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListProtectionCapabilityGroupTagsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListProtectionCapabilityGroupTagsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListProtectionCapabilityGroupTagsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListProtectionCapabilityGroupTagsResponse")
+	}
+	return
+}
+
+// listProtectionCapabilityGroupTags implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listProtectionCapabilityGroupTags(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/protectionCapabilities/groupTags", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListProtectionCapabilityGroupTagsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/ProtectionCapability/ListProtectionCapabilityGroupTags"
+		err = common.PostProcessServiceError(err, "Waf", "ListProtectionCapabilityGroupTags", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWebAppFirewallPolicies Gets a list of all WebAppFirewallPolicies in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWebAppFirewallPolicies.go.html to see an example of how to use ListWebAppFirewallPolicies API.
+// A default retry strategy applies to this operation ListWebAppFirewallPolicies()
+func (client WafClient) ListWebAppFirewallPolicies(ctx context.Context, request ListWebAppFirewallPoliciesRequest) (response ListWebAppFirewallPoliciesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWebAppFirewallPolicies, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWebAppFirewallPoliciesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWebAppFirewallPoliciesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWebAppFirewallPoliciesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWebAppFirewallPoliciesResponse")
+	}
+	return
+}
+
+// listWebAppFirewallPolicies implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listWebAppFirewallPolicies(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/webAppFirewallPolicies", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWebAppFirewallPoliciesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/ListWebAppFirewallPolicies"
+		err = common.PostProcessServiceError(err, "Waf", "ListWebAppFirewallPolicies", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWebAppFirewalls Gets a list of all WebAppFirewalls in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWebAppFirewalls.go.html to see an example of how to use ListWebAppFirewalls API.
+// A default retry strategy applies to this operation ListWebAppFirewalls()
+func (client WafClient) ListWebAppFirewalls(ctx context.Context, request ListWebAppFirewallsRequest) (response ListWebAppFirewallsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWebAppFirewalls, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWebAppFirewallsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWebAppFirewallsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWebAppFirewallsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWebAppFirewallsResponse")
+	}
+	return
+}
+
+// listWebAppFirewalls implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listWebAppFirewalls(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/webAppFirewalls", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWebAppFirewallsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/ListWebAppFirewalls"
+		err = common.PostProcessServiceError(err, "Waf", "ListWebAppFirewalls", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestErrors Return a (paginated) list of errors for a given WorkRequest.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrors API.
+// A default retry strategy applies to this operation ListWorkRequestErrors()
+func (client WafClient) ListWorkRequestErrors(ctx context.Context, request ListWorkRequestErrorsRequest) (response ListWorkRequestErrorsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestErrors, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestErrorsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestErrorsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestErrorsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestErrorsResponse")
+	}
+	return
+}
+
+// listWorkRequestErrors implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listWorkRequestErrors(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/errors", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestErrorsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WorkRequestError/ListWorkRequestErrors"
+		err = common.PostProcessServiceError(err, "Waf", "ListWorkRequestErrors", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestLogs Return a (paginated) list of logs for a given WorkRequest.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogs API.
+// A default retry strategy applies to this operation ListWorkRequestLogs()
+func (client WafClient) ListWorkRequestLogs(ctx context.Context, request ListWorkRequestLogsRequest) (response ListWorkRequestLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestLogsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestLogsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestLogsResponse")
+	}
+	return
+}
+
+// listWorkRequestLogs implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listWorkRequestLogs(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/logs", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WorkRequestLogEntry/ListWorkRequestLogs"
+		err = common.PostProcessServiceError(err, "Waf", "ListWorkRequestLogs", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequests Lists the WorkRequests in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/ListWorkRequests.go.html to see an example of how to use ListWorkRequests API.
+// A default retry strategy applies to this operation ListWorkRequests()
+func (client WafClient) ListWorkRequests(ctx context.Context, request ListWorkRequestsRequest) (response ListWorkRequestsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequests, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestsResponse")
+	}
+	return
+}
+
+// listWorkRequests implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) listWorkRequests(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WorkRequest/ListWorkRequests"
+		err = common.PostProcessServiceError(err, "Waf", "ListWorkRequests", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateNetworkAddressList Update the NetworkAddressList identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateNetworkAddressList.go.html to see an example of how to use UpdateNetworkAddressList API.
+// A default retry strategy applies to this operation UpdateNetworkAddressList()
+func (client WafClient) UpdateNetworkAddressList(ctx context.Context, request UpdateNetworkAddressListRequest) (response UpdateNetworkAddressListResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateNetworkAddressList, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateNetworkAddressListResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateNetworkAddressListResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateNetworkAddressListResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateNetworkAddressListResponse")
+	}
+	return
+}
+
+// updateNetworkAddressList implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) updateNetworkAddressList(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/networkAddressLists/{networkAddressListId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateNetworkAddressListResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/NetworkAddressList/UpdateNetworkAddressList"
+		err = common.PostProcessServiceError(err, "Waf", "UpdateNetworkAddressList", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateWebAppFirewall Updates the WebAppFirewall identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateWebAppFirewall.go.html to see an example of how to use UpdateWebAppFirewall API.
+// A default retry strategy applies to this operation UpdateWebAppFirewall()
+func (client WafClient) UpdateWebAppFirewall(ctx context.Context, request UpdateWebAppFirewallRequest) (response UpdateWebAppFirewallResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateWebAppFirewall, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateWebAppFirewallResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateWebAppFirewallResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateWebAppFirewallResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateWebAppFirewallResponse")
+	}
+	return
+}
+
+// updateWebAppFirewall implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) updateWebAppFirewall(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/webAppFirewalls/{webAppFirewallId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateWebAppFirewallResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewall/UpdateWebAppFirewall"
+		err = common.PostProcessServiceError(err, "Waf", "UpdateWebAppFirewall", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateWebAppFirewallPolicy Update the WebAppFirewallPolicy identified by the OCID.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/waf/UpdateWebAppFirewallPolicy.go.html to see an example of how to use UpdateWebAppFirewallPolicy API.
+// A default retry strategy applies to this operation UpdateWebAppFirewallPolicy()
+func (client WafClient) UpdateWebAppFirewallPolicy(ctx context.Context, request UpdateWebAppFirewallPolicyRequest) (response UpdateWebAppFirewallPolicyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateWebAppFirewallPolicy, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateWebAppFirewallPolicyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateWebAppFirewallPolicyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateWebAppFirewallPolicyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateWebAppFirewallPolicyResponse")
+	}
+	return
+}
+
+// updateWebAppFirewallPolicy implements the OCIOperation interface (enables retrying operations)
+func (client WafClient) updateWebAppFirewallPolicy(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/webAppFirewallPolicies/{webAppFirewallPolicyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateWebAppFirewallPolicyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/waf/20210930/WebAppFirewallPolicy/UpdateWebAppFirewallPolicy"
+		err = common.PostProcessServiceError(err, "Waf", "UpdateWebAppFirewallPolicy", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewall A resource connecting a WebAppFirewallPolicy to a backend of particular type, applying that policy's coverage to the backend.
+type WebAppFirewall interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	GetId() *string
+
+	// WebAppFirewall display name, can be renamed.
+	GetDisplayName() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	GetWebAppFirewallPolicyId() *string
+
+	// The time the WebAppFirewall was created. An RFC3339 formatted datetime string.
+	GetTimeCreated() *common.SDKTime
+
+	// The current state of the WebAppFirewall.
+	GetLifecycleState() WebAppFirewallLifecycleStateEnum
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+
+	// The time the WebAppFirewall was updated. An RFC3339 formatted datetime string.
+	GetTimeUpdated() *common.SDKTime
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	GetLifecycleDetails() *string
+}
+
+type webappfirewall struct {
+	JsonData               []byte
+	Id                     *string                           `mandatory:"true" json:"id"`
+	DisplayName            *string                           `mandatory:"true" json:"displayName"`
+	CompartmentId          *string                           `mandatory:"true" json:"compartmentId"`
+	WebAppFirewallPolicyId *string                           `mandatory:"true" json:"webAppFirewallPolicyId"`
+	TimeCreated            *common.SDKTime                   `mandatory:"true" json:"timeCreated"`
+	LifecycleState         WebAppFirewallLifecycleStateEnum  `mandatory:"true" json:"lifecycleState"`
+	FreeformTags           map[string]string                 `mandatory:"true" json:"freeformTags"`
+	DefinedTags            map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+	SystemTags             map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+	TimeUpdated            *common.SDKTime                   `mandatory:"false" json:"timeUpdated"`
+	LifecycleDetails       *string                           `mandatory:"false" json:"lifecycleDetails"`
+	BackendType            string                            `json:"backendType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *webappfirewall) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerwebappfirewall webappfirewall
+	s := struct {
+		Model Unmarshalerwebappfirewall
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Id = s.Model.Id
+	m.DisplayName = s.Model.DisplayName
+	m.CompartmentId = s.Model.CompartmentId
+	m.WebAppFirewallPolicyId = s.Model.WebAppFirewallPolicyId
+	m.TimeCreated = s.Model.TimeCreated
+	m.LifecycleState = s.Model.LifecycleState
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.TimeUpdated = s.Model.TimeUpdated
+	m.LifecycleDetails = s.Model.LifecycleDetails
+	m.BackendType = s.Model.BackendType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *webappfirewall) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.BackendType {
+	case "LOAD_BALANCER":
+		mm := WebAppFirewallLoadBalancer{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetId returns Id
+func (m webappfirewall) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m webappfirewall) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m webappfirewall) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m webappfirewall) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m webappfirewall) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m webappfirewall) GetLifecycleState() WebAppFirewallLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetFreeformTags returns FreeformTags
+func (m webappfirewall) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m webappfirewall) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m webappfirewall) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m webappfirewall) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m webappfirewall) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+func (m webappfirewall) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m webappfirewall) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWebAppFirewallLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WebAppFirewallLifecycleStateEnum Enum with underlying type: string
+type WebAppFirewallLifecycleStateEnum string
+
+// Set of constants representing the allowable values for WebAppFirewallLifecycleStateEnum
+const (
+	WebAppFirewallLifecycleStateCreating WebAppFirewallLifecycleStateEnum = "CREATING"
+	WebAppFirewallLifecycleStateUpdating WebAppFirewallLifecycleStateEnum = "UPDATING"
+	WebAppFirewallLifecycleStateActive   WebAppFirewallLifecycleStateEnum = "ACTIVE"
+	WebAppFirewallLifecycleStateDeleting WebAppFirewallLifecycleStateEnum = "DELETING"
+	WebAppFirewallLifecycleStateDeleted  WebAppFirewallLifecycleStateEnum = "DELETED"
+	WebAppFirewallLifecycleStateFailed   WebAppFirewallLifecycleStateEnum = "FAILED"
+)
+
+var mappingWebAppFirewallLifecycleStateEnum = map[string]WebAppFirewallLifecycleStateEnum{
+	"CREATING": WebAppFirewallLifecycleStateCreating,
+	"UPDATING": WebAppFirewallLifecycleStateUpdating,
+	"ACTIVE":   WebAppFirewallLifecycleStateActive,
+	"DELETING": WebAppFirewallLifecycleStateDeleting,
+	"DELETED":  WebAppFirewallLifecycleStateDeleted,
+	"FAILED":   WebAppFirewallLifecycleStateFailed,
+}
+
+var mappingWebAppFirewallLifecycleStateEnumLowerCase = map[string]WebAppFirewallLifecycleStateEnum{
+	"creating": WebAppFirewallLifecycleStateCreating,
+	"updating": WebAppFirewallLifecycleStateUpdating,
+	"active":   WebAppFirewallLifecycleStateActive,
+	"deleting": WebAppFirewallLifecycleStateDeleting,
+	"deleted":  WebAppFirewallLifecycleStateDeleted,
+	"failed":   WebAppFirewallLifecycleStateFailed,
+}
+
+// GetWebAppFirewallLifecycleStateEnumValues Enumerates the set of values for WebAppFirewallLifecycleStateEnum
+func GetWebAppFirewallLifecycleStateEnumValues() []WebAppFirewallLifecycleStateEnum {
+	values := make([]WebAppFirewallLifecycleStateEnum, 0)
+	for _, v := range mappingWebAppFirewallLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWebAppFirewallLifecycleStateEnumStringValues Enumerates the set of values in String for WebAppFirewallLifecycleStateEnum
+func GetWebAppFirewallLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"UPDATING",
+		"ACTIVE",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+	}
+}
+
+// GetMappingWebAppFirewallLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWebAppFirewallLifecycleStateEnum(val string) (WebAppFirewallLifecycleStateEnum, bool) {
+	enum, ok := mappingWebAppFirewallLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_collection.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallCollection Result of a WebAppFirewall list operation.
+type WebAppFirewallCollection struct {
+
+	// List of WebAppFirewalls.
+	Items []WebAppFirewallSummary `mandatory:"true" json:"items"`
+}
+
+func (m WebAppFirewallCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *WebAppFirewallCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []webappfirewallsummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]WebAppFirewallSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(WebAppFirewallSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_load_balancer.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_load_balancer.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallLoadBalancer WebAppFirewall to a LoadBalancer resource.
+type WebAppFirewallLoadBalancer struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	Id *string `mandatory:"true" json:"id"`
+
+	// WebAppFirewall display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	WebAppFirewallPolicyId *string `mandatory:"true" json:"webAppFirewallPolicyId"`
+
+	// The time the WebAppFirewall was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// LoadBalancer OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to which the WebAppFirewallPolicy is attached to.
+	LoadBalancerId *string `mandatory:"true" json:"loadBalancerId"`
+
+	// The time the WebAppFirewall was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the WebAppFirewall.
+	LifecycleState WebAppFirewallLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m WebAppFirewallLoadBalancer) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m WebAppFirewallLoadBalancer) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m WebAppFirewallLoadBalancer) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m WebAppFirewallLoadBalancer) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m WebAppFirewallLoadBalancer) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m WebAppFirewallLoadBalancer) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m WebAppFirewallLoadBalancer) GetLifecycleState() WebAppFirewallLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m WebAppFirewallLoadBalancer) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m WebAppFirewallLoadBalancer) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m WebAppFirewallLoadBalancer) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m WebAppFirewallLoadBalancer) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m WebAppFirewallLoadBalancer) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallLoadBalancer) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m WebAppFirewallLoadBalancer) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeWebAppFirewallLoadBalancer WebAppFirewallLoadBalancer
+	s := struct {
+		DiscriminatorParam string `json:"backendType"`
+		MarshalTypeWebAppFirewallLoadBalancer
+	}{
+		"LOAD_BALANCER",
+		(MarshalTypeWebAppFirewallLoadBalancer)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_load_balancer_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_load_balancer_summary.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallLoadBalancerSummary Summary of the WebAppFirewallLoadBalancer.
+type WebAppFirewallLoadBalancerSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	Id *string `mandatory:"true" json:"id"`
+
+	// WebAppFirewall display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	WebAppFirewallPolicyId *string `mandatory:"true" json:"webAppFirewallPolicyId"`
+
+	// The time the WebAppFirewall was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// LoadBalancer OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to which the WebAppFirewallPolicy is attached to.
+	LoadBalancerId *string `mandatory:"true" json:"loadBalancerId"`
+
+	// The time the WebAppFirewall was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The current state of the WebAppFirewall.
+	LifecycleState WebAppFirewallLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+}
+
+//GetId returns Id
+func (m WebAppFirewallLoadBalancerSummary) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m WebAppFirewallLoadBalancerSummary) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m WebAppFirewallLoadBalancerSummary) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m WebAppFirewallLoadBalancerSummary) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m WebAppFirewallLoadBalancerSummary) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m WebAppFirewallLoadBalancerSummary) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m WebAppFirewallLoadBalancerSummary) GetLifecycleState() WebAppFirewallLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m WebAppFirewallLoadBalancerSummary) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+//GetFreeformTags returns FreeformTags
+func (m WebAppFirewallLoadBalancerSummary) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m WebAppFirewallLoadBalancerSummary) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m WebAppFirewallLoadBalancerSummary) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+func (m WebAppFirewallLoadBalancerSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallLoadBalancerSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m WebAppFirewallLoadBalancerSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeWebAppFirewallLoadBalancerSummary WebAppFirewallLoadBalancerSummary
+	s := struct {
+		DiscriminatorParam string `json:"backendType"`
+		MarshalTypeWebAppFirewallLoadBalancerSummary
+	}{
+		"LOAD_BALANCER",
+		(MarshalTypeWebAppFirewallLoadBalancerSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallPolicy The details of WebAppFirewallPolicy. A policy is comprised of rules, which allows executing inspections of
+// incoming/outgoing HTTP message parameters and execution of actions, based on results of rules execution.
+// In policy, rules are grouped into modules by their functionality. Modules can be further divided by the type
+// of HTTP messages they handle:
+//   Modules that inspect incoming HTTP request. These modules are executed in the order they are enumerated here:
+//     * requestAccessControl
+//     * requestRateLimiting
+//     * requestProtection
+//  Modules that inspect outgoing HTTP responses. These modules are executed in the order they are enumerated here:
+//    * responseAccessControl
+//    * responseProtection
+type WebAppFirewallPolicy struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	Id *string `mandatory:"true" json:"id"`
+
+	// WebAppFirewallPolicy display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the WebAppFirewallPolicy was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The current state of the WebAppFirewallPolicy.
+	LifecycleState WebAppFirewallPolicyLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// The time the WebAppFirewallPolicy was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Predefined actions for use in multiple different rules. Not all actions are supported in every module.
+	// Some actions terminate further execution of modules and rules in a module and some do not.
+	// Actions names must be unique within this array.
+	Actions []Action `mandatory:"false" json:"actions"`
+
+	RequestAccessControl *RequestAccessControl `mandatory:"false" json:"requestAccessControl"`
+
+	RequestRateLimiting *RequestRateLimiting `mandatory:"false" json:"requestRateLimiting"`
+
+	RequestProtection *RequestProtection `mandatory:"false" json:"requestProtection"`
+
+	ResponseAccessControl *ResponseAccessControl `mandatory:"false" json:"responseAccessControl"`
+
+	ResponseProtection *ResponseProtection `mandatory:"false" json:"responseProtection"`
+}
+
+func (m WebAppFirewallPolicy) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallPolicy) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWebAppFirewallPolicyLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallPolicyLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *WebAppFirewallPolicy) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		TimeUpdated           *common.SDKTime                        `json:"timeUpdated"`
+		LifecycleDetails      *string                                `json:"lifecycleDetails"`
+		Actions               []action                               `json:"actions"`
+		RequestAccessControl  *RequestAccessControl                  `json:"requestAccessControl"`
+		RequestRateLimiting   *RequestRateLimiting                   `json:"requestRateLimiting"`
+		RequestProtection     *RequestProtection                     `json:"requestProtection"`
+		ResponseAccessControl *ResponseAccessControl                 `json:"responseAccessControl"`
+		ResponseProtection    *ResponseProtection                    `json:"responseProtection"`
+		Id                    *string                                `json:"id"`
+		DisplayName           *string                                `json:"displayName"`
+		CompartmentId         *string                                `json:"compartmentId"`
+		TimeCreated           *common.SDKTime                        `json:"timeCreated"`
+		LifecycleState        WebAppFirewallPolicyLifecycleStateEnum `json:"lifecycleState"`
+		FreeformTags          map[string]string                      `json:"freeformTags"`
+		DefinedTags           map[string]map[string]interface{}      `json:"definedTags"`
+		SystemTags            map[string]map[string]interface{}      `json:"systemTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.TimeUpdated = model.TimeUpdated
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.Actions = make([]Action, len(model.Actions))
+	for i, n := range model.Actions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Actions[i] = nn.(Action)
+		} else {
+			m.Actions[i] = nil
+		}
+	}
+
+	m.RequestAccessControl = model.RequestAccessControl
+
+	m.RequestRateLimiting = model.RequestRateLimiting
+
+	m.RequestProtection = model.RequestProtection
+
+	m.ResponseAccessControl = model.ResponseAccessControl
+
+	m.ResponseProtection = model.ResponseProtection
+
+	m.Id = model.Id
+
+	m.DisplayName = model.DisplayName
+
+	m.CompartmentId = model.CompartmentId
+
+	m.TimeCreated = model.TimeCreated
+
+	m.LifecycleState = model.LifecycleState
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	return
+}
+
+// WebAppFirewallPolicyLifecycleStateEnum Enum with underlying type: string
+type WebAppFirewallPolicyLifecycleStateEnum string
+
+// Set of constants representing the allowable values for WebAppFirewallPolicyLifecycleStateEnum
+const (
+	WebAppFirewallPolicyLifecycleStateCreating WebAppFirewallPolicyLifecycleStateEnum = "CREATING"
+	WebAppFirewallPolicyLifecycleStateUpdating WebAppFirewallPolicyLifecycleStateEnum = "UPDATING"
+	WebAppFirewallPolicyLifecycleStateActive   WebAppFirewallPolicyLifecycleStateEnum = "ACTIVE"
+	WebAppFirewallPolicyLifecycleStateDeleting WebAppFirewallPolicyLifecycleStateEnum = "DELETING"
+	WebAppFirewallPolicyLifecycleStateDeleted  WebAppFirewallPolicyLifecycleStateEnum = "DELETED"
+	WebAppFirewallPolicyLifecycleStateFailed   WebAppFirewallPolicyLifecycleStateEnum = "FAILED"
+)
+
+var mappingWebAppFirewallPolicyLifecycleStateEnum = map[string]WebAppFirewallPolicyLifecycleStateEnum{
+	"CREATING": WebAppFirewallPolicyLifecycleStateCreating,
+	"UPDATING": WebAppFirewallPolicyLifecycleStateUpdating,
+	"ACTIVE":   WebAppFirewallPolicyLifecycleStateActive,
+	"DELETING": WebAppFirewallPolicyLifecycleStateDeleting,
+	"DELETED":  WebAppFirewallPolicyLifecycleStateDeleted,
+	"FAILED":   WebAppFirewallPolicyLifecycleStateFailed,
+}
+
+var mappingWebAppFirewallPolicyLifecycleStateEnumLowerCase = map[string]WebAppFirewallPolicyLifecycleStateEnum{
+	"creating": WebAppFirewallPolicyLifecycleStateCreating,
+	"updating": WebAppFirewallPolicyLifecycleStateUpdating,
+	"active":   WebAppFirewallPolicyLifecycleStateActive,
+	"deleting": WebAppFirewallPolicyLifecycleStateDeleting,
+	"deleted":  WebAppFirewallPolicyLifecycleStateDeleted,
+	"failed":   WebAppFirewallPolicyLifecycleStateFailed,
+}
+
+// GetWebAppFirewallPolicyLifecycleStateEnumValues Enumerates the set of values for WebAppFirewallPolicyLifecycleStateEnum
+func GetWebAppFirewallPolicyLifecycleStateEnumValues() []WebAppFirewallPolicyLifecycleStateEnum {
+	values := make([]WebAppFirewallPolicyLifecycleStateEnum, 0)
+	for _, v := range mappingWebAppFirewallPolicyLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWebAppFirewallPolicyLifecycleStateEnumStringValues Enumerates the set of values in String for WebAppFirewallPolicyLifecycleStateEnum
+func GetWebAppFirewallPolicyLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"UPDATING",
+		"ACTIVE",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+	}
+}
+
+// GetMappingWebAppFirewallPolicyLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWebAppFirewallPolicyLifecycleStateEnum(val string) (WebAppFirewallPolicyLifecycleStateEnum, bool) {
+	enum, ok := mappingWebAppFirewallPolicyLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallPolicyCollection Contains WebAppFirewallPolicySummary items.
+type WebAppFirewallPolicyCollection struct {
+
+	// A list of WebAppFirewallPolicySummary objects.
+	Items []WebAppFirewallPolicySummary `mandatory:"true" json:"items"`
+}
+
+func (m WebAppFirewallPolicyCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallPolicyCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_rule.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallPolicyRule Base schema for WebAppFirewallPolicyRules, including properties common to all of them.
+type WebAppFirewallPolicyRule interface {
+
+	// Rule name. Must be unique within the module.
+	GetName() *string
+
+	// References action by name from actions defined in WebAppFirewallPolicy.
+	GetActionName() *string
+
+	// The language used to parse condition from field `condition`. Available languages:
+	// * **JMESPATH** an extended JMESPath language syntax.
+	GetConditionLanguage() WebAppFirewallPolicyRuleConditionLanguageEnum
+
+	// An expression that determines whether or not the rule action should be executed.
+	GetCondition() *string
+}
+
+type webappfirewallpolicyrule struct {
+	JsonData          []byte
+	Name              *string                                       `mandatory:"true" json:"name"`
+	ActionName        *string                                       `mandatory:"true" json:"actionName"`
+	ConditionLanguage WebAppFirewallPolicyRuleConditionLanguageEnum `mandatory:"false" json:"conditionLanguage,omitempty"`
+	Condition         *string                                       `mandatory:"false" json:"condition"`
+	Type              string                                        `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *webappfirewallpolicyrule) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerwebappfirewallpolicyrule webappfirewallpolicyrule
+	s := struct {
+		Model Unmarshalerwebappfirewallpolicyrule
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.ActionName = s.Model.ActionName
+	m.ConditionLanguage = s.Model.ConditionLanguage
+	m.Condition = s.Model.Condition
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *webappfirewallpolicyrule) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "PROTECTION":
+		mm := ProtectionRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "REQUEST_RATE_LIMITING":
+		mm := RequestRateLimitingRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ACCESS_CONTROL":
+		mm := AccessControlRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m webappfirewallpolicyrule) GetName() *string {
+	return m.Name
+}
+
+//GetActionName returns ActionName
+func (m webappfirewallpolicyrule) GetActionName() *string {
+	return m.ActionName
+}
+
+//GetConditionLanguage returns ConditionLanguage
+func (m webappfirewallpolicyrule) GetConditionLanguage() WebAppFirewallPolicyRuleConditionLanguageEnum {
+	return m.ConditionLanguage
+}
+
+//GetCondition returns Condition
+func (m webappfirewallpolicyrule) GetCondition() *string {
+	return m.Condition
+}
+
+func (m webappfirewallpolicyrule) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m webappfirewallpolicyrule) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum(string(m.ConditionLanguage)); !ok && m.ConditionLanguage != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ConditionLanguage: %s. Supported values are: %s.", m.ConditionLanguage, strings.Join(GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WebAppFirewallPolicyRuleConditionLanguageEnum Enum with underlying type: string
+type WebAppFirewallPolicyRuleConditionLanguageEnum string
+
+// Set of constants representing the allowable values for WebAppFirewallPolicyRuleConditionLanguageEnum
+const (
+	WebAppFirewallPolicyRuleConditionLanguageJmespath WebAppFirewallPolicyRuleConditionLanguageEnum = "JMESPATH"
+)
+
+var mappingWebAppFirewallPolicyRuleConditionLanguageEnum = map[string]WebAppFirewallPolicyRuleConditionLanguageEnum{
+	"JMESPATH": WebAppFirewallPolicyRuleConditionLanguageJmespath,
+}
+
+var mappingWebAppFirewallPolicyRuleConditionLanguageEnumLowerCase = map[string]WebAppFirewallPolicyRuleConditionLanguageEnum{
+	"jmespath": WebAppFirewallPolicyRuleConditionLanguageJmespath,
+}
+
+// GetWebAppFirewallPolicyRuleConditionLanguageEnumValues Enumerates the set of values for WebAppFirewallPolicyRuleConditionLanguageEnum
+func GetWebAppFirewallPolicyRuleConditionLanguageEnumValues() []WebAppFirewallPolicyRuleConditionLanguageEnum {
+	values := make([]WebAppFirewallPolicyRuleConditionLanguageEnum, 0)
+	for _, v := range mappingWebAppFirewallPolicyRuleConditionLanguageEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues Enumerates the set of values in String for WebAppFirewallPolicyRuleConditionLanguageEnum
+func GetWebAppFirewallPolicyRuleConditionLanguageEnumStringValues() []string {
+	return []string{
+		"JMESPATH",
+	}
+}
+
+// GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWebAppFirewallPolicyRuleConditionLanguageEnum(val string) (WebAppFirewallPolicyRuleConditionLanguageEnum, bool) {
+	enum, ok := mappingWebAppFirewallPolicyRuleConditionLanguageEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// WebAppFirewallPolicyRuleTypeEnum Enum with underlying type: string
+type WebAppFirewallPolicyRuleTypeEnum string
+
+// Set of constants representing the allowable values for WebAppFirewallPolicyRuleTypeEnum
+const (
+	WebAppFirewallPolicyRuleTypeAccessControl       WebAppFirewallPolicyRuleTypeEnum = "ACCESS_CONTROL"
+	WebAppFirewallPolicyRuleTypeProtection          WebAppFirewallPolicyRuleTypeEnum = "PROTECTION"
+	WebAppFirewallPolicyRuleTypeRequestRateLimiting WebAppFirewallPolicyRuleTypeEnum = "REQUEST_RATE_LIMITING"
+)
+
+var mappingWebAppFirewallPolicyRuleTypeEnum = map[string]WebAppFirewallPolicyRuleTypeEnum{
+	"ACCESS_CONTROL":        WebAppFirewallPolicyRuleTypeAccessControl,
+	"PROTECTION":            WebAppFirewallPolicyRuleTypeProtection,
+	"REQUEST_RATE_LIMITING": WebAppFirewallPolicyRuleTypeRequestRateLimiting,
+}
+
+var mappingWebAppFirewallPolicyRuleTypeEnumLowerCase = map[string]WebAppFirewallPolicyRuleTypeEnum{
+	"access_control":        WebAppFirewallPolicyRuleTypeAccessControl,
+	"protection":            WebAppFirewallPolicyRuleTypeProtection,
+	"request_rate_limiting": WebAppFirewallPolicyRuleTypeRequestRateLimiting,
+}
+
+// GetWebAppFirewallPolicyRuleTypeEnumValues Enumerates the set of values for WebAppFirewallPolicyRuleTypeEnum
+func GetWebAppFirewallPolicyRuleTypeEnumValues() []WebAppFirewallPolicyRuleTypeEnum {
+	values := make([]WebAppFirewallPolicyRuleTypeEnum, 0)
+	for _, v := range mappingWebAppFirewallPolicyRuleTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWebAppFirewallPolicyRuleTypeEnumStringValues Enumerates the set of values in String for WebAppFirewallPolicyRuleTypeEnum
+func GetWebAppFirewallPolicyRuleTypeEnumStringValues() []string {
+	return []string{
+		"ACCESS_CONTROL",
+		"PROTECTION",
+		"REQUEST_RATE_LIMITING",
+	}
+}
+
+// GetMappingWebAppFirewallPolicyRuleTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWebAppFirewallPolicyRuleTypeEnum(val string) (WebAppFirewallPolicyRuleTypeEnum, bool) {
+	enum, ok := mappingWebAppFirewallPolicyRuleTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_policy_summary.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallPolicySummary Summary of the WebAppFirewallPolicy.
+type WebAppFirewallPolicySummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewallPolicy.
+	Id *string `mandatory:"true" json:"id"`
+
+	// WebAppFirewallPolicy display name, can be renamed.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the WebAppFirewallPolicy was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The current state of the WebAppFirewallPolicy.
+	LifecycleState WebAppFirewallPolicyLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"true" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+
+	// The time the WebAppFirewallPolicy was updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+}
+
+func (m WebAppFirewallPolicySummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WebAppFirewallPolicySummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWebAppFirewallPolicyLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallPolicyLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/web_app_firewall_summary.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WebAppFirewallSummary Summary of the WebAppFirewall.
+type WebAppFirewallSummary interface {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WebAppFirewall.
+	GetId() *string
+
+	// WebAppFirewall display name, can be renamed.
+	GetDisplayName() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of WebAppFirewallPolicy, which is attached to the resource.
+	GetWebAppFirewallPolicyId() *string
+
+	// The time the WebAppFirewall was created. An RFC3339 formatted datetime string.
+	GetTimeCreated() *common.SDKTime
+
+	// The current state of the WebAppFirewall.
+	GetLifecycleState() WebAppFirewallLifecycleStateEnum
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	GetSystemTags() map[string]map[string]interface{}
+
+	// The time the WebAppFirewall was updated. An RFC3339 formatted datetime string.
+	GetTimeUpdated() *common.SDKTime
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a resource in FAILED state.
+	GetLifecycleDetails() *string
+}
+
+type webappfirewallsummary struct {
+	JsonData               []byte
+	Id                     *string                           `mandatory:"true" json:"id"`
+	DisplayName            *string                           `mandatory:"true" json:"displayName"`
+	CompartmentId          *string                           `mandatory:"true" json:"compartmentId"`
+	WebAppFirewallPolicyId *string                           `mandatory:"true" json:"webAppFirewallPolicyId"`
+	TimeCreated            *common.SDKTime                   `mandatory:"true" json:"timeCreated"`
+	LifecycleState         WebAppFirewallLifecycleStateEnum  `mandatory:"true" json:"lifecycleState"`
+	FreeformTags           map[string]string                 `mandatory:"true" json:"freeformTags"`
+	DefinedTags            map[string]map[string]interface{} `mandatory:"true" json:"definedTags"`
+	SystemTags             map[string]map[string]interface{} `mandatory:"true" json:"systemTags"`
+	TimeUpdated            *common.SDKTime                   `mandatory:"false" json:"timeUpdated"`
+	LifecycleDetails       *string                           `mandatory:"false" json:"lifecycleDetails"`
+	BackendType            string                            `json:"backendType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *webappfirewallsummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerwebappfirewallsummary webappfirewallsummary
+	s := struct {
+		Model Unmarshalerwebappfirewallsummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Id = s.Model.Id
+	m.DisplayName = s.Model.DisplayName
+	m.CompartmentId = s.Model.CompartmentId
+	m.WebAppFirewallPolicyId = s.Model.WebAppFirewallPolicyId
+	m.TimeCreated = s.Model.TimeCreated
+	m.LifecycleState = s.Model.LifecycleState
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.SystemTags = s.Model.SystemTags
+	m.TimeUpdated = s.Model.TimeUpdated
+	m.LifecycleDetails = s.Model.LifecycleDetails
+	m.BackendType = s.Model.BackendType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *webappfirewallsummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.BackendType {
+	case "LOAD_BALANCER":
+		mm := WebAppFirewallLoadBalancerSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetId returns Id
+func (m webappfirewallsummary) GetId() *string {
+	return m.Id
+}
+
+//GetDisplayName returns DisplayName
+func (m webappfirewallsummary) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m webappfirewallsummary) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetWebAppFirewallPolicyId returns WebAppFirewallPolicyId
+func (m webappfirewallsummary) GetWebAppFirewallPolicyId() *string {
+	return m.WebAppFirewallPolicyId
+}
+
+//GetTimeCreated returns TimeCreated
+func (m webappfirewallsummary) GetTimeCreated() *common.SDKTime {
+	return m.TimeCreated
+}
+
+//GetLifecycleState returns LifecycleState
+func (m webappfirewallsummary) GetLifecycleState() WebAppFirewallLifecycleStateEnum {
+	return m.LifecycleState
+}
+
+//GetFreeformTags returns FreeformTags
+func (m webappfirewallsummary) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m webappfirewallsummary) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+//GetSystemTags returns SystemTags
+func (m webappfirewallsummary) GetSystemTags() map[string]map[string]interface{} {
+	return m.SystemTags
+}
+
+//GetTimeUpdated returns TimeUpdated
+func (m webappfirewallsummary) GetTimeUpdated() *common.SDKTime {
+	return m.TimeUpdated
+}
+
+//GetLifecycleDetails returns LifecycleDetails
+func (m webappfirewallsummary) GetLifecycleDetails() *string {
+	return m.LifecycleDetails
+}
+
+func (m webappfirewallsummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m webappfirewallsummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWebAppFirewallLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWebAppFirewallLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequest A description of WorkRequest status
+type WorkRequest struct {
+
+	// Type of the WorkRequest
+	OperationType WorkRequestOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// Status of current work request.
+	Status WorkRequestStatusEnum `mandatory:"true" json:"status"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the WorkRequest.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the WorkRequest.
+	// WorkRequests should be scoped to the same compartment as the resource the work request affects.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The resources affected by this WorkRequest.
+	Resources []WorkRequestResource `mandatory:"true" json:"resources"`
+
+	// Percentage of the request completed.
+	PercentComplete *float32 `mandatory:"true" json:"percentComplete"`
+
+	// The date and time the request was created, as described in
+	// RFC 3339 (https://tools.ietf.org/rfc/rfc3339), section 14.29.
+	TimeAccepted *common.SDKTime `mandatory:"true" json:"timeAccepted"`
+
+	// The date and time the request was started, as described in
+	// RFC 3339 (https://tools.ietf.org/rfc/rfc3339), section 14.29.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The date and time the object was finished, as described in RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWorkRequestOperationTypeEnum(string(m.OperationType)); !ok && m.OperationType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for OperationType: %s. Supported values are: %s.", m.OperationType, strings.Join(GetWorkRequestOperationTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingWorkRequestStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetWorkRequestStatusEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestOperationTypeEnum Enum with underlying type: string
+type WorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+const (
+	WorkRequestOperationTypeCreateWafPolicy          WorkRequestOperationTypeEnum = "CREATE_WAF_POLICY"
+	WorkRequestOperationTypeUpdateWafPolicy          WorkRequestOperationTypeEnum = "UPDATE_WAF_POLICY"
+	WorkRequestOperationTypeDeleteWafPolicy          WorkRequestOperationTypeEnum = "DELETE_WAF_POLICY"
+	WorkRequestOperationTypeMoveWafPolicy            WorkRequestOperationTypeEnum = "MOVE_WAF_POLICY"
+	WorkRequestOperationTypeCreateNetworkAddressList WorkRequestOperationTypeEnum = "CREATE_NETWORK_ADDRESS_LIST"
+	WorkRequestOperationTypeUpdateNetworkAddressList WorkRequestOperationTypeEnum = "UPDATE_NETWORK_ADDRESS_LIST"
+	WorkRequestOperationTypeDeleteNetworkAddressList WorkRequestOperationTypeEnum = "DELETE_NETWORK_ADDRESS_LIST"
+	WorkRequestOperationTypeMoveNetworkAddressList   WorkRequestOperationTypeEnum = "MOVE_NETWORK_ADDRESS_LIST"
+	WorkRequestOperationTypeCreateWebAppFirewall     WorkRequestOperationTypeEnum = "CREATE_WEB_APP_FIREWALL"
+	WorkRequestOperationTypeUpdateWebAppFirewall     WorkRequestOperationTypeEnum = "UPDATE_WEB_APP_FIREWALL"
+	WorkRequestOperationTypeDeleteWebAppFirewall     WorkRequestOperationTypeEnum = "DELETE_WEB_APP_FIREWALL"
+	WorkRequestOperationTypeMoveWebAppFirewall       WorkRequestOperationTypeEnum = "MOVE_WEB_APP_FIREWALL"
+)
+
+var mappingWorkRequestOperationTypeEnum = map[string]WorkRequestOperationTypeEnum{
+	"CREATE_WAF_POLICY":           WorkRequestOperationTypeCreateWafPolicy,
+	"UPDATE_WAF_POLICY":           WorkRequestOperationTypeUpdateWafPolicy,
+	"DELETE_WAF_POLICY":           WorkRequestOperationTypeDeleteWafPolicy,
+	"MOVE_WAF_POLICY":             WorkRequestOperationTypeMoveWafPolicy,
+	"CREATE_NETWORK_ADDRESS_LIST": WorkRequestOperationTypeCreateNetworkAddressList,
+	"UPDATE_NETWORK_ADDRESS_LIST": WorkRequestOperationTypeUpdateNetworkAddressList,
+	"DELETE_NETWORK_ADDRESS_LIST": WorkRequestOperationTypeDeleteNetworkAddressList,
+	"MOVE_NETWORK_ADDRESS_LIST":   WorkRequestOperationTypeMoveNetworkAddressList,
+	"CREATE_WEB_APP_FIREWALL":     WorkRequestOperationTypeCreateWebAppFirewall,
+	"UPDATE_WEB_APP_FIREWALL":     WorkRequestOperationTypeUpdateWebAppFirewall,
+	"DELETE_WEB_APP_FIREWALL":     WorkRequestOperationTypeDeleteWebAppFirewall,
+	"MOVE_WEB_APP_FIREWALL":       WorkRequestOperationTypeMoveWebAppFirewall,
+}
+
+var mappingWorkRequestOperationTypeEnumLowerCase = map[string]WorkRequestOperationTypeEnum{
+	"create_waf_policy":           WorkRequestOperationTypeCreateWafPolicy,
+	"update_waf_policy":           WorkRequestOperationTypeUpdateWafPolicy,
+	"delete_waf_policy":           WorkRequestOperationTypeDeleteWafPolicy,
+	"move_waf_policy":             WorkRequestOperationTypeMoveWafPolicy,
+	"create_network_address_list": WorkRequestOperationTypeCreateNetworkAddressList,
+	"update_network_address_list": WorkRequestOperationTypeUpdateNetworkAddressList,
+	"delete_network_address_list": WorkRequestOperationTypeDeleteNetworkAddressList,
+	"move_network_address_list":   WorkRequestOperationTypeMoveNetworkAddressList,
+	"create_web_app_firewall":     WorkRequestOperationTypeCreateWebAppFirewall,
+	"update_web_app_firewall":     WorkRequestOperationTypeUpdateWebAppFirewall,
+	"delete_web_app_firewall":     WorkRequestOperationTypeDeleteWebAppFirewall,
+	"move_web_app_firewall":       WorkRequestOperationTypeMoveWebAppFirewall,
+}
+
+// GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumValues() []WorkRequestOperationTypeEnum {
+	values := make([]WorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestOperationTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestOperationTypeEnumStringValues Enumerates the set of values in String for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumStringValues() []string {
+	return []string{
+		"CREATE_WAF_POLICY",
+		"UPDATE_WAF_POLICY",
+		"DELETE_WAF_POLICY",
+		"MOVE_WAF_POLICY",
+		"CREATE_NETWORK_ADDRESS_LIST",
+		"UPDATE_NETWORK_ADDRESS_LIST",
+		"DELETE_NETWORK_ADDRESS_LIST",
+		"MOVE_NETWORK_ADDRESS_LIST",
+		"CREATE_WEB_APP_FIREWALL",
+		"UPDATE_WEB_APP_FIREWALL",
+		"DELETE_WEB_APP_FIREWALL",
+		"MOVE_WEB_APP_FIREWALL",
+	}
+}
+
+// GetMappingWorkRequestOperationTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestOperationTypeEnum(val string) (WorkRequestOperationTypeEnum, bool) {
+	enum, ok := mappingWorkRequestOperationTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// WorkRequestStatusEnum Enum with underlying type: string
+type WorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+const (
+	WorkRequestStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestStatusEnum = map[string]WorkRequestStatusEnum{
+	"ACCEPTED":    WorkRequestStatusAccepted,
+	"IN_PROGRESS": WorkRequestStatusInProgress,
+	"FAILED":      WorkRequestStatusFailed,
+	"SUCCEEDED":   WorkRequestStatusSucceeded,
+	"CANCELING":   WorkRequestStatusCanceling,
+	"CANCELED":    WorkRequestStatusCanceled,
+}
+
+var mappingWorkRequestStatusEnumLowerCase = map[string]WorkRequestStatusEnum{
+	"accepted":    WorkRequestStatusAccepted,
+	"in_progress": WorkRequestStatusInProgress,
+	"failed":      WorkRequestStatusFailed,
+	"succeeded":   WorkRequestStatusSucceeded,
+	"canceling":   WorkRequestStatusCanceling,
+	"canceled":    WorkRequestStatusCanceled,
+}
+
+// GetWorkRequestStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumValues() []WorkRequestStatusEnum {
+	values := make([]WorkRequestStatusEnum, 0)
+	for _, v := range mappingWorkRequestStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestStatusEnumStringValues Enumerates the set of values in String for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumStringValues() []string {
+	return []string{
+		"ACCEPTED",
+		"IN_PROGRESS",
+		"FAILED",
+		"SUCCEEDED",
+		"CANCELING",
+		"CANCELED",
+	}
+}
+
+// GetMappingWorkRequestStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestStatusEnum(val string) (WorkRequestStatusEnum, bool) {
+	enum, ok := mappingWorkRequestStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestCollection Result of a WorkRequest search. Contains both WorkRequest items and other information, such as metadata.
+type WorkRequestCollection struct {
+
+	// List of WorkRequests.
+	Items []WorkRequest `mandatory:"true" json:"items"`
+}
+
+func (m WorkRequestCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestError An error encountered while executing a WorkRequest.
+type WorkRequestError struct {
+
+	// A machine-usable code for the error that occured. Error codes are listed on
+	// https://docs.cloud.oracle.com/Content/API/References/apierrors.htm.
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human readable description of the issue encountered.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The time the error occured. An RFC3339 formatted datetime string.
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_error_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_error_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestErrorCollection Result of a WorkRequestError search. Contains both WorkRequestError items and other information, such as metadata.
+type WorkRequestErrorCollection struct {
+
+	// List of WorkRequestError objects.
+	Items []WorkRequestError `mandatory:"true" json:"items"`
+}
+
+func (m WorkRequestErrorCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestErrorCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_log_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_log_entry.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestLogEntry A log message from the execution of a WorkRequest.
+type WorkRequestLogEntry struct {
+
+	// Human-readable log message.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The time the log message was written. An RFC3339 formatted datetime string.
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestLogEntry) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestLogEntry) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_log_entry_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_log_entry_collection.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestLogEntryCollection Result of a WorkRequestLog search. Contains both WorkRequestLog items and other information, such as metadata.
+type WorkRequestLogEntryCollection struct {
+
+	// List of WorkRequestLogEntries.
+	Items []WorkRequestLogEntry `mandatory:"true" json:"items"`
+}
+
+func (m WorkRequestLogEntryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestLogEntryCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/waf/work_request_resource.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Web Application Firewall (WAF) API
+//
+// API for the Web Application Firewall service.
+// Use this API to manage regional Web App Firewalls and corresponding policies for protecting HTTP services.
+//
+
+package waf
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestResource A resource created or operated on by a WorkRequest.
+type WorkRequestResource struct {
+
+	// The resource type the WorkRequest affects.
+	EntityType *string `mandatory:"true" json:"entityType"`
+
+	// The way in which this resource is affected by the work tracked in the WorkRequest.
+	// A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+	// work is complete for that resource at which point it will transition to CREATED, UPDATED,
+	// or DELETED, respectively.
+	ActionType WorkRequestResourceActionTypeEnum `mandatory:"true" json:"actionType"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource the WorkRequest affects.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// The URI path that the user can do a GET on to access the resource metadata.
+	EntityUri *string `mandatory:"false" json:"entityUri"`
+}
+
+func (m WorkRequestResource) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestResource) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWorkRequestResourceActionTypeEnum(string(m.ActionType)); !ok && m.ActionType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ActionType: %s. Supported values are: %s.", m.ActionType, strings.Join(GetWorkRequestResourceActionTypeEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestResourceActionTypeEnum Enum with underlying type: string
+type WorkRequestResourceActionTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestResourceActionTypeEnum
+const (
+	WorkRequestResourceActionTypeCreated    WorkRequestResourceActionTypeEnum = "CREATED"
+	WorkRequestResourceActionTypeUpdated    WorkRequestResourceActionTypeEnum = "UPDATED"
+	WorkRequestResourceActionTypeDeleted    WorkRequestResourceActionTypeEnum = "DELETED"
+	WorkRequestResourceActionTypeInProgress WorkRequestResourceActionTypeEnum = "IN_PROGRESS"
+	WorkRequestResourceActionTypeRelated    WorkRequestResourceActionTypeEnum = "RELATED"
+)
+
+var mappingWorkRequestResourceActionTypeEnum = map[string]WorkRequestResourceActionTypeEnum{
+	"CREATED":     WorkRequestResourceActionTypeCreated,
+	"UPDATED":     WorkRequestResourceActionTypeUpdated,
+	"DELETED":     WorkRequestResourceActionTypeDeleted,
+	"IN_PROGRESS": WorkRequestResourceActionTypeInProgress,
+	"RELATED":     WorkRequestResourceActionTypeRelated,
+}
+
+var mappingWorkRequestResourceActionTypeEnumLowerCase = map[string]WorkRequestResourceActionTypeEnum{
+	"created":     WorkRequestResourceActionTypeCreated,
+	"updated":     WorkRequestResourceActionTypeUpdated,
+	"deleted":     WorkRequestResourceActionTypeDeleted,
+	"in_progress": WorkRequestResourceActionTypeInProgress,
+	"related":     WorkRequestResourceActionTypeRelated,
+}
+
+// GetWorkRequestResourceActionTypeEnumValues Enumerates the set of values for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumValues() []WorkRequestResourceActionTypeEnum {
+	values := make([]WorkRequestResourceActionTypeEnum, 0)
+	for _, v := range mappingWorkRequestResourceActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestResourceActionTypeEnumStringValues Enumerates the set of values in String for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumStringValues() []string {
+	return []string{
+		"CREATED",
+		"UPDATED",
+		"DELETED",
+		"IN_PROGRESS",
+		"RELATED",
+	}
+}
+
+// GetMappingWorkRequestResourceActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestResourceActionTypeEnum(val string) (WorkRequestResourceActionTypeEnum, bool) {
+	enum, ok := mappingWorkRequestResourceActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,6 +115,7 @@ github.com/oracle/oci-go-sdk/v65/common
 github.com/oracle/oci-go-sdk/v65/common/auth
 github.com/oracle/oci-go-sdk/v65/common/utils
 github.com/oracle/oci-go-sdk/v65/loadbalancer
+github.com/oracle/oci-go-sdk/v65/waf
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
- Added support for annotation `oci-native-ingress.oraclecloud.com/waf-policy-ocid` which enables user to add firewall policy id to IngressClass. It helps us create and add firewall to the corresponding LB.
- Post creation of firewall, we add the corresponding firewall ocid to the ingressclass via `oci-native-ingress.oraclecloud.com/firewall-id`.
- [OKE-27261-Fixed-multi-path-bug](https://github.com/oracle/oci-native-ingress-controller/pull/14/commits/b90ba24f5e3313857c6d7ca999b31a97aff7db01)