### PR TITLE
OKE-27032 Flannel Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,8 @@
 name: Unit Tests
 
 on:
-  pull_request: {}
-  push: {}
+  pull_request: { }
+  push: { }
 jobs:
   build:
     name: Build
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          go test -covermode=count -coverprofile=profile.cov ./pkg/...
+          go test -covermode=count -coverprofile=profile.cov  $(go list ./pkg/... | grep -v /server | grep -v /testutil)
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -118,6 +118,7 @@ Allow <subject> to read certificate-authority-bundles in compartment <compartmen
 ALLOW <subject> native-ingress-controller to read public-ips in tenancy
 ALLOW <subject> native-ingress-controller to manage floating-ips in tenancy 
 Allow <subject> to manage waf-family in compartment <compartment-id>
+Allow <subject> to read cluster-family in compartment <compartment-id>
 
 Policy scope can be broadened to Tenancy or restricted to a particular location as shown below:
 allow <subject> to manage load-balancers in tenancy

--- a/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
@@ -61,15 +61,15 @@ spec:
           - --controller-class=oci.oraclecloud.com/native-ingress-controller
           - --compartment-id=
           - --subnet-id=
+          - --cluster-id=
           - --metrics-backend=prometheus
           - --metrics-port=2223
-          - --cniType=OCI_VCN_IP_NATIVE
           - --v=4
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION
               value: "2.2"
             - name: OCI_RESOURCE_PRINCIPAL_REGION
-              value: "us-ashburn-1"
+              value: "us-phoenix-1"
             - name: OCI_SDK_DEFAULT_RETRY_ENABLED
               value: "true"
           ports:

--- a/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
@@ -18,10 +18,10 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -51,7 +51,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
-          image: "ghcr.io/oracle/oci-native-ingress-controller:v1.0.0"
+          image: "ghcr.io/oracle/oci-native-ingress-controller:v1.3.0"
           imagePullPolicy: Always
           args: 
           - --lease-lock-name=oci-native-ingress-controller
@@ -63,6 +63,7 @@ spec:
           - --subnet-id=
           - --metrics-backend=prometheus
           - --metrics-port=2223
+          - --cniType=OCI_VCN_IP_NATIVE
           - --v=4
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION

--- a/deploy/manifests/oci-native-ingress-controller/templates/rbac.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/rbac.yaml
@@ -11,10 +11,10 @@ kind: ClusterRole
 metadata:
   name: oci-native-ingress-controller-role
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -48,10 +48,10 @@ kind: ClusterRoleBinding
 metadata:
   name: oci-native-ingress-controller-rolebinding
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69,10 +69,10 @@ metadata:
   name: oci-native-ingress-controller-leader-election-role
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: ["coordination.k8s.io"]
@@ -90,10 +90,10 @@ metadata:
   name: oci-native-ingress-controller-leader-election-rolebinding
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/manifests/oci-native-ingress-controller/templates/service.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/service.yaml
@@ -12,10 +12,10 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/deploy/manifests/oci-native-ingress-controller/templates/serviceaccount.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/serviceaccount.yaml
@@ -12,8 +12,8 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm

--- a/deploy/manifests/oci-native-ingress-controller/templates/webhook.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/webhook.yaml
@@ -36,10 +36,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: oci-native-ingress-controller-webhook
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.0.0
+    helm.sh/chart: oci-native-ingress-controller-1.3.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/inject-ca-from: native-ingress-controller-system/oci-native-ingress-controller-webhook-serving-cert

--- a/helm/oci-native-ingress-controller/Chart.yaml
+++ b/helm/oci-native-ingress-controller/Chart.yaml
@@ -8,8 +8,8 @@ apiVersion: v2
 name: oci-native-ingress-controller
 description: OCI Native Ingress Controller
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.3.0
+appVersion: "1.3.0"
 
 maintainers:
   - name: OKE Foundations team

--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
           - --subnet-id={{ .Values.subnet_id }}
           - --metrics-backend={{.Values.metrics.backend}}
           - --metrics-port={{.Values.metrics.port}}
+          - --cniType={{.Values.cniType}}
           - --v=4
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION

--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -61,15 +61,15 @@ spec:
           - --controller-class={{ .Values.controller_class }}
           - --compartment-id={{ .Values.compartment_id }}
           - --subnet-id={{ .Values.subnet_id }}
+          - --cluster-id={{.Values.cluster_id }}
           - --metrics-backend={{.Values.metrics.backend}}
           - --metrics-port={{.Values.metrics.port}}
-          - --cniType={{.Values.cniType}}
           - --v=4
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION
               value: "2.2"
             - name: OCI_RESOURCE_PRINCIPAL_REGION
-              value: "us-ashburn-1"
+              value: "us-phoenix-1"
             - name: OCI_SDK_DEFAULT_RETRY_ENABLED
               value: "true"
           ports:

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -21,7 +21,7 @@ image:
   repository: ghcr.io/oracle/oci-native-ingress-controller
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.0"
+  tag: "v1.3.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -110,3 +110,7 @@ objectSelector:
 metrics:
   backend: prometheus
   port: 2223
+
+
+# Supported CNI : OCI_VCN_IP_NATIVE, FLANNEL_OVERLAY
+cniType: OCI_VCN_IP_NATIVE

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -13,6 +13,7 @@ controller_class: oci.oraclecloud.com/native-ingress-controller
 lease_lock_name: oci-native-ingress-controller
 compartment_id: ""
 subnet_id: ""
+cluster_id: ""
 
 deploymentNamespace : native-ingress-controller-system
 replicaCount: 1
@@ -110,7 +111,3 @@ objectSelector:
 metrics:
   backend: prometheus
   port: 2223
-
-
-# Supported CNI : OCI_VCN_IP_NATIVE, FLANNEL_OVERLAY
-cniType: OCI_VCN_IP_NATIVE

--- a/main.go
+++ b/main.go
@@ -9,213 +9,224 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
-	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
-	"github.com/oracle/oci-native-ingress-controller/pkg/server"
-	"github.com/oracle/oci-native-ingress-controller/pkg/types"
-	"k8s.io/klog/v2"
-
-	ctrcache "sigs.k8s.io/controller-runtime/pkg/cache"
-
-	"github.com/google/uuid"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/informers"
-	clientset "k8s.io/client-go/kubernetes"
-
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-
-	"github.com/oracle/oci-native-ingress-controller/api/v1beta1"
+    "context"
+    "flag"
+    "net/http"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
+    
+    "github.com/oracle/oci-native-ingress-controller/pkg/metric"
+    "github.com/oracle/oci-native-ingress-controller/pkg/server"
+    "github.com/oracle/oci-native-ingress-controller/pkg/types"
+    v1 `k8s.io/client-go/informers/core/v1`
+    networkinginformers `k8s.io/client-go/informers/networking/v1`
+    "k8s.io/klog/v2"
+    
+    ctrcache "sigs.k8s.io/controller-runtime/pkg/cache"
+    
+    "github.com/google/uuid"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/client-go/informers"
+    clientset "k8s.io/client-go/kubernetes"
+    
+    "k8s.io/client-go/kubernetes/scheme"
+    "k8s.io/client-go/tools/cache"
+    "k8s.io/client-go/tools/leaderelection"
+    "k8s.io/client-go/tools/leaderelection/resourcelock"
+    
+    "github.com/oracle/oci-native-ingress-controller/api/v1beta1"
 )
 
 func main() {
+    
+    klog.InitFlags(nil)
+    
+    var opts types.IngressOpts
+    
+    flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+    flag.StringVar(&opts.LeaseID, "id", uuid.New().String(), "the holder identity name")
+    flag.StringVar(&opts.LeaseLockName, "lease-lock-name", "", "the lease lock resource name")
+    flag.StringVar(&opts.LeaseLockNamespace, "lease-lock-namespace", "", "the lease lock resource namespace")
+    
+    flag.StringVar(&opts.CompartmentId, "compartment-id", "", "the default compartment for oci resource creation")
+    flag.StringVar(&opts.SubnetId, "subnet-id", "", "the default subnet for load balancers")
+    flag.StringVar(&opts.ClusterId, "cluster-id", "", "the oke cluster id")
+    flag.StringVar(&opts.ControllerClass, "controller-class", "oci.oraclecloud.com/native-ingress-controller", "the controller class name")
+    flag.StringVar(&opts.AuthType, "authType", "instance", "The auth type to be used - supported values : user, instance(Default).")
+    flag.StringVar(&opts.AuthSecretName, "auth-secret-name", "", "Secret name used for auth, cannot be empty if authType is user principal")
+    flag.StringVar(&opts.MetricsBackend, "metrics-backend", "prometheus", "Backend used for metrics")
+    flag.IntVar(&opts.MetricsPort, "metrics-port", 2223, "Metrics port for metrics backend")
+    flag.Parse()
+    
+    if opts.LeaseLockName == "" {
+        klog.Fatal("unable to get lease lock resource name (missing lease-lock-name flag).")
+    }
+    if opts.LeaseLockNamespace == "" {
+        klog.Fatal("unable to get lease lock resource namespace (missing lease-lock-namespace flag).")
+    }
+    
+    if opts.CompartmentId == "" {
+        klog.Fatal("unable to get compartment id (missing compartment-id flag).")
+    }
+    
+    if opts.SubnetId == "" {
+        klog.Fatal("unable to get subnet id (missing subnet-id flag).")
+    }
+    
+    if opts.ClusterId == "" {
+        klog.Fatal("unable to get cluster id (missing cluster-id flag).")
+    }
+    
+    if opts.AuthType == "user" {
+        if opts.AuthSecretName == "" {
+            klog.Fatal("unable to get secret name (missing secret-name flag) since authType is user.")
+        }
+    }
+    
+    // leader election uses the Kubernetes API by writing to a
+    // lock object, which can be a LeaseLock object (preferred),
+    // a ConfigMap, or an Endpoints (deprecated) object.
+    // Conflicting writes are detected and each client handles those actions
+    // independently.
+    config, err := server.BuildConfig(opts.KubeConfig)
+    if err != nil {
+        klog.Fatal(err)
+    }
+    client := clientset.NewForConfigOrDie(config)
+    
+    // Register our CRD with the default scheme to be understood by clients.
+    v1beta1.AddToScheme(scheme.Scheme)
+    
+    c, err := ctrcache.New(config, ctrcache.Options{
+        Scheme: scheme.Scheme,
+    })
+    if err != nil {
+        klog.Fatalf("failed to construct cache for crds: %w", err)
+    }
+    // use a Go context, so we can tell the leaderelection code when we
+    // want to step down
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+    
+    classParamInformer, err := c.GetInformer(ctx, &v1beta1.IngressClassParameters{})
+    if err != nil {
+        klog.Fatalf("failed to construct informer for class params: %w", err)
+    }
+    
+    go func() {
+        klog.Info("starting controller runtime informers")
+        err = c.Start(ctx)
+        if err != nil {
+            klog.Fatalf("failed to start informers for class params: %w", err)
+        }
+    }()
+    
+    informerFactory := informers.NewSharedInformerFactory(client, 1*time.Minute)
+    
+    // listen for interrupts or the Linux SIGTERM signal and cancel
+    // our context, which the leader election code will observe and
+    // step down
+    ch := make(chan os.Signal, 1)
+    signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+    go func() {
+        <-ch
+        klog.Info("Received termination, signaling shutdown")
+        cancel()
+    }()
+    
+    ingressClassInformer, ingressInformer, serviceInformer, endpointInformer, podInformer, nodeInformer := setupInformers(informerFactory, ctx, classParamInformer)
+    
+    server.SetupWebhookServer(ingressInformer, serviceInformer, client, ctx)
+    mux := http.NewServeMux()
+    reg, err := server.SetupMetricsServer(opts.MetricsBackend, opts.MetricsPort, mux, ctx)
+    
+    run := server.SetUpControllers(opts, ingressClassInformer, ingressInformer, client, serviceInformer, endpointInformer, podInformer, nodeInformer, c, reg)
+    
+    metric.ServeMetrics(opts.MetricsPort, mux)
+    // we use the Lease lock type since edits to Leases are less common
+    // and fewer objects in the cluster watch "all Leases".
+    lock := &resourcelock.LeaseLock{
+        LeaseMeta: metav1.ObjectMeta{
+            Name:      opts.LeaseLockName,
+            Namespace: opts.LeaseLockNamespace,
+        },
+        Client: client.CoordinationV1(),
+        LockConfig: resourcelock.ResourceLockConfig{
+            Identity: opts.LeaseID,
+        },
+    }
+    
+    // start the leader election code loop
+    leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+        Lock: lock,
+        // IMPORTANT: you MUST ensure that any code you have that
+        // is protected by the lease must terminate **before**
+        // you call cancel. Otherwise, you could have a background
+        // loop still running and another process could
+        // get elected before your background loop finished, violating
+        // the stated goal of the lease.
+        ReleaseOnCancel: true,
+        LeaseDuration:   60 * time.Second,
+        RenewDeadline:   15 * time.Second,
+        RetryPeriod:     5 * time.Second,
+        Callbacks: leaderelection.LeaderCallbacks{
+            OnStartedLeading: func(ctx context.Context) {
+                // we're notified when we start - this is where you would
+                // usually put your code
+                run(ctx)
+            },
+            OnStoppedLeading: func() {
+                klog.Infof("leader lost: %s", opts.LeaseID)
+                os.Exit(0)
+            },
+            OnNewLeader: func(identity string) {
+                // we're notified when new leader elected
+                if identity == opts.LeaseID {
+                    // I just got the lock
+                    return
+                }
+                klog.Infof("new leader elected: %s", identity)
+            },
+        },
+    })
+}
 
-	klog.InitFlags(nil)
-
-	var opts types.IngressOpts
-
-	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
-	flag.StringVar(&opts.LeaseID, "id", uuid.New().String(), "the holder identity name")
-	flag.StringVar(&opts.LeaseLockName, "lease-lock-name", "", "the lease lock resource name")
-	flag.StringVar(&opts.LeaseLockNamespace, "lease-lock-namespace", "", "the lease lock resource namespace")
-
-	flag.StringVar(&opts.CompartmentId, "compartment-id", "", "the default compartment for oci resource creation")
-	flag.StringVar(&opts.SubnetId, "subnet-id", "", "the default subnet for load balancers")
-	flag.StringVar(&opts.ControllerClass, "controller-class", "oci.oraclecloud.com/native-ingress-controller", "the controller class name")
-	flag.StringVar(&opts.AuthType, "authType", "instance", "The auth type to be used - supported values : user, instance(Default).")
-	flag.StringVar(&opts.AuthSecretName, "auth-secret-name", "", "Secret name used for auth, cannot be empty if authType is user principal")
-	flag.StringVar(&opts.MetricsBackend, "metrics-backend", "prometheus", "Backend used for metrics")
-	flag.IntVar(&opts.MetricsPort, "metrics-port", 2223, "Metrics port for metrics backend")
-	flag.StringVar(&opts.CniType, "cniType", "OCI_VCN_IP_NATIVE", "the default CNI for the cluster")
-	flag.Parse()
-
-	if opts.LeaseLockName == "" {
-		klog.Fatal("unable to get lease lock resource name (missing lease-lock-name flag).")
-	}
-	if opts.LeaseLockNamespace == "" {
-		klog.Fatal("unable to get lease lock resource namespace (missing lease-lock-namespace flag).")
-	}
-
-	if opts.CompartmentId == "" {
-		klog.Fatal("unable to get compartment id (missing compartment-id flag).")
-	}
-
-	if opts.SubnetId == "" {
-		klog.Fatal("unable to get subnet id (missing subnet-id flag).")
-	}
-
-	if opts.AuthType == "user" {
-		if opts.AuthSecretName == "" {
-			klog.Fatal("unable to get secret name (missing secret-name flag) since authType is user.")
-		}
-	}
-
-	// leader election uses the Kubernetes API by writing to a
-	// lock object, which can be a LeaseLock object (preferred),
-	// a ConfigMap, or an Endpoints (deprecated) object.
-	// Conflicting writes are detected and each client handles those actions
-	// independently.
-	config, err := server.BuildConfig(opts.KubeConfig)
-	if err != nil {
-		klog.Fatal(err)
-	}
-	client := clientset.NewForConfigOrDie(config)
-
-	// Register our CRD with the default scheme to be understood by clients.
-	v1beta1.AddToScheme(scheme.Scheme)
-
-	c, err := ctrcache.New(config, ctrcache.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		klog.Fatalf("failed to construct cache for crds: %w", err)
-	}
-	// use a Go context so we can tell the leaderelection code when we
-	// want to step down
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	classParamInformer, err := c.GetInformer(ctx, &v1beta1.IngressClassParameters{})
-	if err != nil {
-		klog.Fatalf("failed to construct informer for class params: %w", err)
-	}
-
-	go func() {
-		klog.Info("starting controller runtime informers")
-		err = c.Start(ctx)
-		if err != nil {
-			klog.Fatalf("failed to start informers for class params: %w", err)
-		}
-	}()
-
-	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Minute)
-
-	// listen for interrupts or the Linux SIGTERM signal and cancel
-	// our context, which the leader election code will observe and
-	// step down
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-ch
-		klog.Info("Received termination, signaling shutdown")
-		cancel()
-	}()
-
-	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
-	go ingressClassInformer.Informer().Run(ctx.Done())
-
-	ingressInformer := informerFactory.Networking().V1().Ingresses()
-	go ingressInformer.Informer().Run(ctx.Done())
-
-	serviceInformer := informerFactory.Core().V1().Services()
-	go serviceInformer.Informer().Run(ctx.Done())
-
-	endpointInformer := informerFactory.Core().V1().Endpoints()
-	go endpointInformer.Informer().Run(ctx.Done())
-
-	podInformer := informerFactory.Core().V1().Pods()
-	go podInformer.Informer().Run(ctx.Done())
-
-	nodeInformer := informerFactory.Core().V1().Nodes()
-	go nodeInformer.Informer().Run(ctx.Done())
-
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	klog.Info("waiting on caches to sync")
-
-	// wait for the initial synchronization of the local cache.
-	if !cache.WaitForCacheSync(ctx.Done(),
-		ingressClassInformer.Informer().HasSynced,
-		ingressInformer.Informer().HasSynced,
-		serviceInformer.Informer().HasSynced,
-		endpointInformer.Informer().HasSynced,
-		podInformer.Informer().HasSynced,
-		classParamInformer.HasSynced,
-		nodeInformer.Informer().HasSynced) {
-
-		klog.Fatal("failed to sync informers")
-	}
-
-	server.SetupWebhookServer(ingressInformer, serviceInformer, client, ctx)
-	mux := http.NewServeMux()
-	reg, err := server.SetupMetricsServer(opts.MetricsBackend, opts.MetricsPort, mux, ctx)
-
-	run := server.SetUpControllers(opts, ingressClassInformer, ingressInformer, client, serviceInformer, endpointInformer, podInformer, nodeInformer, c, reg)
-
-	metric.ServeMetrics(opts.MetricsPort, mux)
-	// we use the Lease lock type since edits to Leases are less common
-	// and fewer objects in the cluster watch "all Leases".
-	lock := &resourcelock.LeaseLock{
-		LeaseMeta: metav1.ObjectMeta{
-			Name:      opts.LeaseLockName,
-			Namespace: opts.LeaseLockNamespace,
-		},
-		Client: client.CoordinationV1(),
-		LockConfig: resourcelock.ResourceLockConfig{
-			Identity: opts.LeaseID,
-		},
-	}
-
-	// start the leader election code loop
-	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-		Lock: lock,
-		// IMPORTANT: you MUST ensure that any code you have that
-		// is protected by the lease must terminate **before**
-		// you call cancel. Otherwise, you could have a background
-		// loop still running and another process could
-		// get elected before your background loop finished, violating
-		// the stated goal of the lease.
-		ReleaseOnCancel: true,
-		LeaseDuration:   60 * time.Second,
-		RenewDeadline:   15 * time.Second,
-		RetryPeriod:     5 * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				// we're notified when we start - this is where you would
-				// usually put your code
-				run(ctx)
-			},
-			OnStoppedLeading: func() {
-				klog.Infof("leader lost: %s", opts.LeaseID)
-				os.Exit(0)
-			},
-			OnNewLeader: func(identity string) {
-				// we're notified when new leader elected
-				if identity == opts.LeaseID {
-					// I just got the lock
-					return
-				}
-				klog.Infof("new leader elected: %s", identity)
-			},
-		},
-	})
+func setupInformers(informerFactory informers.SharedInformerFactory, ctx context.Context, classParamInformer ctrcache.Informer) (networkinginformers.IngressClassInformer, networkinginformers.IngressInformer, v1.ServiceInformer, v1.EndpointsInformer, v1.PodInformer, v1.NodeInformer) {
+    ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
+    go ingressClassInformer.Informer().Run(ctx.Done())
+    
+    ingressInformer := informerFactory.Networking().V1().Ingresses()
+    go ingressInformer.Informer().Run(ctx.Done())
+    
+    serviceInformer := informerFactory.Core().V1().Services()
+    go serviceInformer.Informer().Run(ctx.Done())
+    
+    endpointInformer := informerFactory.Core().V1().Endpoints()
+    go endpointInformer.Informer().Run(ctx.Done())
+    
+    podInformer := informerFactory.Core().V1().Pods()
+    go podInformer.Informer().Run(ctx.Done())
+    
+    nodeInformer := informerFactory.Core().V1().Nodes()
+    go nodeInformer.Informer().Run(ctx.Done())
+    
+    informerFactory.Start(ctx.Done())
+    informerFactory.WaitForCacheSync(ctx.Done())
+    klog.Info("waiting on caches to sync")
+    
+    // wait for the initial synchronization of the local cache.
+    if !cache.WaitForCacheSync(ctx.Done(),
+        ingressClassInformer.Informer().HasSynced,
+        ingressInformer.Informer().HasSynced,
+        serviceInformer.Informer().HasSynced,
+        endpointInformer.Informer().HasSynced,
+        podInformer.Informer().HasSynced,
+        classParamInformer.HasSynced,
+        nodeInformer.Informer().HasSynced) {
+        
+        klog.Fatal("failed to sync informers")
+    }
+    return ingressClassInformer, ingressInformer, serviceInformer, endpointInformer, podInformer, nodeInformer
 }

--- a/pkg/auth/auth_service_test.go
+++ b/pkg/auth/auth_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/types"
-	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -24,7 +24,7 @@ func setUp(secret *v1.Secret, setClient bool) *fakeclientset.Clientset {
 		action := "get"
 		resource := "secrets"
 		obj := secret
-		util.FakeClientGetCall(client, action, resource, obj)
+		testutil.FakeClientGetCall(client, action, resource, obj)
 	}
 	return client
 }
@@ -38,7 +38,7 @@ func TestGetConfigurationProviderSuccess(t *testing.T) {
 	}
 	configName := "config"
 	privateKey := "private-key"
-	secret := util.GetSampleSecret(configName, privateKey, data, PrivateKey)
+	secret := testutil.GetSampleSecret(configName, privateKey, data, PrivateKey)
 	client := setUp(secret, true)
 
 	auth, err := GetConfigurationProvider(ctx, opts, client)
@@ -53,7 +53,7 @@ func TestGetConfigurationProviderFailSecret(t *testing.T) {
 		AuthType:       "user",
 		AuthSecretName: "oci-config",
 	}
-	secret := util.GetSampleSecret("test", "error", data, PrivateKey)
+	secret := testutil.GetSampleSecret("test", "error", data, PrivateKey)
 
 	client := setUp(secret, false)
 	auth, err := GetConfigurationProvider(ctx, opts, client)
@@ -67,14 +67,14 @@ func TestGetConfigurationProviderFailSecret(t *testing.T) {
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("auth config data is empty: oci-config"))
 
-	secret = util.GetSampleSecret("config", "error", data, PrivateKey)
+	secret = testutil.GetSampleSecret("config", "error", data, PrivateKey)
 	client = setUp(secret, true)
 	auth, err = GetConfigurationProvider(ctx, opts, client)
 	Expect(auth == nil).Should(BeTrue())
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("missing auth config data: invalid user auth config data: oci-config"))
 
-	secret = util.GetSampleSecret("configs", "error", data, PrivateKey)
+	secret = testutil.GetSampleSecret("configs", "error", data, PrivateKey)
 	client = setUp(secret, true)
 	auth, err = GetConfigurationProvider(ctx, opts, client)
 	Expect(auth == nil).Should(BeTrue())
@@ -108,7 +108,7 @@ func TestParseAuthConfig(t *testing.T) {
 	RegisterTestingT(t)
 	configName := "config"
 	privateKey := "private-key"
-	secret := util.GetSampleSecret(configName, privateKey, data, PrivateKey)
+	secret := testutil.GetSampleSecret(configName, privateKey, data, PrivateKey)
 	authCfg, err := ParseAuthConfig(secret, "oci-config")
 	Expect(err == nil).Should(BeTrue())
 	Expect(authCfg.TenancyID).Should(Equal("ocid1.tenancy.oc1..aaaaaaaa_example"))
@@ -121,12 +121,12 @@ func TestParseAuthConfig(t *testing.T) {
 
 func TestParseAuthConfigWithError(t *testing.T) {
 	RegisterTestingT(t)
-	secret := util.GetSampleSecret("error", "", data, PrivateKey)
+	secret := testutil.GetSampleSecret("error", "", data, PrivateKey)
 	_, err := ParseAuthConfig(secret, "oci-configs")
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("invalid auth config data: oci-configs"))
 
-	secret = util.GetSampleSecret("config", "", data, PrivateKey)
+	secret = testutil.GetSampleSecret("config", "", data, PrivateKey)
 	_, err = ParseAuthConfig(secret, "oci-configs")
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("invalid user auth config data: oci-configs"))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/oracle/oci-go-sdk/v65/containerengine"
 	"github.com/oracle/oci-native-ingress-controller/pkg/certificate"
 	"github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/waf"
@@ -8,14 +9,15 @@ import (
 )
 
 type ClientProvider struct {
-	kubernetesClient   kubernetes.Interface
-	wafClient          *waf.Client
-	lbClient           *loadbalancer.LoadBalancerClient
-	certificatesClient *certificate.CertificatesClient
+	kubernetesClient      kubernetes.Interface
+	wafClient             *waf.Client
+	lbClient              *loadbalancer.LoadBalancerClient
+	certificatesClient    *certificate.CertificatesClient
+	containerEngineClient *containerengine.ContainerEngineClient
 }
 
-func NewWrapperClient(kubernetesClient kubernetes.Interface, wafClient *waf.Client, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient) *ClientProvider {
-	return &ClientProvider{kubernetesClient: kubernetesClient, wafClient: wafClient, lbClient: lbClient, certificatesClient: certificatesClient}
+func NewWrapperClient(kubernetesClient kubernetes.Interface, wafClient *waf.Client, lbClient *loadbalancer.LoadBalancerClient, certificatesClient *certificate.CertificatesClient, containerEngineClient *containerengine.ContainerEngineClient) *ClientProvider {
+	return &ClientProvider{kubernetesClient: kubernetesClient, wafClient: wafClient, lbClient: lbClient, certificatesClient: certificatesClient, containerEngineClient: containerEngineClient}
 }
 
 func (c ClientProvider) GetK8Client() kubernetes.Interface {
@@ -32,4 +34,8 @@ func (c ClientProvider) GetLbClient() *loadbalancer.LoadBalancerClient {
 
 func (c ClientProvider) GetCertClient() *certificate.CertificatesClient {
 	return c.certificatesClient
+}
+
+func (c ClientProvider) GetContainerEngineClient() *containerengine.ContainerEngineClient {
+	return c.containerEngineClient
 }

--- a/pkg/controllers/ingress/util_test.go
+++ b/pkg/controllers/ingress/util_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/state"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -122,11 +123,11 @@ const (
 
 func initsUtil() (*client.ClientProvider, ociloadbalancer.LoadBalancer) {
 	k8client := fakeclientset.NewSimpleClientset()
-	secret := util.GetSampleCertSecret()
+	secret := testutil.GetSampleCertSecret()
 	action := "get"
 	resource := "secrets"
 	obj := secret
-	util.FakeClientGetCall(k8client, action, resource, obj)
+	testutil.FakeClientGetCall(k8client, action, resource, obj)
 
 	certClient := GetCertClient()
 	certManageClient := GetCertManageClient()
@@ -187,7 +188,7 @@ func initsUtil() (*client.ClientProvider, ociloadbalancer.LoadBalancer) {
 		RuleSets:                nil,
 		RoutingPolicies:         nil,
 	}
-	client := client.NewWrapperClient(k8client, nil, nil, certificatesClient)
+	client := client.NewWrapperClient(k8client, nil, nil, certificatesClient, nil)
 	return client, lb
 }
 

--- a/pkg/controllers/ingressclass/ingressclass_test.go
+++ b/pkg/controllers/ingressclass/ingressclass_test.go
@@ -106,7 +106,7 @@ func TestSetupWebApplicationFirewall_WithPolicySet(t *testing.T) {
 	defer cancel()
 	id := "id"
 	compartmentId := "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
-	annotations := map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: "ocid1.webappfirewallpolicy.oc1.phx.amaaaaaah4gjgpya3siqywzdmre3mv4op3rzpo"}
+	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: "ocid1.webappfirewallpolicy.oc1.phx.amaaaaaah4gjgpya3siqywzdmre3mv4op3rzpo"}
 	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	c := inits(ctx, ingressClassList)
 	err := c.setupWebApplicationFirewall(&ingressClassList.Items[0], &compartmentId, &id)
@@ -159,7 +159,7 @@ func TestDeleteFinalizer(t *testing.T) {
 	ingressClass := &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "name",
-			Annotations: map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint("isDefault")},
+			Annotations: map[string]string{util.IngressClassIsDefault: fmt.Sprint("isDefault")},
 			Finalizers:  finalizers,
 		},
 		Spec: networkingv1.IngressClassSpec{

--- a/pkg/controllers/ingressclass/ingressclass_test.go
+++ b/pkg/controllers/ingressclass/ingressclass_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 
 	"github.com/oracle/oci-go-sdk/v65/waf"
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
@@ -32,7 +33,7 @@ import (
 func TestEnsureLoadBalancer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -43,7 +44,7 @@ func TestEnsureLoadBalancerWithLbIdSet(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := util.GetIngressClassListWithLBSet("id")
+	ingressClassList := testutil.GetIngressClassListWithLBSet("id")
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -54,7 +55,7 @@ func TestEnsureLoadBalancerWithNotFound(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := util.GetIngressClassListWithLBSet("notfound")
+	ingressClassList := testutil.GetIngressClassListWithLBSet("notfound")
 	c := inits(ctx, ingressClassList)
 
 	ic := &ingressClassList.Items[0]
@@ -67,7 +68,7 @@ func TestEnsureLoadBalancerWithNetworkError(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := util.GetIngressClassListWithLBSet("networkerror")
+	ingressClassList := testutil.GetIngressClassListWithLBSet("networkerror")
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -79,7 +80,7 @@ func TestIngressClassAdd(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassAdd(&ingressClassList.Items[0])
@@ -90,7 +91,7 @@ func TestIngressUpdate(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassUpdate(&ingressClassList.Items[0], &ingressClassList.Items[0])
@@ -100,7 +101,7 @@ func TestIngressClassDelete(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassDelete(&ingressClassList.Items[0])
@@ -111,7 +112,7 @@ func TestDeleteIngressClass(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.deleteIngressClass(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -121,7 +122,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.deleteLoadBalancer(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -131,7 +132,7 @@ func TestEnsureFinalizer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.ensureFinalizer(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -144,7 +145,7 @@ func TestSetupWebApplicationFirewall_WithPolicySet(t *testing.T) {
 	id := "id"
 	compartmentId := "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: "ocid1.webappfirewallpolicy.oc1.phx.amaaaaaah4gjgpya3siqywzdmre3mv4op3rzpo"}
-	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList := testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	c := inits(ctx, ingressClassList)
 	err := c.setupWebApplicationFirewall(&ingressClassList.Items[0], &compartmentId, &id)
 	Expect(err).Should(BeNil())
@@ -157,7 +158,7 @@ func TestSetupWebApplicationFirewall_NoPolicySet(t *testing.T) {
 	id := "id"
 	compartmentId := "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.setupWebApplicationFirewall(&ingressClassList.Items[0], &compartmentId, &id)
 	Expect(err).Should(BeNil())
@@ -167,7 +168,7 @@ func TestCheckForIngressClassParameterUpdates(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	loadBalancer, _, _ := c.client.GetLbClient().GetLoadBalancer(context.TODO(), "id")
 	icp := v1beta1.IngressClassParameters{
@@ -188,7 +189,7 @@ func TestDeleteFinalizer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	var finalizers []string
 	finalizer := "oci.oraclecloud.com/ingress-controller-protection"
@@ -227,7 +228,7 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList)
 	}
 
 	ingressClassInformer, k8client := setUp(ctx, ingressClassList)
-	client := client.NewWrapperClient(k8client, firewallClient, loadBalancerClient, nil)
+	client := client.NewWrapperClient(k8client, firewallClient, loadBalancerClient, nil, nil)
 	c := NewController("", "", "oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, client, nil)
 	return c
 }
@@ -235,8 +236,8 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList)
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList) (networkinginformers.IngressClassInformer, *fakeclientset.Clientset) {
 	client := fakeclientset.NewSimpleClientset()
 
-	util.UpdateFakeClientCall(client, "list", "ingressclasses", ingressClassList)
-	util.UpdateFakeClientCall(client, "patch", "ingressclasses", &ingressClassList.Items[0])
+	testutil.UpdateFakeClientCall(client, "list", "ingressclasses", ingressClassList)
+	testutil.UpdateFakeClientCall(client, "patch", "ingressclasses", &ingressClassList.Items[0])
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -289,7 +290,7 @@ func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request oci
 		return ociloadbalancer.GetLoadBalancerResponse{}, &exception.NotFoundServiceError{}
 	}
 
-	res := util.SampleLoadBalancerResponse()
+	res := testutil.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/controllers/nodeBackend/ingressPath.yaml
+++ b/pkg/controllers/nodeBackend/ingressPath.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+  namespace: default
+spec:
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho1"
+            backend:
+              service:
+                name: testecho1
+                port:
+                  number: 80

--- a/pkg/controllers/nodeBackend/ingressWithDefault.yaml
+++ b/pkg/controllers/nodeBackend/ingressWithDefault.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+  namespace: default
+spec:
+  defaultBackend:
+    service:
+      name: host-es
+      port:
+        number: 8080
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho1"
+            backend:
+              service:
+                name: testecho1
+                port:
+                  number: 80

--- a/pkg/controllers/nodeBackend/nodeportService.yaml
+++ b/pkg/controllers/nodeBackend/nodeportService.yaml
@@ -1,3 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-es
+  labels:
+    app: host-es
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: host-es
+  template:
+    metadata:
+      labels:
+        app: host-es
+    spec:
+      containers:
+        - name: host-es
+          image: iad.ocir.io/odx-mockcustomer/nirpai/testservice:0.4
+          args:
+            - --response-text=host-es
+            - --port=8082
+          ports:
+            - containerPort: 8082
+      imagePullSecrets:
+        - name: ocirsecret
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: host-es
+spec:
+  selector:
+    app: host-es
+  ports:
+    - protocol: TCP
+      port: 82
+      targetPort: 8082
+  type: NodePort
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,7 +49,7 @@ metadata:
   labels:
     app: testecho1
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: testecho1
@@ -33,15 +77,61 @@ spec:
       port: 80
       targetPort: 8080
   type: NodePort
+  externalTrafficPolicy: Local
 
 ---
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testecho2
+  labels:
+    app: testecho2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: testecho2
+  template:
+    metadata:
+      labels:
+        app: testecho2
+    spec:
+      containers:
+        - name: testecho1
+          image: registry.k8s.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testecho2
+spec:
+  selector:
+    app: testecho2
+  ports:
+    - protocol: TCP
+      port: 81
+      targetPort: 8080
+  type: NodePort
+
+---
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-readiness
+  name: ingress-flannel
 spec:
+  defaultBackend:
+    service:
+      name: host-es
+      port:
+        number: 8082
   rules:
-    - host: "foo.bar.com"
+    - host: "foo1.bar.com"
       http:
         paths:
           - pathType: Exact
@@ -51,3 +141,13 @@ spec:
                 name: testecho1
                 port:
                   number: 80
+    - host: "foo2.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho2"
+            backend:
+              service:
+                name: testecho2
+                port:
+                  number: 81

--- a/pkg/controllers/nodeBackend/nodeportService.yaml
+++ b/pkg/controllers/nodeBackend/nodeportService.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testecho1
+  labels:
+    app: testecho1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testecho1
+  template:
+    metadata:
+      labels:
+        app: testecho1
+    spec:
+      containers:
+        - name: testecho1
+          image: registry.k8s.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testecho1
+spec:
+  selector:
+    app: testecho1
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: NodePort
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+spec:
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho1"
+            backend:
+              service:
+                name: testecho1
+                port:
+                  number: 80

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -144,7 +144,7 @@ func (c *Controller) ensureRoutingRules(ingressClass *networkingv1.IngressClass)
 		if util.IsIngressDeleting(ingress) {
 			continue
 		}
-		if ingress.Spec.IngressClassName == nil && ingressClass.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+		if ingress.Spec.IngressClassName == nil && ingressClass.Annotations[util.IngressClassIsDefault] == "true" {
 			// ingress has on class name defined and our ingress class is default
 			ingresses = append(ingresses, ingress)
 		}

--- a/pkg/controllers/routingpolicy/routingpolicy_test.go
+++ b/pkg/controllers/routingpolicy/routingpolicy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
-	"github.com/oracle/oci-native-ingress-controller/pkg/util"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ func TestEnsureRoutingRules(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	err := c.ensureRoutingRules(&ingressClassList.Items[0])
@@ -38,7 +38,7 @@ func TestProcessRoutingPolicy(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	listenerPaths := map[string][]*listenerPath{}
@@ -133,7 +133,7 @@ func TestRunPusher(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	c.runPusher()
@@ -142,8 +142,8 @@ func TestRunPusher(t *testing.T) {
 
 func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList, yamlPath string) *Controller {
 
-	ingressList := util.ReadResourceAsIngressList(yamlPath)
-	testService := util.GetServiceListResource("test", "testecho1", 80)
+	ingressList := testutil.ReadResourceAsIngressList(yamlPath)
+	testService := testutil.GetServiceListResource("test", "testecho1", 80)
 	lbClient := getLoadBalancerClient()
 
 	loadBalancerClient := &lb.LoadBalancerClient{
@@ -153,7 +153,7 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	}
 
 	ingressClassInformer, ingressInformer, serviceLister, k8client := setUp(ctx, ingressClassList, ingressList, testService)
-	client := client.NewWrapperClient(k8client, nil, loadBalancerClient, nil)
+	client := client.NewWrapperClient(k8client, nil, loadBalancerClient, nil, nil)
 	c := NewController("oci.oraclecloud.com/native-ingress-controller",
 		ingressClassInformer, ingressInformer, serviceLister, client)
 	return c
@@ -163,9 +163,9 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 
 	action := "list"
-	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	util.UpdateFakeClientCall(client, action, "services", testService)
+	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	testutil.UpdateFakeClientCall(client, action, "services", testService)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -192,7 +192,7 @@ type MockLoadBalancerClient struct {
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := util.SampleLoadBalancerResponse()
+	res := testutil.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -212,7 +213,7 @@ func (m MockLoadBalancerClient) UpdateLoadBalancerShape(ctx context.Context, req
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := util.SampleLoadBalancerResponse()
+	res := testutil.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/podreadiness/webhook_test.go
+++ b/pkg/podreadiness/webhook_test.go
@@ -16,10 +16,10 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 
 	cl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,8 +80,8 @@ func TestHandle(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressList := util.ReadResourceAsIngressList(podReadinessPath)
-	testService := util.GetServiceListResource("default", "testecho1", 80)
+	ingressList := testutil.ReadResourceAsIngressList(podReadinessPath)
+	testService := testutil.GetServiceListResource("default", "testecho1", 80)
 	ingressLister, serviceLister, client := setUp(ctx, ingressList, testService)
 	wb := NewWebhook(ingressLister, serviceLister, client)
 
@@ -175,7 +175,7 @@ func TestHandle(t *testing.T) {
 							Image: "echoserver",
 						},
 					},
-					ReadinessGates: util.GetPodReadinessGates("ingress-readiness", "foo.bar.com"),
+					ReadinessGates: testutil.GetPodReadinessGates("ingress-readiness", "foo.bar.com"),
 				},
 			},
 			op:            admissionv1.Create,

--- a/pkg/state/ingressstate.go
+++ b/pkg/state/ingressstate.go
@@ -11,6 +11,8 @@ package state
 
 import (
 	"fmt"
+	"reflect"
+
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
@@ -21,7 +23,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/klog/v2"
-	"reflect"
 )
 
 const (
@@ -93,7 +94,7 @@ func (s *StateStore) BuildState(ingressClass *networkingv1.IngressClass) error {
 		if err != nil {
 			return errors.Wrap(err, "error getting ingress class")
 		}
-		if ingressClass.Name == ingIc.Name && !util.IsIngressDeleting(ing) {
+		if ingIc != nil && ingressClass.Name == ingIc.Name && !util.IsIngressDeleting(ing) {
 			ingressGroup = append(ingressGroup, ing)
 		}
 	}

--- a/pkg/state/ingressstate_test.go
+++ b/pkg/state/ingressstate_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -39,9 +40,9 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 
 	action := "list"
-	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	util.UpdateFakeClientCall(client, action, "services", testService)
+	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	testutil.UpdateFakeClientCall(client, action, "services", testService)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -65,10 +66,10 @@ func TestListenerWithDifferentSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -82,15 +83,15 @@ func TestListenerWithSameSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	secretName := "same_secret_name"
 	ingressList.Items[0].Spec.TLS[0].SecretName = secretName
 	ingressList.Items[1].Spec.TLS[0].SecretName = secretName
 
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -114,14 +115,14 @@ func TestListenerWithSecretAndCertificate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "certificateId"}
 
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -136,16 +137,16 @@ func TestListenerWithDifferentCertificates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	ingressList.Items[0].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[0].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "certificateId"}
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "differentCertificateId"}
 
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -159,9 +160,9 @@ func TestListenerWithSameCertificate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	certificateId := "certificateId"
 	ingressList.Items[0].Spec.TLS = []networkingv1.IngressTLS{}
@@ -170,7 +171,7 @@ func TestListenerWithSameCertificate(t *testing.T) {
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: certificateId}
 
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -192,11 +193,11 @@ func TestIngressState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TestIngressStateFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateFilePath)
 
-	testService := util.GetServiceListResource("default", "tls-test", 943)
+	testService := testutil.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -211,11 +212,11 @@ func TestIngressStateWithPortName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(TestIngressStateWithPortNameFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateWithPortNameFilePath)
 
-	testService := util.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
+	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -262,11 +263,11 @@ func TestValidateHealthCheckerConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
 
-	testService := util.GetServiceListResource("default", "test-health-checker-annotation", 800)
+	testService := testutil.GetServiceListResource("default", "test-health-checker-annotation", 800)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -298,13 +299,13 @@ func TestValidateHealthCheckerConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressHealthCheckPortAnnotation] = "9090"
 
-	testService := util.GetServiceListResource("default", "test-health-checker-annotation", 800)
+	testService := testutil.GetServiceListResource("default", "test-health-checker-annotation", 800)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -319,11 +320,11 @@ func TestValidatePolicyConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
 
-	testService := util.GetServiceListResource("default", "test-policy-annotation", 900)
+	testService := testutil.GetServiceListResource("default", "test-policy-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -342,13 +343,13 @@ func TestValidatePolicyConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressPolicyAnnotation] = "LEAST_CONNECTIONS"
 
-	testService := util.GetServiceListResource("default", "test-policy-annotation", 900)
+	testService := testutil.GetServiceListResource("default", "test-policy-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -363,11 +364,11 @@ func TestValidateProtocolConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
 
-	testService := util.GetServiceListResource("default", "test-protocol-annotation", 900)
+	testService := testutil.GetServiceListResource("default", "test-protocol-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -382,13 +383,13 @@ func TestValidateProtocolConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := util.GetIngressClassList()
+	ingressClassList := testutil.GetIngressClassList()
 
-	ingressList := util.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
+	ingressList := testutil.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressProtocolAnnotation] = "HTTP"
 
-	testService := util.GetServiceListResource("default", "test-protocol-annotation", 900)
+	testService := testutil.GetServiceListResource("default", "test-protocol-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -30,12 +30,12 @@ type IngressOpts struct {
 	LeaseID            string
 	CompartmentId      string
 	SubnetId           string
+	ClusterId          string
 	ControllerClass    string
 	AuthType           string
 	AuthSecretName     string
 	MetricsBackend     string
 	MetricsPort        int
-	CniType            string
 }
 
 func MapToPrincipalType(authType string) (OCIPrincipalType, error) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,7 @@ type IngressOpts struct {
 	AuthSecretName     string
 	MetricsBackend     string
 	MetricsPort        int
+	CniType            string
 }
 
 func MapToPrincipalType(authType string) (OCIPrincipalType, error) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -540,7 +540,7 @@ func getIngressClassResource(name string, isDefault bool, controller string) *ne
 	return &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint(isDefault)},
+			Annotations: map[string]string{IngressClassIsDefault: fmt.Sprint(isDefault)},
 		},
 		Spec: networkingv1.IngressClassSpec{
 			Controller: controller,

--- a/pkg/waf/waf_test.go
+++ b/pkg/waf/waf_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	networkingv1 "k8s.io/api/networking/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -29,10 +30,10 @@ func setupClient() (*fakeclientset.Clientset, *Client, *networkingv1.IngressClas
 
 	k8client := fakeclientset.NewSimpleClientset()
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId}
-	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList := testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 
-	util.UpdateFakeClientCall(k8client, "list", "ingressclasses", ingressClassList)
-	util.UpdateFakeClientCall(k8client, "patch", "ingressclasses", &ingressClassList.Items[0])
+	testutil.UpdateFakeClientCall(k8client, "list", "ingressclasses", ingressClassList)
+	testutil.UpdateFakeClientCall(k8client, "patch", "ingressclasses", &ingressClassList.Items[0])
 
 	return k8client, wafClient, ingressClassList
 }
@@ -48,16 +49,16 @@ func TestClient_GetFireWallId(t *testing.T) {
 
 	// PolicyId and FireWall Set
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId, util.IngressClassFireWallIdAnnotation: "SetFirewall"}
-	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList = testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// Only FireWall Set
 	annotations = map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassFireWallIdAnnotation: "SetFirewall"}
-	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList = testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// None Set
-	ingressClassList = util.GetIngressClassList()
+	ingressClassList = testutil.GetIngressClassList()
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 }

--- a/pkg/waf/waf_test.go
+++ b/pkg/waf/waf_test.go
@@ -28,7 +28,7 @@ func setupClient() (*fakeclientset.Clientset, *Client, *networkingv1.IngressClas
 	}
 
 	k8client := fakeclientset.NewSimpleClientset()
-	annotations := map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId}
+	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId}
 	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 
 	util.UpdateFakeClientCall(k8client, "list", "ingressclasses", ingressClassList)
@@ -47,12 +47,12 @@ func TestClient_GetFireWallId(t *testing.T) {
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// PolicyId and FireWall Set
-	annotations := map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId, util.IngressClassFireWallIdAnnotation: "SetFirewall"}
+	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId, util.IngressClassFireWallIdAnnotation: "SetFirewall"}
 	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// Only FireWall Set
-	annotations = map[string]string{"ingressclass.kubernetes.io/is-default-class": fmt.Sprint(false), util.IngressClassFireWallIdAnnotation: "SetFirewall"}
+	annotations = map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassFireWallIdAnnotation: "SetFirewall"}
 	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/add_on_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/add_on_options.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddOnOptions The properties that define options for supported add-ons.
+type AddOnOptions struct {
+
+	// Whether or not to enable the Kubernetes Dashboard add-on.
+	IsKubernetesDashboardEnabled *bool `mandatory:"false" json:"isKubernetesDashboardEnabled"`
+
+	// Whether or not to enable the Tiller add-on.
+	IsTillerEnabled *bool `mandatory:"false" json:"isTillerEnabled"`
+}
+
+func (m AddOnOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddOnOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Addon The properties that define an addon.
+type Addon struct {
+
+	// The name of the addon.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The state of the addon.
+	LifecycleState AddonLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// selected addon version, or null indicates autoUpdate
+	Version *string `mandatory:"false" json:"version"`
+
+	// current installed version of the addon
+	CurrentInstalledVersion *string `mandatory:"false" json:"currentInstalledVersion"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+
+	// The error info of the addon.
+	AddonError *AddonError `mandatory:"false" json:"addonError"`
+}
+
+func (m Addon) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Addon) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_configuration.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonConfiguration Defines the configuration of available addons for a cluster
+type AddonConfiguration struct {
+
+	// configuration key name
+	Key *string `mandatory:"false" json:"key"`
+
+	// configuration value name
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m AddonConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonError The error info of the addon.
+type AddonError struct {
+
+	// A short error code that defines the upstream error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"false" json:"code"`
+
+	// A human-readable error string of the upstream error.
+	Message *string `mandatory:"false" json:"message"`
+
+	// The status of the HTTP response encountered in the upstream error.
+	Status *string `mandatory:"false" json:"status"`
+}
+
+func (m AddonError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// AddonLifecycleStateEnum Enum with underlying type: string
+type AddonLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AddonLifecycleStateEnum
+const (
+	AddonLifecycleStateCreating       AddonLifecycleStateEnum = "CREATING"
+	AddonLifecycleStateActive         AddonLifecycleStateEnum = "ACTIVE"
+	AddonLifecycleStateDeleting       AddonLifecycleStateEnum = "DELETING"
+	AddonLifecycleStateDeleted        AddonLifecycleStateEnum = "DELETED"
+	AddonLifecycleStateUpdating       AddonLifecycleStateEnum = "UPDATING"
+	AddonLifecycleStateNeedsAttention AddonLifecycleStateEnum = "NEEDS_ATTENTION"
+	AddonLifecycleStateFailed         AddonLifecycleStateEnum = "FAILED"
+)
+
+var mappingAddonLifecycleStateEnum = map[string]AddonLifecycleStateEnum{
+	"CREATING":        AddonLifecycleStateCreating,
+	"ACTIVE":          AddonLifecycleStateActive,
+	"DELETING":        AddonLifecycleStateDeleting,
+	"DELETED":         AddonLifecycleStateDeleted,
+	"UPDATING":        AddonLifecycleStateUpdating,
+	"NEEDS_ATTENTION": AddonLifecycleStateNeedsAttention,
+	"FAILED":          AddonLifecycleStateFailed,
+}
+
+var mappingAddonLifecycleStateEnumLowerCase = map[string]AddonLifecycleStateEnum{
+	"creating":        AddonLifecycleStateCreating,
+	"active":          AddonLifecycleStateActive,
+	"deleting":        AddonLifecycleStateDeleting,
+	"deleted":         AddonLifecycleStateDeleted,
+	"updating":        AddonLifecycleStateUpdating,
+	"needs_attention": AddonLifecycleStateNeedsAttention,
+	"failed":          AddonLifecycleStateFailed,
+}
+
+// GetAddonLifecycleStateEnumValues Enumerates the set of values for AddonLifecycleStateEnum
+func GetAddonLifecycleStateEnumValues() []AddonLifecycleStateEnum {
+	values := make([]AddonLifecycleStateEnum, 0)
+	for _, v := range mappingAddonLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonLifecycleStateEnumStringValues Enumerates the set of values in String for AddonLifecycleStateEnum
+func GetAddonLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"DELETING",
+		"DELETED",
+		"UPDATING",
+		"NEEDS_ATTENTION",
+		"FAILED",
+	}
+}
+
+// GetMappingAddonLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonLifecycleStateEnum(val string) (AddonLifecycleStateEnum, bool) {
+	enum, ok := mappingAddonLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_option_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_option_summary.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonOptionSummary The properties that define addon summary.
+type AddonOptionSummary struct {
+
+	// Name of the addon and it would be unique.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The life cycle state of the addon.
+	LifecycleState AddonOptionSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Is it an essential addon for cluster operation or not.
+	IsEssential *bool `mandatory:"true" json:"isEssential"`
+
+	// The resources this work request affects.
+	Versions []AddonVersions `mandatory:"true" json:"versions"`
+
+	// Addon definition schema version to validate addon.
+	AddonSchemaVersion *string `mandatory:"false" json:"addonSchemaVersion"`
+
+	// Addon group info, a namespace concept that groups addons with similar functionalities.
+	AddonGroup *string `mandatory:"false" json:"addonGroup"`
+
+	// Description on the addon.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The time the work request was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+}
+
+func (m AddonOptionSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonOptionSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonOptionSummaryLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonOptionSummaryLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// AddonOptionSummaryLifecycleStateEnum Enum with underlying type: string
+type AddonOptionSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AddonOptionSummaryLifecycleStateEnum
+const (
+	AddonOptionSummaryLifecycleStateActive   AddonOptionSummaryLifecycleStateEnum = "ACTIVE"
+	AddonOptionSummaryLifecycleStateInactive AddonOptionSummaryLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingAddonOptionSummaryLifecycleStateEnum = map[string]AddonOptionSummaryLifecycleStateEnum{
+	"ACTIVE":   AddonOptionSummaryLifecycleStateActive,
+	"INACTIVE": AddonOptionSummaryLifecycleStateInactive,
+}
+
+var mappingAddonOptionSummaryLifecycleStateEnumLowerCase = map[string]AddonOptionSummaryLifecycleStateEnum{
+	"active":   AddonOptionSummaryLifecycleStateActive,
+	"inactive": AddonOptionSummaryLifecycleStateInactive,
+}
+
+// GetAddonOptionSummaryLifecycleStateEnumValues Enumerates the set of values for AddonOptionSummaryLifecycleStateEnum
+func GetAddonOptionSummaryLifecycleStateEnumValues() []AddonOptionSummaryLifecycleStateEnum {
+	values := make([]AddonOptionSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingAddonOptionSummaryLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonOptionSummaryLifecycleStateEnumStringValues Enumerates the set of values in String for AddonOptionSummaryLifecycleStateEnum
+func GetAddonOptionSummaryLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"INACTIVE",
+	}
+}
+
+// GetMappingAddonOptionSummaryLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonOptionSummaryLifecycleStateEnum(val string) (AddonOptionSummaryLifecycleStateEnum, bool) {
+	enum, ok := mappingAddonOptionSummaryLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_summary.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonSummary The properties that define an addon summary.
+type AddonSummary struct {
+
+	// The name of the addon.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The state of the addon.
+	LifecycleState AddonLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// selected addon version, or null indicates autoUpdate
+	Version *string `mandatory:"false" json:"version"`
+
+	// current installed version of the addon
+	CurrentInstalledVersion *string `mandatory:"false" json:"currentInstalledVersion"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The error info of the addon.
+	AddonError *AddonError `mandatory:"false" json:"addonError"`
+}
+
+func (m AddonSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_version_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_version_configuration.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonVersionConfiguration Addon version configuration details.
+type AddonVersionConfiguration struct {
+
+	// If the the configuration is required or not.
+	IsRequired *bool `mandatory:"false" json:"isRequired"`
+
+	// Addon configuration key
+	Key *string `mandatory:"false" json:"key"`
+
+	// Addon configuration value
+	Value *string `mandatory:"false" json:"value"`
+
+	// Display name of addon version.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Information about the addon version configuration.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+func (m AddonVersionConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonVersionConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_versions.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_versions.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonVersions The properties that define a work request resource.
+type AddonVersions struct {
+
+	// Current state of the addon, only active will be visible to customer, visibility of versions in other status will be filtered  based on limits property.
+	Status AddonVersionsStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// Version number, need be comparable within an addon.
+	VersionNumber *string `mandatory:"false" json:"versionNumber"`
+
+	// Information about the addon version.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The range of kubernetes versions an addon can be configured.
+	KubernetesVersionFilters *KubernetesVersionsFilters `mandatory:"false" json:"kubernetesVersionFilters"`
+
+	// Addon version configuration details.
+	Configurations []AddonVersionConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m AddonVersions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonVersions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingAddonVersionsStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetAddonVersionsStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// AddonVersionsStatusEnum Enum with underlying type: string
+type AddonVersionsStatusEnum string
+
+// Set of constants representing the allowable values for AddonVersionsStatusEnum
+const (
+	AddonVersionsStatusActive     AddonVersionsStatusEnum = "ACTIVE"
+	AddonVersionsStatusDeprecated AddonVersionsStatusEnum = "DEPRECATED"
+	AddonVersionsStatusPreview    AddonVersionsStatusEnum = "PREVIEW"
+	AddonVersionsStatusRecalled   AddonVersionsStatusEnum = "RECALLED"
+)
+
+var mappingAddonVersionsStatusEnum = map[string]AddonVersionsStatusEnum{
+	"ACTIVE":     AddonVersionsStatusActive,
+	"DEPRECATED": AddonVersionsStatusDeprecated,
+	"PREVIEW":    AddonVersionsStatusPreview,
+	"RECALLED":   AddonVersionsStatusRecalled,
+}
+
+var mappingAddonVersionsStatusEnumLowerCase = map[string]AddonVersionsStatusEnum{
+	"active":     AddonVersionsStatusActive,
+	"deprecated": AddonVersionsStatusDeprecated,
+	"preview":    AddonVersionsStatusPreview,
+	"recalled":   AddonVersionsStatusRecalled,
+}
+
+// GetAddonVersionsStatusEnumValues Enumerates the set of values for AddonVersionsStatusEnum
+func GetAddonVersionsStatusEnumValues() []AddonVersionsStatusEnum {
+	values := make([]AddonVersionsStatusEnum, 0)
+	for _, v := range mappingAddonVersionsStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonVersionsStatusEnumStringValues Enumerates the set of values in String for AddonVersionsStatusEnum
+func GetAddonVersionsStatusEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"DEPRECATED",
+		"PREVIEW",
+		"RECALLED",
+	}
+}
+
+// GetMappingAddonVersionsStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonVersionsStatusEnum(val string) (AddonVersionsStatusEnum, bool) {
+	enum, ok := mappingAddonVersionsStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/admission_controller_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/admission_controller_options.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AdmissionControllerOptions The properties that define supported admission controllers.
+type AdmissionControllerOptions struct {
+
+	// Whether or not to enable the Pod Security Policy admission controller.
+	IsPodSecurityPolicyEnabled *bool `mandatory:"false" json:"isPodSecurityPolicyEnabled"`
+}
+
+func (m AdmissionControllerOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AdmissionControllerOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Cluster A Kubernetes cluster. Avoid entering confidential information.
+type Cluster struct {
+
+	// The OCID of the cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the cluster.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The OCID of the compartment in which the cluster exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the virtual cloud network (VCN) in which the cluster exists.
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The version of Kubernetes running on the cluster masters.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// Metadata about the cluster.
+	Metadata *ClusterMetadata `mandatory:"false" json:"metadata"`
+
+	// The state of the cluster masters.
+	LifecycleState ClusterLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the cluster masters.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Endpoints served up by the cluster masters.
+	Endpoints *ClusterEndpoints `mandatory:"false" json:"endpoints"`
+
+	// Available Kubernetes versions to which the clusters masters may be upgraded.
+	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m Cluster) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Cluster) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Cluster) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                          *string                           `json:"id"`
+		Name                        *string                           `json:"name"`
+		CompartmentId               *string                           `json:"compartmentId"`
+		EndpointConfig              *ClusterEndpointConfig            `json:"endpointConfig"`
+		VcnId                       *string                           `json:"vcnId"`
+		KubernetesVersion           *string                           `json:"kubernetesVersion"`
+		KmsKeyId                    *string                           `json:"kmsKeyId"`
+		FreeformTags                map[string]string                 `json:"freeformTags"`
+		DefinedTags                 map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                  map[string]map[string]interface{} `json:"systemTags"`
+		Options                     *ClusterCreateOptions             `json:"options"`
+		Metadata                    *ClusterMetadata                  `json:"metadata"`
+		LifecycleState              ClusterLifecycleStateEnum         `json:"lifecycleState"`
+		LifecycleDetails            *string                           `json:"lifecycleDetails"`
+		Endpoints                   *ClusterEndpoints                 `json:"endpoints"`
+		AvailableKubernetesUpgrades []string                          `json:"availableKubernetesUpgrades"`
+		ImagePolicyConfig           *ImagePolicyConfig                `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions    []clusterpodnetworkoptiondetails  `json:"clusterPodNetworkOptions"`
+		Type                        ClusterTypeEnum                   `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.EndpointConfig = model.EndpointConfig
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Options = model.Options
+
+	m.Metadata = model.Metadata
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.Endpoints = model.Endpoints
+
+	m.AvailableKubernetesUpgrades = make([]string, len(model.AvailableKubernetesUpgrades))
+	for i, n := range model.AvailableKubernetesUpgrades {
+		m.AvailableKubernetesUpgrades[i] = n
+	}
+
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+
+	m.Type = model.Type
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_create_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_create_options.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterCreateOptions The properties that define extra options for a cluster.
+type ClusterCreateOptions struct {
+
+	// The OCIDs of the subnets used for Kubernetes services load balancers.
+	ServiceLbSubnetIds []string `mandatory:"false" json:"serviceLbSubnetIds"`
+
+	// Network configuration for Kubernetes.
+	KubernetesNetworkConfig *KubernetesNetworkConfig `mandatory:"false" json:"kubernetesNetworkConfig"`
+
+	// Configurable cluster add-ons
+	AddOns *AddOnOptions `mandatory:"false" json:"addOns"`
+
+	// Configurable cluster admission controllers
+	AdmissionControllerOptions *AdmissionControllerOptions `mandatory:"false" json:"admissionControllerOptions"`
+
+	PersistentVolumeConfig *PersistentVolumeConfigDetails `mandatory:"false" json:"persistentVolumeConfig"`
+
+	ServiceLbConfig *ServiceLbConfigDetails `mandatory:"false" json:"serviceLbConfig"`
+}
+
+func (m ClusterCreateOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterCreateOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoint_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoint_config.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterEndpointConfig The properties that define the network configuration for the Cluster endpoint.
+type ClusterEndpointConfig struct {
+
+	// The OCID of the regional subnet in which to place the Cluster endpoint.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m ClusterEndpointConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterEndpointConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoints.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoints.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterEndpoints The properties that define endpoints for a cluster.
+type ClusterEndpoints struct {
+
+	// The non-native networking Kubernetes API server endpoint.
+	Kubernetes *string `mandatory:"false" json:"kubernetes"`
+
+	// The public native networking Kubernetes API server endpoint, if one was requested.
+	PublicEndpoint *string `mandatory:"false" json:"publicEndpoint"`
+
+	// The private native networking Kubernetes API server endpoint.
+	PrivateEndpoint *string `mandatory:"false" json:"privateEndpoint"`
+
+	// The FQDN assigned to the Kubernetes API private endpoint.
+	// Example: 'https://yourVcnHostnameEndpoint'
+	VcnHostnameEndpoint *string `mandatory:"false" json:"vcnHostnameEndpoint"`
+}
+
+func (m ClusterEndpoints) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterEndpoints) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_lifecycle_state.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// ClusterLifecycleStateEnum Enum with underlying type: string
+type ClusterLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ClusterLifecycleStateEnum
+const (
+	ClusterLifecycleStateCreating ClusterLifecycleStateEnum = "CREATING"
+	ClusterLifecycleStateActive   ClusterLifecycleStateEnum = "ACTIVE"
+	ClusterLifecycleStateFailed   ClusterLifecycleStateEnum = "FAILED"
+	ClusterLifecycleStateDeleting ClusterLifecycleStateEnum = "DELETING"
+	ClusterLifecycleStateDeleted  ClusterLifecycleStateEnum = "DELETED"
+	ClusterLifecycleStateUpdating ClusterLifecycleStateEnum = "UPDATING"
+)
+
+var mappingClusterLifecycleStateEnum = map[string]ClusterLifecycleStateEnum{
+	"CREATING": ClusterLifecycleStateCreating,
+	"ACTIVE":   ClusterLifecycleStateActive,
+	"FAILED":   ClusterLifecycleStateFailed,
+	"DELETING": ClusterLifecycleStateDeleting,
+	"DELETED":  ClusterLifecycleStateDeleted,
+	"UPDATING": ClusterLifecycleStateUpdating,
+}
+
+var mappingClusterLifecycleStateEnumLowerCase = map[string]ClusterLifecycleStateEnum{
+	"creating": ClusterLifecycleStateCreating,
+	"active":   ClusterLifecycleStateActive,
+	"failed":   ClusterLifecycleStateFailed,
+	"deleting": ClusterLifecycleStateDeleting,
+	"deleted":  ClusterLifecycleStateDeleted,
+	"updating": ClusterLifecycleStateUpdating,
+}
+
+// GetClusterLifecycleStateEnumValues Enumerates the set of values for ClusterLifecycleStateEnum
+func GetClusterLifecycleStateEnumValues() []ClusterLifecycleStateEnum {
+	values := make([]ClusterLifecycleStateEnum, 0)
+	for _, v := range mappingClusterLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterLifecycleStateEnumStringValues Enumerates the set of values in String for ClusterLifecycleStateEnum
+func GetClusterLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"FAILED",
+		"DELETING",
+		"DELETED",
+		"UPDATING",
+	}
+}
+
+// GetMappingClusterLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterLifecycleStateEnum(val string) (ClusterLifecycleStateEnum, bool) {
+	enum, ok := mappingClusterLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_metadata.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_metadata.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMetadata The properties that define meta data for a cluster.
+type ClusterMetadata struct {
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The user who created the cluster.
+	CreatedByUserId *string `mandatory:"false" json:"createdByUserId"`
+
+	// The OCID of the work request which created the cluster.
+	CreatedByWorkRequestId *string `mandatory:"false" json:"createdByWorkRequestId"`
+
+	// The time the cluster was deleted.
+	TimeDeleted *common.SDKTime `mandatory:"false" json:"timeDeleted"`
+
+	// The user who deleted the cluster.
+	DeletedByUserId *string `mandatory:"false" json:"deletedByUserId"`
+
+	// The OCID of the work request which deleted the cluster.
+	DeletedByWorkRequestId *string `mandatory:"false" json:"deletedByWorkRequestId"`
+
+	// The time the cluster was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The user who updated the cluster.
+	UpdatedByUserId *string `mandatory:"false" json:"updatedByUserId"`
+
+	// The OCID of the work request which updated the cluster.
+	UpdatedByWorkRequestId *string `mandatory:"false" json:"updatedByWorkRequestId"`
+}
+
+func (m ClusterMetadata) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMetadata) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnDetails The properties that define a request to migrate a cluster to Native VCN.
+type ClusterMigrateToNativeVcnDetails struct {
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"true" json:"endpointConfig"`
+
+	// The optional override of the non-native endpoint decommission time after migration is complete. Defaults to 30 days.
+	DecommissionDelayDuration *string `mandatory:"false" json:"decommissionDelayDuration"`
+}
+
+func (m ClusterMigrateToNativeVcnDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMigrateToNativeVcnDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnRequest wrapper for the ClusterMigrateToNativeVcn operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ClusterMigrateToNativeVcn.go.html to see an example of how to use ClusterMigrateToNativeVcnRequest.
+type ClusterMigrateToNativeVcnRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details for the cluster's migration to native VCN.
+	ClusterMigrateToNativeVcnDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ClusterMigrateToNativeVcnRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ClusterMigrateToNativeVcnRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ClusterMigrateToNativeVcnRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ClusterMigrateToNativeVcnRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ClusterMigrateToNativeVcnRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterMigrateToNativeVcnResponse wrapper for the ClusterMigrateToNativeVcn operation
+type ClusterMigrateToNativeVcnResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ClusterMigrateToNativeVcnResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ClusterMigrateToNativeVcnResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_status.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnStatus Information regarding a cluster's move to Native VCN.
+type ClusterMigrateToNativeVcnStatus struct {
+
+	// The current migration status of the cluster.
+	State ClusterMigrateToNativeVcnStatusStateEnum `mandatory:"true" json:"state"`
+
+	// The date and time the non-native VCN is due to be decommissioned.
+	TimeDecommissionScheduled *common.SDKTime `mandatory:"false" json:"timeDecommissionScheduled"`
+}
+
+func (m ClusterMigrateToNativeVcnStatus) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMigrateToNativeVcnStatus) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingClusterMigrateToNativeVcnStatusStateEnum(string(m.State)); !ok && m.State != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for State: %s. Supported values are: %s.", m.State, strings.Join(GetClusterMigrateToNativeVcnStatusStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterMigrateToNativeVcnStatusStateEnum Enum with underlying type: string
+type ClusterMigrateToNativeVcnStatusStateEnum string
+
+// Set of constants representing the allowable values for ClusterMigrateToNativeVcnStatusStateEnum
+const (
+	ClusterMigrateToNativeVcnStatusStateNotStarted          ClusterMigrateToNativeVcnStatusStateEnum = "NOT_STARTED"
+	ClusterMigrateToNativeVcnStatusStateRequested           ClusterMigrateToNativeVcnStatusStateEnum = "REQUESTED"
+	ClusterMigrateToNativeVcnStatusStateInProgress          ClusterMigrateToNativeVcnStatusStateEnum = "IN_PROGRESS"
+	ClusterMigrateToNativeVcnStatusStatePendingDecommission ClusterMigrateToNativeVcnStatusStateEnum = "PENDING_DECOMMISSION"
+	ClusterMigrateToNativeVcnStatusStateCompleted           ClusterMigrateToNativeVcnStatusStateEnum = "COMPLETED"
+)
+
+var mappingClusterMigrateToNativeVcnStatusStateEnum = map[string]ClusterMigrateToNativeVcnStatusStateEnum{
+	"NOT_STARTED":          ClusterMigrateToNativeVcnStatusStateNotStarted,
+	"REQUESTED":            ClusterMigrateToNativeVcnStatusStateRequested,
+	"IN_PROGRESS":          ClusterMigrateToNativeVcnStatusStateInProgress,
+	"PENDING_DECOMMISSION": ClusterMigrateToNativeVcnStatusStatePendingDecommission,
+	"COMPLETED":            ClusterMigrateToNativeVcnStatusStateCompleted,
+}
+
+var mappingClusterMigrateToNativeVcnStatusStateEnumLowerCase = map[string]ClusterMigrateToNativeVcnStatusStateEnum{
+	"not_started":          ClusterMigrateToNativeVcnStatusStateNotStarted,
+	"requested":            ClusterMigrateToNativeVcnStatusStateRequested,
+	"in_progress":          ClusterMigrateToNativeVcnStatusStateInProgress,
+	"pending_decommission": ClusterMigrateToNativeVcnStatusStatePendingDecommission,
+	"completed":            ClusterMigrateToNativeVcnStatusStateCompleted,
+}
+
+// GetClusterMigrateToNativeVcnStatusStateEnumValues Enumerates the set of values for ClusterMigrateToNativeVcnStatusStateEnum
+func GetClusterMigrateToNativeVcnStatusStateEnumValues() []ClusterMigrateToNativeVcnStatusStateEnum {
+	values := make([]ClusterMigrateToNativeVcnStatusStateEnum, 0)
+	for _, v := range mappingClusterMigrateToNativeVcnStatusStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterMigrateToNativeVcnStatusStateEnumStringValues Enumerates the set of values in String for ClusterMigrateToNativeVcnStatusStateEnum
+func GetClusterMigrateToNativeVcnStatusStateEnumStringValues() []string {
+	return []string{
+		"NOT_STARTED",
+		"REQUESTED",
+		"IN_PROGRESS",
+		"PENDING_DECOMMISSION",
+		"COMPLETED",
+	}
+}
+
+// GetMappingClusterMigrateToNativeVcnStatusStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterMigrateToNativeVcnStatusStateEnum(val string) (ClusterMigrateToNativeVcnStatusStateEnum, bool) {
+	enum, ok := mappingClusterMigrateToNativeVcnStatusStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_options.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterOptions Options for creating or updating clusters.
+type ClusterOptions struct {
+
+	// Available Kubernetes versions.
+	KubernetesVersions []string `mandatory:"false" json:"kubernetesVersions"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+}
+
+func (m ClusterOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ClusterOptions) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersions       []string                         `json:"kubernetesVersions"`
+		ClusterPodNetworkOptions []clusterpodnetworkoptiondetails `json:"clusterPodNetworkOptions"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersions = make([]string, len(model.KubernetesVersions))
+	for i, n := range model.KubernetesVersions {
+		m.KubernetesVersions[i] = n
+	}
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_pod_network_option_details.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterPodNetworkOptionDetails The CNI type and relevant network details potentially applicable to the node pools of the cluster
+type ClusterPodNetworkOptionDetails interface {
+}
+
+type clusterpodnetworkoptiondetails struct {
+	JsonData []byte
+	CniType  string `json:"cniType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *clusterpodnetworkoptiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerclusterpodnetworkoptiondetails clusterpodnetworkoptiondetails
+	s := struct {
+		Model Unmarshalerclusterpodnetworkoptiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CniType = s.Model.CniType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *clusterpodnetworkoptiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CniType {
+	case "FLANNEL_OVERLAY":
+		mm := FlannelOverlayClusterPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "OCI_VCN_IP_NATIVE":
+		mm := OciVcnIpNativeClusterPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m clusterpodnetworkoptiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m clusterpodnetworkoptiondetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterPodNetworkOptionDetailsCniTypeEnum Enum with underlying type: string
+type ClusterPodNetworkOptionDetailsCniTypeEnum string
+
+// Set of constants representing the allowable values for ClusterPodNetworkOptionDetailsCniTypeEnum
+const (
+	ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative ClusterPodNetworkOptionDetailsCniTypeEnum = "OCI_VCN_IP_NATIVE"
+	ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay ClusterPodNetworkOptionDetailsCniTypeEnum = "FLANNEL_OVERLAY"
+)
+
+var mappingClusterPodNetworkOptionDetailsCniTypeEnum = map[string]ClusterPodNetworkOptionDetailsCniTypeEnum{
+	"OCI_VCN_IP_NATIVE": ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"FLANNEL_OVERLAY":   ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+var mappingClusterPodNetworkOptionDetailsCniTypeEnumLowerCase = map[string]ClusterPodNetworkOptionDetailsCniTypeEnum{
+	"oci_vcn_ip_native": ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"flannel_overlay":   ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+// GetClusterPodNetworkOptionDetailsCniTypeEnumValues Enumerates the set of values for ClusterPodNetworkOptionDetailsCniTypeEnum
+func GetClusterPodNetworkOptionDetailsCniTypeEnumValues() []ClusterPodNetworkOptionDetailsCniTypeEnum {
+	values := make([]ClusterPodNetworkOptionDetailsCniTypeEnum, 0)
+	for _, v := range mappingClusterPodNetworkOptionDetailsCniTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterPodNetworkOptionDetailsCniTypeEnumStringValues Enumerates the set of values in String for ClusterPodNetworkOptionDetailsCniTypeEnum
+func GetClusterPodNetworkOptionDetailsCniTypeEnumStringValues() []string {
+	return []string{
+		"OCI_VCN_IP_NATIVE",
+		"FLANNEL_OVERLAY",
+	}
+}
+
+// GetMappingClusterPodNetworkOptionDetailsCniTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterPodNetworkOptionDetailsCniTypeEnum(val string) (ClusterPodNetworkOptionDetailsCniTypeEnum, bool) {
+	enum, ok := mappingClusterPodNetworkOptionDetailsCniTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_summary.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterSummary The properties that define a cluster summary.
+type ClusterSummary struct {
+
+	// The OCID of the cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the cluster.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The OCID of the compartment in which the cluster exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the virtual cloud network (VCN) in which the cluster exists
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The version of Kubernetes running on the cluster masters.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// Metadata about the cluster.
+	Metadata *ClusterMetadata `mandatory:"false" json:"metadata"`
+
+	// The state of the cluster masters.
+	LifecycleState ClusterLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the cluster masters.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Endpoints served up by the cluster masters.
+	Endpoints *ClusterEndpoints `mandatory:"false" json:"endpoints"`
+
+	// Available Kubernetes versions to which the clusters masters may be upgraded.
+	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m ClusterSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ClusterSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                          *string                           `json:"id"`
+		Name                        *string                           `json:"name"`
+		CompartmentId               *string                           `json:"compartmentId"`
+		EndpointConfig              *ClusterEndpointConfig            `json:"endpointConfig"`
+		VcnId                       *string                           `json:"vcnId"`
+		KubernetesVersion           *string                           `json:"kubernetesVersion"`
+		FreeformTags                map[string]string                 `json:"freeformTags"`
+		DefinedTags                 map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                  map[string]map[string]interface{} `json:"systemTags"`
+		Options                     *ClusterCreateOptions             `json:"options"`
+		Metadata                    *ClusterMetadata                  `json:"metadata"`
+		LifecycleState              ClusterLifecycleStateEnum         `json:"lifecycleState"`
+		LifecycleDetails            *string                           `json:"lifecycleDetails"`
+		Endpoints                   *ClusterEndpoints                 `json:"endpoints"`
+		AvailableKubernetesUpgrades []string                          `json:"availableKubernetesUpgrades"`
+		ImagePolicyConfig           *ImagePolicyConfig                `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions    []clusterpodnetworkoptiondetails  `json:"clusterPodNetworkOptions"`
+		Type                        ClusterTypeEnum                   `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.EndpointConfig = model.EndpointConfig
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Options = model.Options
+
+	m.Metadata = model.Metadata
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.Endpoints = model.Endpoints
+
+	m.AvailableKubernetesUpgrades = make([]string, len(model.AvailableKubernetesUpgrades))
+	for i, n := range model.AvailableKubernetesUpgrades {
+		m.AvailableKubernetesUpgrades[i] = n
+	}
+
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+
+	m.Type = model.Type
+
+	return
+}
+
+// ClusterSummaryLifecycleStateEnum is an alias to type: ClusterLifecycleStateEnum
+// Consider using ClusterLifecycleStateEnum instead
+// Deprecated
+type ClusterSummaryLifecycleStateEnum = ClusterLifecycleStateEnum
+
+// Set of constants representing the allowable values for ClusterLifecycleStateEnum
+// Deprecated
+const (
+	ClusterSummaryLifecycleStateCreating ClusterLifecycleStateEnum = "CREATING"
+	ClusterSummaryLifecycleStateActive   ClusterLifecycleStateEnum = "ACTIVE"
+	ClusterSummaryLifecycleStateFailed   ClusterLifecycleStateEnum = "FAILED"
+	ClusterSummaryLifecycleStateDeleting ClusterLifecycleStateEnum = "DELETING"
+	ClusterSummaryLifecycleStateDeleted  ClusterLifecycleStateEnum = "DELETED"
+	ClusterSummaryLifecycleStateUpdating ClusterLifecycleStateEnum = "UPDATING"
+)
+
+// GetClusterSummaryLifecycleStateEnumValues Enumerates the set of values for ClusterLifecycleStateEnum
+// Consider using GetClusterLifecycleStateEnumValue
+// Deprecated
+var GetClusterSummaryLifecycleStateEnumValues = GetClusterLifecycleStateEnumValues

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_type.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// ClusterTypeEnum Enum with underlying type: string
+type ClusterTypeEnum string
+
+// Set of constants representing the allowable values for ClusterTypeEnum
+const (
+	ClusterTypeBasicCluster    ClusterTypeEnum = "BASIC_CLUSTER"
+	ClusterTypeEnhancedCluster ClusterTypeEnum = "ENHANCED_CLUSTER"
+)
+
+var mappingClusterTypeEnum = map[string]ClusterTypeEnum{
+	"BASIC_CLUSTER":    ClusterTypeBasicCluster,
+	"ENHANCED_CLUSTER": ClusterTypeEnhancedCluster,
+}
+
+var mappingClusterTypeEnumLowerCase = map[string]ClusterTypeEnum{
+	"basic_cluster":    ClusterTypeBasicCluster,
+	"enhanced_cluster": ClusterTypeEnhancedCluster,
+}
+
+// GetClusterTypeEnumValues Enumerates the set of values for ClusterTypeEnum
+func GetClusterTypeEnumValues() []ClusterTypeEnum {
+	values := make([]ClusterTypeEnum, 0)
+	for _, v := range mappingClusterTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterTypeEnumStringValues Enumerates the set of values in String for ClusterTypeEnum
+func GetClusterTypeEnumStringValues() []string {
+	return []string{
+		"BASIC_CLUSTER",
+		"ENHANCED_CLUSTER",
+	}
+}
+
+// GetMappingClusterTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterTypeEnum(val string) (ClusterTypeEnum, bool) {
+	enum, ok := mappingClusterTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/containerengine_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/containerengine_client.go
@@ -1,0 +1,2197 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+	"net/http"
+)
+
+//ContainerEngineClient a client for ContainerEngine
+type ContainerEngineClient struct {
+	common.BaseClient
+	config *common.ConfigurationProvider
+}
+
+// NewContainerEngineClientWithConfigurationProvider Creates a new default ContainerEngine client with the given configuration provider.
+// the configuration provider will be used for the default signer as well as reading the region
+func NewContainerEngineClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client ContainerEngineClient, err error) {
+	provider, err := auth.GetGenericConfigurationProvider(configProvider)
+	if err != nil {
+		return client, err
+	}
+	baseClient, e := common.NewClientWithConfig(provider)
+	if e != nil {
+		return client, e
+	}
+	return newContainerEngineClientFromBaseClient(baseClient, provider)
+}
+
+// NewContainerEngineClientWithOboToken Creates a new default ContainerEngine client with the given configuration provider.
+// The obotoken will be added to default headers and signed; the configuration provider will be used for the signer
+//  as well as reading the region
+func NewContainerEngineClientWithOboToken(configProvider common.ConfigurationProvider, oboToken string) (client ContainerEngineClient, err error) {
+	baseClient, err := common.NewClientWithOboToken(configProvider, oboToken)
+	if err != nil {
+		return client, err
+	}
+
+	return newContainerEngineClientFromBaseClient(baseClient, configProvider)
+}
+
+func newContainerEngineClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ContainerEngineClient, err error) {
+	// ContainerEngine service default circuit breaker is enabled
+	baseClient.Configuration.CircuitBreaker = common.NewCircuitBreaker(common.DefaultCircuitBreakerSettingWithServiceName("ContainerEngine"))
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
+	client = ContainerEngineClient{BaseClient: baseClient}
+	client.BasePath = "20180222"
+	err = client.setConfigurationProvider(configProvider)
+	return
+}
+
+// SetRegion overrides the region of this client.
+func (client *ContainerEngineClient) SetRegion(region string) {
+	client.Host = common.StringToRegion(region).EndpointForTemplate("containerengine", "https://containerengine.{region}.oci.{secondLevelDomain}")
+}
+
+// SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
+func (client *ContainerEngineClient) setConfigurationProvider(configProvider common.ConfigurationProvider) error {
+	if ok, err := common.IsConfigurationProviderValid(configProvider); !ok {
+		return err
+	}
+
+	// Error has been checked already
+	region, _ := configProvider.Region()
+	client.SetRegion(region)
+	if client.Host == "" {
+		return fmt.Errorf("Invalid region or Host. Endpoint cannot be constructed without endpointServiceName or serviceEndpointTemplate for a dotted region")
+	}
+	client.config = &configProvider
+	return nil
+}
+
+// ConfigurationProvider the ConfigurationProvider used in this client, or null if none set
+func (client *ContainerEngineClient) ConfigurationProvider() *common.ConfigurationProvider {
+	return client.config
+}
+
+// ClusterMigrateToNativeVcn Initiates cluster migration to use native VCN.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ClusterMigrateToNativeVcn.go.html to see an example of how to use ClusterMigrateToNativeVcn API.
+// A default retry strategy applies to this operation ClusterMigrateToNativeVcn()
+func (client ContainerEngineClient) ClusterMigrateToNativeVcn(ctx context.Context, request ClusterMigrateToNativeVcnRequest) (response ClusterMigrateToNativeVcnResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.clusterMigrateToNativeVcn, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ClusterMigrateToNativeVcnResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ClusterMigrateToNativeVcnResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ClusterMigrateToNativeVcnResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ClusterMigrateToNativeVcnResponse")
+	}
+	return
+}
+
+// clusterMigrateToNativeVcn implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) clusterMigrateToNativeVcn(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/migrateToNativeVcn", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ClusterMigrateToNativeVcnResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/ClusterMigrateToNativeVcn"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ClusterMigrateToNativeVcn", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateCluster Create a new cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateCluster.go.html to see an example of how to use CreateCluster API.
+// A default retry strategy applies to this operation CreateCluster()
+func (client ContainerEngineClient) CreateCluster(ctx context.Context, request CreateClusterRequest) (response CreateClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateClusterResponse")
+	}
+	return
+}
+
+// createCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CreateCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateKubeconfig Create the Kubeconfig YAML for a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateKubeconfig.go.html to see an example of how to use CreateKubeconfig API.
+// A default retry strategy applies to this operation CreateKubeconfig()
+func (client ContainerEngineClient) CreateKubeconfig(ctx context.Context, request CreateKubeconfigRequest) (response CreateKubeconfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.createKubeconfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateKubeconfigResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateKubeconfigResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateKubeconfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateKubeconfigResponse")
+	}
+	return
+}
+
+// createKubeconfig implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createKubeconfig(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/kubeconfig/content", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateKubeconfigResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CreateKubeconfig"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateKubeconfig", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateNodePool Create a new node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateNodePool.go.html to see an example of how to use CreateNodePool API.
+// A default retry strategy applies to this operation CreateNodePool()
+func (client ContainerEngineClient) CreateNodePool(ctx context.Context, request CreateNodePoolRequest) (response CreateNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateNodePoolResponse")
+	}
+	return
+}
+
+// createNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/nodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/CreateNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateVirtualNodePool Create a new virtual node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateVirtualNodePool.go.html to see an example of how to use CreateVirtualNodePool API.
+// A default retry strategy applies to this operation CreateVirtualNodePool()
+func (client ContainerEngineClient) CreateVirtualNodePool(ctx context.Context, request CreateVirtualNodePoolRequest) (response CreateVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateVirtualNodePoolResponse")
+	}
+	return
+}
+
+// createVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/virtualNodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/CreateVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteCluster Delete a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteCluster.go.html to see an example of how to use DeleteCluster API.
+// A default retry strategy applies to this operation DeleteCluster()
+func (client ContainerEngineClient) DeleteCluster(ctx context.Context, request DeleteClusterRequest) (response DeleteClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteClusterResponse")
+	}
+	return
+}
+
+// deleteCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/DeleteCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteNode Delete node.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNode.go.html to see an example of how to use DeleteNode API.
+// A default retry strategy applies to this operation DeleteNode()
+func (client ContainerEngineClient) DeleteNode(ctx context.Context, request DeleteNodeRequest) (response DeleteNodeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteNode, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteNodeResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteNodeResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteNodeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteNodeResponse")
+	}
+	return
+}
+
+// deleteNode implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteNode(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/nodePools/{nodePoolId}/node/{nodeId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteNodeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/DeleteNode"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteNode", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteNodePool Delete a node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNodePool.go.html to see an example of how to use DeleteNodePool API.
+// A default retry strategy applies to this operation DeleteNodePool()
+func (client ContainerEngineClient) DeleteNodePool(ctx context.Context, request DeleteNodePoolRequest) (response DeleteNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteNodePoolResponse")
+	}
+	return
+}
+
+// deleteNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/DeleteNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteVirtualNodePool Delete a virtual node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteVirtualNodePool.go.html to see an example of how to use DeleteVirtualNodePool API.
+// A default retry strategy applies to this operation DeleteVirtualNodePool()
+func (client ContainerEngineClient) DeleteVirtualNodePool(ctx context.Context, request DeleteVirtualNodePoolRequest) (response DeleteVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteVirtualNodePoolResponse")
+	}
+	return
+}
+
+// deleteVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/DeleteVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWorkRequest Cancel a work request that has not started.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkRequest.go.html to see an example of how to use DeleteWorkRequest API.
+// A default retry strategy applies to this operation DeleteWorkRequest()
+func (client ContainerEngineClient) DeleteWorkRequest(ctx context.Context, request DeleteWorkRequestRequest) (response DeleteWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWorkRequestResponse")
+	}
+	return
+}
+
+// deleteWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteWorkRequest(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workRequests/{workRequestId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequest/DeleteWorkRequest"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteWorkRequest", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DisableAddon Disable addon for a provisioned cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DisableAddon.go.html to see an example of how to use DisableAddon API.
+// A default retry strategy applies to this operation DisableAddon()
+func (client ContainerEngineClient) DisableAddon(ctx context.Context, request DisableAddonRequest) (response DisableAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.disableAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DisableAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DisableAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DisableAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DisableAddonResponse")
+	}
+	return
+}
+
+// disableAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) disableAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DisableAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/DisableAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DisableAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetAddon Get the specified addon for a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetAddon.go.html to see an example of how to use GetAddon API.
+// A default retry strategy applies to this operation GetAddon()
+func (client ContainerEngineClient) GetAddon(ctx context.Context, request GetAddonRequest) (response GetAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetAddonResponse")
+	}
+	return
+}
+
+// getAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/GetAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCluster Get the details of a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCluster.go.html to see an example of how to use GetCluster API.
+// A default retry strategy applies to this operation GetCluster()
+func (client ContainerEngineClient) GetCluster(ctx context.Context, request GetClusterRequest) (response GetClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterResponse")
+	}
+	return
+}
+
+// getCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/GetCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetClusterMigrateToNativeVcnStatus Get details on a cluster's migration to native VCN.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterMigrateToNativeVcnStatus.go.html to see an example of how to use GetClusterMigrateToNativeVcnStatus API.
+// A default retry strategy applies to this operation GetClusterMigrateToNativeVcnStatus()
+func (client ContainerEngineClient) GetClusterMigrateToNativeVcnStatus(ctx context.Context, request GetClusterMigrateToNativeVcnStatusRequest) (response GetClusterMigrateToNativeVcnStatusResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getClusterMigrateToNativeVcnStatus, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterMigrateToNativeVcnStatusResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterMigrateToNativeVcnStatusResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterMigrateToNativeVcnStatusResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterMigrateToNativeVcnStatusResponse")
+	}
+	return
+}
+
+// getClusterMigrateToNativeVcnStatus implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getClusterMigrateToNativeVcnStatus(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/migrateToNativeVcnStatus", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterMigrateToNativeVcnStatusResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterMigrateToNativeVcnStatus/GetClusterMigrateToNativeVcnStatus"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetClusterMigrateToNativeVcnStatus", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetClusterOptions Get options available for clusters.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterOptions.go.html to see an example of how to use GetClusterOptions API.
+// A default retry strategy applies to this operation GetClusterOptions()
+func (client ContainerEngineClient) GetClusterOptions(ctx context.Context, request GetClusterOptionsRequest) (response GetClusterOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getClusterOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterOptionsResponse")
+	}
+	return
+}
+
+// getClusterOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getClusterOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusterOptions/{clusterOptionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterOptions/GetClusterOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetClusterOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetNodePool Get the details of a node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePool.go.html to see an example of how to use GetNodePool API.
+// A default retry strategy applies to this operation GetNodePool()
+func (client ContainerEngineClient) GetNodePool(ctx context.Context, request GetNodePoolRequest) (response GetNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetNodePoolResponse")
+	}
+	return
+}
+
+// getNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/GetNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetNodePoolOptions Get options available for node pools.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePoolOptions.go.html to see an example of how to use GetNodePoolOptions API.
+// A default retry strategy applies to this operation GetNodePoolOptions()
+func (client ContainerEngineClient) GetNodePoolOptions(ctx context.Context, request GetNodePoolOptionsRequest) (response GetNodePoolOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getNodePoolOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetNodePoolOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetNodePoolOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetNodePoolOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetNodePoolOptionsResponse")
+	}
+	return
+}
+
+// getNodePoolOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getNodePoolOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePoolOptions/{nodePoolOptionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetNodePoolOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePoolOptions/GetNodePoolOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetNodePoolOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVirtualNode Get the details of a virtual node.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNode.go.html to see an example of how to use GetVirtualNode API.
+// A default retry strategy applies to this operation GetVirtualNode()
+func (client ContainerEngineClient) GetVirtualNode(ctx context.Context, request GetVirtualNodeRequest) (response GetVirtualNodeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVirtualNode, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetVirtualNodeResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetVirtualNodeResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVirtualNodeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVirtualNodeResponse")
+	}
+	return
+}
+
+// getVirtualNode implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getVirtualNode(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}/virtualNodes/{virtualNodeId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVirtualNodeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/GetVirtualNode"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetVirtualNode", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVirtualNodePool Get the details of a virtual node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNodePool.go.html to see an example of how to use GetVirtualNodePool API.
+// A default retry strategy applies to this operation GetVirtualNodePool()
+func (client ContainerEngineClient) GetVirtualNodePool(ctx context.Context, request GetVirtualNodePoolRequest) (response GetVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVirtualNodePoolResponse")
+	}
+	return
+}
+
+// getVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/GetVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkRequest Get the details of a work request.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkRequest.go.html to see an example of how to use GetWorkRequest API.
+// A default retry strategy applies to this operation GetWorkRequest()
+func (client ContainerEngineClient) GetWorkRequest(ctx context.Context, request GetWorkRequestRequest) (response GetWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkRequestResponse")
+	}
+	return
+}
+
+// getWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getWorkRequest(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequest/GetWorkRequest"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetWorkRequest", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// InstallAddon Install the specified addon for a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/InstallAddon.go.html to see an example of how to use InstallAddon API.
+// A default retry strategy applies to this operation InstallAddon()
+func (client ContainerEngineClient) InstallAddon(ctx context.Context, request InstallAddonRequest) (response InstallAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.installAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = InstallAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = InstallAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(InstallAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into InstallAddonResponse")
+	}
+	return
+}
+
+// installAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) installAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/addons", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InstallAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/InstallAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "InstallAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAddonOptions Get list of supported addons for a specific kubernetes version.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddonOptions.go.html to see an example of how to use ListAddonOptions API.
+// A default retry strategy applies to this operation ListAddonOptions()
+func (client ContainerEngineClient) ListAddonOptions(ctx context.Context, request ListAddonOptionsRequest) (response ListAddonOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAddonOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAddonOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAddonOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAddonOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAddonOptionsResponse")
+	}
+	return
+}
+
+// listAddonOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listAddonOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/addonOptions", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAddonOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/AddonOptionSummary/ListAddonOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListAddonOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAddons List addon for a provisioned cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddons.go.html to see an example of how to use ListAddons API.
+// A default retry strategy applies to this operation ListAddons()
+func (client ContainerEngineClient) ListAddons(ctx context.Context, request ListAddonsRequest) (response ListAddonsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAddons, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAddonsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAddonsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAddonsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAddonsResponse")
+	}
+	return
+}
+
+// listAddons implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listAddons(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/addons", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAddonsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/ListAddons"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListAddons", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListClusters List all the cluster objects in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListClusters.go.html to see an example of how to use ListClusters API.
+// A default retry strategy applies to this operation ListClusters()
+func (client ContainerEngineClient) ListClusters(ctx context.Context, request ListClustersRequest) (response ListClustersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listClusters, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListClustersResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListClustersResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListClustersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListClustersResponse")
+	}
+	return
+}
+
+// listClusters implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listClusters(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListClustersResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterSummary/ListClusters"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListClusters", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListNodePools List all the node pools in a compartment, and optionally filter by cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListNodePools.go.html to see an example of how to use ListNodePools API.
+// A default retry strategy applies to this operation ListNodePools()
+func (client ContainerEngineClient) ListNodePools(ctx context.Context, request ListNodePoolsRequest) (response ListNodePoolsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listNodePools, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListNodePoolsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListNodePoolsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListNodePoolsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListNodePoolsResponse")
+	}
+	return
+}
+
+// listNodePools implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listNodePools(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListNodePoolsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePoolSummary/ListNodePools"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListNodePools", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPodShapes List all the Pod Shapes in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListPodShapes.go.html to see an example of how to use ListPodShapes API.
+// A default retry strategy applies to this operation ListPodShapes()
+func (client ContainerEngineClient) ListPodShapes(ctx context.Context, request ListPodShapesRequest) (response ListPodShapesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPodShapes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPodShapesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPodShapesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPodShapesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPodShapesResponse")
+	}
+	return
+}
+
+// listPodShapes implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listPodShapes(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/podShapes", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPodShapesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/PodShapeSummary/ListPodShapes"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListPodShapes", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVirtualNodePools List all the virtual node pools in a compartment, and optionally filter by cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodePools.go.html to see an example of how to use ListVirtualNodePools API.
+// A default retry strategy applies to this operation ListVirtualNodePools()
+func (client ContainerEngineClient) ListVirtualNodePools(ctx context.Context, request ListVirtualNodePoolsRequest) (response ListVirtualNodePoolsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVirtualNodePools, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListVirtualNodePoolsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListVirtualNodePoolsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVirtualNodePoolsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVirtualNodePoolsResponse")
+	}
+	return
+}
+
+// listVirtualNodePools implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listVirtualNodePools(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVirtualNodePoolsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePoolSummary/ListVirtualNodePools"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListVirtualNodePools", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVirtualNodes List virtual nodes in a virtual node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodes.go.html to see an example of how to use ListVirtualNodes API.
+// A default retry strategy applies to this operation ListVirtualNodes()
+func (client ContainerEngineClient) ListVirtualNodes(ctx context.Context, request ListVirtualNodesRequest) (response ListVirtualNodesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVirtualNodes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListVirtualNodesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListVirtualNodesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVirtualNodesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVirtualNodesResponse")
+	}
+	return
+}
+
+// listVirtualNodes implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listVirtualNodes(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}/virtualNodes", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVirtualNodesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/ListVirtualNodes"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListVirtualNodes", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestErrors Get the errors of a work request.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrors API.
+// A default retry strategy applies to this operation ListWorkRequestErrors()
+func (client ContainerEngineClient) ListWorkRequestErrors(ctx context.Context, request ListWorkRequestErrorsRequest) (response ListWorkRequestErrorsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestErrors, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestErrorsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestErrorsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestErrorsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestErrorsResponse")
+	}
+	return
+}
+
+// listWorkRequestErrors implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequestErrors(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/errors", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestErrorsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestError/ListWorkRequestErrors"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequestErrors", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestLogs Get the logs of a work request.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogs API.
+// A default retry strategy applies to this operation ListWorkRequestLogs()
+func (client ContainerEngineClient) ListWorkRequestLogs(ctx context.Context, request ListWorkRequestLogsRequest) (response ListWorkRequestLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestLogsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestLogsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestLogsResponse")
+	}
+	return
+}
+
+// listWorkRequestLogs implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequestLogs(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/logs", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestLogEntry/ListWorkRequestLogs"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequestLogs", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequests List all work requests in a compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequests.go.html to see an example of how to use ListWorkRequests API.
+// A default retry strategy applies to this operation ListWorkRequests()
+func (client ContainerEngineClient) ListWorkRequests(ctx context.Context, request ListWorkRequestsRequest) (response ListWorkRequestsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequests, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestsResponse")
+	}
+	return
+}
+
+// listWorkRequests implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequests(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestSummary/ListWorkRequests"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequests", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateAddon Update addon details for a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateAddon.go.html to see an example of how to use UpdateAddon API.
+// A default retry strategy applies to this operation UpdateAddon()
+func (client ContainerEngineClient) UpdateAddon(ctx context.Context, request UpdateAddonRequest) (response UpdateAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateAddonResponse")
+	}
+	return
+}
+
+// updateAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateCluster Update the details of a cluster.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateCluster.go.html to see an example of how to use UpdateCluster API.
+// A default retry strategy applies to this operation UpdateCluster()
+func (client ContainerEngineClient) UpdateCluster(ctx context.Context, request UpdateClusterRequest) (response UpdateClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateClusterResponse")
+	}
+	return
+}
+
+// updateCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateClusterEndpointConfig Update the details of the cluster endpoint configuration.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateClusterEndpointConfig.go.html to see an example of how to use UpdateClusterEndpointConfig API.
+// A default retry strategy applies to this operation UpdateClusterEndpointConfig()
+func (client ContainerEngineClient) UpdateClusterEndpointConfig(ctx context.Context, request UpdateClusterEndpointConfigRequest) (response UpdateClusterEndpointConfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateClusterEndpointConfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateClusterEndpointConfigResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateClusterEndpointConfigResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateClusterEndpointConfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateClusterEndpointConfigResponse")
+	}
+	return
+}
+
+// updateClusterEndpointConfig implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateClusterEndpointConfig(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/updateEndpointConfig", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateClusterEndpointConfigResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateClusterEndpointConfig"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateClusterEndpointConfig", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateNodePool Update the details of a node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateNodePool.go.html to see an example of how to use UpdateNodePool API.
+// A default retry strategy applies to this operation UpdateNodePool()
+func (client ContainerEngineClient) UpdateNodePool(ctx context.Context, request UpdateNodePoolRequest) (response UpdateNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateNodePoolResponse")
+	}
+	return
+}
+
+// updateNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/UpdateNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateVirtualNodePool Update the details of a virtual node pool.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateVirtualNodePool.go.html to see an example of how to use UpdateVirtualNodePool API.
+// A default retry strategy applies to this operation UpdateVirtualNodePool()
+func (client ContainerEngineClient) UpdateVirtualNodePool(ctx context.Context, request UpdateVirtualNodePoolRequest) (response UpdateVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateVirtualNodePoolResponse")
+	}
+	return
+}
+
+// updateVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/UpdateVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_details.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterDetails The properties that define a request to create a cluster.
+type CreateClusterDetails struct {
+
+	// The name of the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The OCID of the compartment in which to create the cluster.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the virtual cloud network (VCN) in which to create the cluster.
+	VcnId *string `mandatory:"true" json:"vcnId"`
+
+	// The version of Kubernetes to install into the cluster masters.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *CreateClusterEndpointConfigDetails `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	// When used, `kubernetesVersion` must be at least `v1.13.0`.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *CreateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m CreateClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateClusterDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		EndpointConfig           *CreateClusterEndpointConfigDetails `json:"endpointConfig"`
+		KmsKeyId                 *string                             `json:"kmsKeyId"`
+		FreeformTags             map[string]string                   `json:"freeformTags"`
+		DefinedTags              map[string]map[string]interface{}   `json:"definedTags"`
+		Options                  *ClusterCreateOptions               `json:"options"`
+		ImagePolicyConfig        *CreateImagePolicyConfigDetails     `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions []clusterpodnetworkoptiondetails    `json:"clusterPodNetworkOptions"`
+		Type                     ClusterTypeEnum                     `json:"type"`
+		Name                     *string                             `json:"name"`
+		CompartmentId            *string                             `json:"compartmentId"`
+		VcnId                    *string                             `json:"vcnId"`
+		KubernetesVersion        *string                             `json:"kubernetesVersion"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.EndpointConfig = model.EndpointConfig
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.Options = model.Options
+
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+
+	m.Type = model.Type
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_endpoint_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_endpoint_config_details.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterEndpointConfigDetails The properties that define the network configuration for the Cluster endpoint.
+type CreateClusterEndpointConfigDetails struct {
+
+	// The OCID of the regional subnet in which to place the Cluster endpoint.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m CreateClusterEndpointConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterEndpointConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_kubeconfig_content_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_kubeconfig_content_details.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterKubeconfigContentDetails The properties that define a request to create a cluster kubeconfig.
+type CreateClusterKubeconfigContentDetails struct {
+
+	// The version of the kubeconfig token. Supported value 2.0.0
+	TokenVersion *string `mandatory:"false" json:"tokenVersion"`
+
+	// Deprecated. This field is no longer used.
+	Expiration *int `mandatory:"false" json:"expiration"`
+
+	// The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+	Endpoint CreateClusterKubeconfigContentDetailsEndpointEnum `mandatory:"false" json:"endpoint,omitempty"`
+}
+
+func (m CreateClusterKubeconfigContentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterKubeconfigContentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum(string(m.Endpoint)); !ok && m.Endpoint != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Endpoint: %s. Supported values are: %s.", m.Endpoint, strings.Join(GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateClusterKubeconfigContentDetailsEndpointEnum Enum with underlying type: string
+type CreateClusterKubeconfigContentDetailsEndpointEnum string
+
+// Set of constants representing the allowable values for CreateClusterKubeconfigContentDetailsEndpointEnum
+const (
+	CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes CreateClusterKubeconfigContentDetailsEndpointEnum = "LEGACY_KUBERNETES"
+	CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint   CreateClusterKubeconfigContentDetailsEndpointEnum = "PUBLIC_ENDPOINT"
+	CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint  CreateClusterKubeconfigContentDetailsEndpointEnum = "PRIVATE_ENDPOINT"
+	CreateClusterKubeconfigContentDetailsEndpointVcnHostname      CreateClusterKubeconfigContentDetailsEndpointEnum = "VCN_HOSTNAME"
+)
+
+var mappingCreateClusterKubeconfigContentDetailsEndpointEnum = map[string]CreateClusterKubeconfigContentDetailsEndpointEnum{
+	"LEGACY_KUBERNETES": CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes,
+	"PUBLIC_ENDPOINT":   CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint,
+	"PRIVATE_ENDPOINT":  CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint,
+	"VCN_HOSTNAME":      CreateClusterKubeconfigContentDetailsEndpointVcnHostname,
+}
+
+var mappingCreateClusterKubeconfigContentDetailsEndpointEnumLowerCase = map[string]CreateClusterKubeconfigContentDetailsEndpointEnum{
+	"legacy_kubernetes": CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes,
+	"public_endpoint":   CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint,
+	"private_endpoint":  CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint,
+	"vcn_hostname":      CreateClusterKubeconfigContentDetailsEndpointVcnHostname,
+}
+
+// GetCreateClusterKubeconfigContentDetailsEndpointEnumValues Enumerates the set of values for CreateClusterKubeconfigContentDetailsEndpointEnum
+func GetCreateClusterKubeconfigContentDetailsEndpointEnumValues() []CreateClusterKubeconfigContentDetailsEndpointEnum {
+	values := make([]CreateClusterKubeconfigContentDetailsEndpointEnum, 0)
+	for _, v := range mappingCreateClusterKubeconfigContentDetailsEndpointEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues Enumerates the set of values in String for CreateClusterKubeconfigContentDetailsEndpointEnum
+func GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues() []string {
+	return []string{
+		"LEGACY_KUBERNETES",
+		"PUBLIC_ENDPOINT",
+		"PRIVATE_ENDPOINT",
+		"VCN_HOSTNAME",
+	}
+}
+
+// GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum(val string) (CreateClusterKubeconfigContentDetailsEndpointEnum, bool) {
+	enum, ok := mappingCreateClusterKubeconfigContentDetailsEndpointEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateClusterRequest wrapper for the CreateCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateCluster.go.html to see an example of how to use CreateClusterRequest.
+type CreateClusterRequest struct {
+
+	// The details of the cluster to create.
+	CreateClusterDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateClusterResponse wrapper for the CreateCluster operation
+type CreateClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_image_policy_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_image_policy_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateImagePolicyConfigDetails The properties that define a image verification policy.
+type CreateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m CreateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateImagePolicyConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_kubeconfig_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_kubeconfig_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// CreateKubeconfigRequest wrapper for the CreateKubeconfig operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateKubeconfig.go.html to see an example of how to use CreateKubeconfigRequest.
+type CreateKubeconfigRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The details of the cluster kubeconfig to create.
+	CreateClusterKubeconfigContentDetails `contributesTo:"body"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateKubeconfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateKubeconfigRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateKubeconfigRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateKubeconfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateKubeconfigRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateKubeconfigResponse wrapper for the CreateKubeconfig operation
+type CreateKubeconfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateKubeconfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateKubeconfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_details.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodePoolDetails The properties that define a request to create a node pool.
+type CreateNodePoolDetails struct {
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// The name of the node pool. Avoid entering confidential information.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"true" json:"nodeShape"`
+
+	// The version of Kubernetes to install on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Deprecated. Use `nodeSourceDetails` instead.
+	// If you specify values for both, this value is ignored.
+	// The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// Specify the configuration of the shape to launch nodes in the node pool.
+	NodeShapeConfig *CreateNodeShapeConfigDetails `mandatory:"false" json:"nodeShapeConfig"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// Optional, default to 1. The number of nodes to create in each subnet specified in subnetIds property.
+	// When used, subnetIds is required. This property is deprecated, use nodeConfigDetails instead.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. When used, quantityPerSubnet
+	// can be provided. This property is deprecated, use nodeConfigDetails. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	NodeConfigDetails *CreateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+}
+
+func (m CreateNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateNodePoolDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShapeConfig              *CreateNodeShapeConfigDetails     `json:"nodeShapeConfig"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *CreateNodePoolNodeConfigDetails  `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		NodeShape                    *string                           `json:"nodeShape"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeMetadata = model.NodeMetadata
+
+	m.NodeImageName = model.NodeImageName
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	for i, n := range model.InitialNodeLabels {
+		m.InitialNodeLabels[i] = n
+	}
+
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	for i, n := range model.SubnetIds {
+		m.SubnetIds[i] = n
+	}
+
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.NodeShape = model.NodeShape
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_node_config_details.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type CreateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes that should be in the node pool.
+	Size *int `mandatory:"true" json:"size"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"true" json:"placementConfigs"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m CreateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateNodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+		Size                            *int                              `json:"size"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.NsgIds = make([]string, len(model.NsgIds))
+	for i, n := range model.NsgIds {
+		m.NsgIds[i] = n
+	}
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	m.Size = model.Size
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	for i, n := range model.PlacementConfigs {
+		m.PlacementConfigs[i] = n
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateNodePoolRequest wrapper for the CreateNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateNodePool.go.html to see an example of how to use CreateNodePoolRequest.
+type CreateNodePoolRequest struct {
+
+	// The details of the node pool to create.
+	CreateNodePoolDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateNodePoolResponse wrapper for the CreateNodePool operation
+type CreateNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_shape_config_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodeShapeConfigDetails The shape configuration of the nodes.
+type CreateNodeShapeConfigDetails struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m CreateNodeShapeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodeShapeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_details.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateVirtualNodePoolDetails The properties that define a request to create a virtual node pool.
+type CreateVirtualNodePoolDetails struct {
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m CreateVirtualNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateVirtualNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateVirtualNodePoolRequest wrapper for the CreateVirtualNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateVirtualNodePool.go.html to see an example of how to use CreateVirtualNodePoolRequest.
+type CreateVirtualNodePoolRequest struct {
+
+	// The details of the virtual node pool to create.
+	CreateVirtualNodePoolDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateVirtualNodePoolResponse wrapper for the CreateVirtualNodePool operation
+type CreateVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_cluster_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteClusterRequest wrapper for the DeleteCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteCluster.go.html to see an example of how to use DeleteClusterRequest.
+type DeleteClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteClusterResponse wrapper for the DeleteCluster operation
+type DeleteClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_pool_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteNodePoolRequest wrapper for the DeleteNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNodePool.go.html to see an example of how to use DeleteNodePoolRequest.
+type DeleteNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteNodePoolResponse wrapper for the DeleteNodePool operation
+type DeleteNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteNodeRequest wrapper for the DeleteNode operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNode.go.html to see an example of how to use DeleteNodeRequest.
+type DeleteNodeRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// The OCID of the compute instance.
+	NodeId *string `mandatory:"true" contributesTo:"path" name:"nodeId"`
+
+	// If the nodepool should be scaled down after the node is deleted.
+	IsDecrementSize *bool `mandatory:"false" contributesTo:"query" name:"isDecrementSize"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteNodeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteNodeRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteNodeRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteNodeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteNodeRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteNodeResponse wrapper for the DeleteNode operation
+type DeleteNodeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteNodeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteNodeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_virtual_node_pool_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteVirtualNodePoolRequest wrapper for the DeleteVirtualNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteVirtualNodePool.go.html to see an example of how to use DeleteVirtualNodePoolRequest.
+type DeleteVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which Sk8s will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the virtual node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDurationVnp *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDurationVnp"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDurationVnp *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDurationVnp"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteVirtualNodePoolResponse wrapper for the DeleteVirtualNodePool operation
+type DeleteVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_work_request_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteWorkRequestRequest wrapper for the DeleteWorkRequest operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkRequest.go.html to see an example of how to use DeleteWorkRequestRequest.
+type DeleteWorkRequestRequest struct {
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWorkRequestRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteWorkRequestRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteWorkRequestRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteWorkRequestResponse wrapper for the DeleteWorkRequest operation
+type DeleteWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/disable_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/disable_addon_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DisableAddonRequest wrapper for the DisableAddon operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DisableAddon.go.html to see an example of how to use DisableAddonRequest.
+type DisableAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// Whether existing addon resources should be deleted or not. True would remove the underlying resources completely.
+	IsRemoveExistingAddOn *bool `mandatory:"true" contributesTo:"query" name:"isRemoveExistingAddOn"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DisableAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DisableAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DisableAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DisableAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DisableAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DisableAddonResponse wrapper for the DisableAddon operation
+type DisableAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DisableAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DisableAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_cluster_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// FlannelOverlayClusterPodNetworkOptionDetails Network options specific to using the flannel (FLANNEL_OVERLAY) CNI
+type FlannelOverlayClusterPodNetworkOptionDetails struct {
+}
+
+func (m FlannelOverlayClusterPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m FlannelOverlayClusterPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m FlannelOverlayClusterPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails FlannelOverlayClusterPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails
+	}{
+		"FLANNEL_OVERLAY",
+		(MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_node_pool_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// FlannelOverlayNodePoolPodNetworkOptionDetails Network options specific to using the flannel (FLANNEL_OVERLAY) CNI
+type FlannelOverlayNodePoolPodNetworkOptionDetails struct {
+}
+
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails FlannelOverlayNodePoolPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails
+	}{
+		"FLANNEL_OVERLAY",
+		(MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_addon_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetAddonRequest wrapper for the GetAddon operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetAddon.go.html to see an example of how to use GetAddonRequest.
+type GetAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetAddonResponse wrapper for the GetAddon operation
+type GetAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Addon instance
+	Addon `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_migrate_to_native_vcn_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_migrate_to_native_vcn_status_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterMigrateToNativeVcnStatusRequest wrapper for the GetClusterMigrateToNativeVcnStatus operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterMigrateToNativeVcnStatus.go.html to see an example of how to use GetClusterMigrateToNativeVcnStatusRequest.
+type GetClusterMigrateToNativeVcnStatusRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterMigrateToNativeVcnStatusRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterMigrateToNativeVcnStatusRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterMigrateToNativeVcnStatusRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterMigrateToNativeVcnStatusRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterMigrateToNativeVcnStatusRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterMigrateToNativeVcnStatusResponse wrapper for the GetClusterMigrateToNativeVcnStatus operation
+type GetClusterMigrateToNativeVcnStatusResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ClusterMigrateToNativeVcnStatus instance
+	ClusterMigrateToNativeVcnStatus `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterMigrateToNativeVcnStatusResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterMigrateToNativeVcnStatusResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_options_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterOptionsRequest wrapper for the GetClusterOptions operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterOptions.go.html to see an example of how to use GetClusterOptionsRequest.
+type GetClusterOptionsRequest struct {
+
+	// The id of the option set to retrieve. Use "all" get all options, or use a cluster ID to get options specific to the provided cluster.
+	ClusterOptionId *string `mandatory:"true" contributesTo:"path" name:"clusterOptionId"`
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterOptionsResponse wrapper for the GetClusterOptions operation
+type GetClusterOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ClusterOptions instance
+	ClusterOptions `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterRequest wrapper for the GetCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCluster.go.html to see an example of how to use GetClusterRequest.
+type GetClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterResponse wrapper for the GetCluster operation
+type GetClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Cluster instance
+	Cluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_options_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetNodePoolOptionsRequest wrapper for the GetNodePoolOptions operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePoolOptions.go.html to see an example of how to use GetNodePoolOptionsRequest.
+type GetNodePoolOptionsRequest struct {
+
+	// The id of the option set to retrieve. Use "all" get all options, or use a cluster ID to get options specific to the provided cluster.
+	NodePoolOptionId *string `mandatory:"true" contributesTo:"path" name:"nodePoolOptionId"`
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetNodePoolOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetNodePoolOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetNodePoolOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetNodePoolOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetNodePoolOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetNodePoolOptionsResponse wrapper for the GetNodePoolOptions operation
+type GetNodePoolOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NodePoolOptions instance
+	NodePoolOptions `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetNodePoolOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetNodePoolOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetNodePoolRequest wrapper for the GetNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePool.go.html to see an example of how to use GetNodePoolRequest.
+type GetNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetNodePoolResponse wrapper for the GetNodePool operation
+type GetNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NodePool instance
+	NodePool `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetVirtualNodePoolRequest wrapper for the GetVirtualNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNodePool.go.html to see an example of how to use GetVirtualNodePoolRequest.
+type GetVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetVirtualNodePoolResponse wrapper for the GetVirtualNodePool operation
+type GetVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VirtualNodePool instance
+	VirtualNodePool `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetVirtualNodeRequest wrapper for the GetVirtualNode operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNode.go.html to see an example of how to use GetVirtualNodeRequest.
+type GetVirtualNodeRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// The OCID of the virtual node.
+	VirtualNodeId *string `mandatory:"true" contributesTo:"path" name:"virtualNodeId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVirtualNodeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVirtualNodeRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetVirtualNodeRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVirtualNodeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetVirtualNodeRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetVirtualNodeResponse wrapper for the GetVirtualNode operation
+type GetVirtualNodeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VirtualNode instance
+	VirtualNode `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVirtualNodeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVirtualNodeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_work_request_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWorkRequestRequest wrapper for the GetWorkRequest operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkRequest.go.html to see an example of how to use GetWorkRequestRequest.
+type GetWorkRequestRequest struct {
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkRequestRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWorkRequestRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWorkRequestRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWorkRequestResponse wrapper for the GetWorkRequest operation
+type GetWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkRequest instance
+	WorkRequest `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// the number of seconds to should wait before polling this endpoint again
+	RetryAfter *int `presentIn:"header" name:"retry-after"`
+}
+
+func (response GetWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/image_policy_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/image_policy_config.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ImagePolicyConfig The properties that define a image verification policy.
+type ImagePolicyConfig struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m ImagePolicyConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ImagePolicyConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/initial_virtual_node_label.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/initial_virtual_node_label.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// InitialVirtualNodeLabel The properties that define a key value pair.
+type InitialVirtualNodeLabel struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m InitialVirtualNodeLabel) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m InitialVirtualNodeLabel) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_details.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// InstallAddonDetails The properties that define to install/enable addon on a cluster
+type InstallAddonDetails struct {
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" json:"addonName"`
+
+	// The version of addon to be installed.
+	Version *string `mandatory:"false" json:"version"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m InstallAddonDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m InstallAddonDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// InstallAddonRequest wrapper for the InstallAddon operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/InstallAddon.go.html to see an example of how to use InstallAddonRequest.
+type InstallAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the addon to be installed.
+	InstallAddonDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request InstallAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request InstallAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request InstallAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request InstallAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request InstallAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// InstallAddonResponse wrapper for the InstallAddon operation
+type InstallAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response InstallAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response InstallAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KeyDetails The properties that define the kms keys used by OKE for Image Signature verification.
+type KeyDetails struct {
+
+	// The OCIDs of the KMS key that will be used to verify whether the images are signed by an approved source.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+}
+
+func (m KeyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KeyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_value.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_value.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KeyValue The properties that define a key value pair.
+type KeyValue struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m KeyValue) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KeyValue) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_network_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_network_config.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KubernetesNetworkConfig The properties that define the network configuration for Kubernetes.
+type KubernetesNetworkConfig struct {
+
+	// The CIDR block for Kubernetes pods. Optional, defaults to 10.244.0.0/16.
+	PodsCidr *string `mandatory:"false" json:"podsCidr"`
+
+	// The CIDR block for Kubernetes services. Optional, defaults to 10.96.0.0/16.
+	ServicesCidr *string `mandatory:"false" json:"servicesCidr"`
+}
+
+func (m KubernetesNetworkConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KubernetesNetworkConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_versions_filters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_versions_filters.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KubernetesVersionsFilters The range of kubernetes versions an addon can be configured.
+type KubernetesVersionsFilters struct {
+
+	// The earliest kubernetes version.
+	MinimalVersion *string `mandatory:"false" json:"minimalVersion"`
+
+	// The latest kubernetes version.
+	MaximumVersion *string `mandatory:"false" json:"maximumVersion"`
+
+	// The exact version of kubernetes that are compatible.
+	ExactKubernetesVersions []string `mandatory:"false" json:"exactKubernetesVersions"`
+}
+
+func (m KubernetesVersionsFilters) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KubernetesVersionsFilters) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addon_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addon_options_request_response.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListAddonOptionsRequest wrapper for the ListAddonOptions operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddonOptions.go.html to see an example of how to use ListAddonOptionsRequest.
+type ListAddonOptionsRequest struct {
+
+	// The kubernetes version to fetch the addons.
+	KubernetesVersion *string `mandatory:"true" contributesTo:"query" name:"kubernetesVersion"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"false" contributesTo:"query" name:"addonName"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListAddonOptionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListAddonOptionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAddonOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAddonOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListAddonOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAddonOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListAddonOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListAddonOptionsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAddonOptionsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAddonOptionsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListAddonOptionsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListAddonOptionsResponse wrapper for the ListAddonOptions operation
+type ListAddonOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []AddonOptionSummary instances
+	Items []AddonOptionSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListAddonOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAddonOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAddonOptionsSortOrderEnum Enum with underlying type: string
+type ListAddonOptionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAddonOptionsSortOrderEnum
+const (
+	ListAddonOptionsSortOrderAsc  ListAddonOptionsSortOrderEnum = "ASC"
+	ListAddonOptionsSortOrderDesc ListAddonOptionsSortOrderEnum = "DESC"
+)
+
+var mappingListAddonOptionsSortOrderEnum = map[string]ListAddonOptionsSortOrderEnum{
+	"ASC":  ListAddonOptionsSortOrderAsc,
+	"DESC": ListAddonOptionsSortOrderDesc,
+}
+
+var mappingListAddonOptionsSortOrderEnumLowerCase = map[string]ListAddonOptionsSortOrderEnum{
+	"asc":  ListAddonOptionsSortOrderAsc,
+	"desc": ListAddonOptionsSortOrderDesc,
+}
+
+// GetListAddonOptionsSortOrderEnumValues Enumerates the set of values for ListAddonOptionsSortOrderEnum
+func GetListAddonOptionsSortOrderEnumValues() []ListAddonOptionsSortOrderEnum {
+	values := make([]ListAddonOptionsSortOrderEnum, 0)
+	for _, v := range mappingListAddonOptionsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonOptionsSortOrderEnumStringValues Enumerates the set of values in String for ListAddonOptionsSortOrderEnum
+func GetListAddonOptionsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListAddonOptionsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonOptionsSortOrderEnum(val string) (ListAddonOptionsSortOrderEnum, bool) {
+	enum, ok := mappingListAddonOptionsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAddonOptionsSortByEnum Enum with underlying type: string
+type ListAddonOptionsSortByEnum string
+
+// Set of constants representing the allowable values for ListAddonOptionsSortByEnum
+const (
+	ListAddonOptionsSortByName        ListAddonOptionsSortByEnum = "NAME"
+	ListAddonOptionsSortByTimeCreated ListAddonOptionsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListAddonOptionsSortByEnum = map[string]ListAddonOptionsSortByEnum{
+	"NAME":         ListAddonOptionsSortByName,
+	"TIME_CREATED": ListAddonOptionsSortByTimeCreated,
+}
+
+var mappingListAddonOptionsSortByEnumLowerCase = map[string]ListAddonOptionsSortByEnum{
+	"name":         ListAddonOptionsSortByName,
+	"time_created": ListAddonOptionsSortByTimeCreated,
+}
+
+// GetListAddonOptionsSortByEnumValues Enumerates the set of values for ListAddonOptionsSortByEnum
+func GetListAddonOptionsSortByEnumValues() []ListAddonOptionsSortByEnum {
+	values := make([]ListAddonOptionsSortByEnum, 0)
+	for _, v := range mappingListAddonOptionsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonOptionsSortByEnumStringValues Enumerates the set of values in String for ListAddonOptionsSortByEnum
+func GetListAddonOptionsSortByEnumStringValues() []string {
+	return []string{
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListAddonOptionsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonOptionsSortByEnum(val string) (ListAddonOptionsSortByEnum, bool) {
+	enum, ok := mappingListAddonOptionsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addons_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addons_request_response.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListAddonsRequest wrapper for the ListAddons operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddons.go.html to see an example of how to use ListAddonsRequest.
+type ListAddonsRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListAddonsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListAddonsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAddonsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAddonsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListAddonsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAddonsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListAddonsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListAddonsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAddonsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAddonsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListAddonsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListAddonsResponse wrapper for the ListAddons operation
+type ListAddonsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []AddonSummary instances
+	Items []AddonSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListAddonsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAddonsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAddonsSortOrderEnum Enum with underlying type: string
+type ListAddonsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAddonsSortOrderEnum
+const (
+	ListAddonsSortOrderAsc  ListAddonsSortOrderEnum = "ASC"
+	ListAddonsSortOrderDesc ListAddonsSortOrderEnum = "DESC"
+)
+
+var mappingListAddonsSortOrderEnum = map[string]ListAddonsSortOrderEnum{
+	"ASC":  ListAddonsSortOrderAsc,
+	"DESC": ListAddonsSortOrderDesc,
+}
+
+var mappingListAddonsSortOrderEnumLowerCase = map[string]ListAddonsSortOrderEnum{
+	"asc":  ListAddonsSortOrderAsc,
+	"desc": ListAddonsSortOrderDesc,
+}
+
+// GetListAddonsSortOrderEnumValues Enumerates the set of values for ListAddonsSortOrderEnum
+func GetListAddonsSortOrderEnumValues() []ListAddonsSortOrderEnum {
+	values := make([]ListAddonsSortOrderEnum, 0)
+	for _, v := range mappingListAddonsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonsSortOrderEnumStringValues Enumerates the set of values in String for ListAddonsSortOrderEnum
+func GetListAddonsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListAddonsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonsSortOrderEnum(val string) (ListAddonsSortOrderEnum, bool) {
+	enum, ok := mappingListAddonsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAddonsSortByEnum Enum with underlying type: string
+type ListAddonsSortByEnum string
+
+// Set of constants representing the allowable values for ListAddonsSortByEnum
+const (
+	ListAddonsSortByName        ListAddonsSortByEnum = "NAME"
+	ListAddonsSortByTimeCreated ListAddonsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListAddonsSortByEnum = map[string]ListAddonsSortByEnum{
+	"NAME":         ListAddonsSortByName,
+	"TIME_CREATED": ListAddonsSortByTimeCreated,
+}
+
+var mappingListAddonsSortByEnumLowerCase = map[string]ListAddonsSortByEnum{
+	"name":         ListAddonsSortByName,
+	"time_created": ListAddonsSortByTimeCreated,
+}
+
+// GetListAddonsSortByEnumValues Enumerates the set of values for ListAddonsSortByEnum
+func GetListAddonsSortByEnumValues() []ListAddonsSortByEnum {
+	values := make([]ListAddonsSortByEnum, 0)
+	for _, v := range mappingListAddonsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonsSortByEnumStringValues Enumerates the set of values in String for ListAddonsSortByEnum
+func GetListAddonsSortByEnumStringValues() []string {
+	return []string{
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListAddonsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonsSortByEnum(val string) (ListAddonsSortByEnum, bool) {
+	enum, ok := mappingListAddonsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_clusters_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_clusters_request_response.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListClustersRequest wrapper for the ListClusters operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListClusters.go.html to see an example of how to use ListClustersRequest.
+type ListClustersRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A cluster lifecycle state to filter on. Can have multiple parameters of this name.
+	LifecycleState []ClusterLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListClustersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListClustersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListClustersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListClustersRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListClustersRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListClustersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListClustersRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingClusterLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if _, ok := GetMappingListClustersSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListClustersSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListClustersSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListClustersSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListClustersResponse wrapper for the ListClusters operation
+type ListClustersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ClusterSummary instances
+	Items []ClusterSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListClustersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListClustersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListClustersSortOrderEnum Enum with underlying type: string
+type ListClustersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListClustersSortOrderEnum
+const (
+	ListClustersSortOrderAsc  ListClustersSortOrderEnum = "ASC"
+	ListClustersSortOrderDesc ListClustersSortOrderEnum = "DESC"
+)
+
+var mappingListClustersSortOrderEnum = map[string]ListClustersSortOrderEnum{
+	"ASC":  ListClustersSortOrderAsc,
+	"DESC": ListClustersSortOrderDesc,
+}
+
+var mappingListClustersSortOrderEnumLowerCase = map[string]ListClustersSortOrderEnum{
+	"asc":  ListClustersSortOrderAsc,
+	"desc": ListClustersSortOrderDesc,
+}
+
+// GetListClustersSortOrderEnumValues Enumerates the set of values for ListClustersSortOrderEnum
+func GetListClustersSortOrderEnumValues() []ListClustersSortOrderEnum {
+	values := make([]ListClustersSortOrderEnum, 0)
+	for _, v := range mappingListClustersSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListClustersSortOrderEnumStringValues Enumerates the set of values in String for ListClustersSortOrderEnum
+func GetListClustersSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListClustersSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListClustersSortOrderEnum(val string) (ListClustersSortOrderEnum, bool) {
+	enum, ok := mappingListClustersSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListClustersSortByEnum Enum with underlying type: string
+type ListClustersSortByEnum string
+
+// Set of constants representing the allowable values for ListClustersSortByEnum
+const (
+	ListClustersSortById          ListClustersSortByEnum = "ID"
+	ListClustersSortByName        ListClustersSortByEnum = "NAME"
+	ListClustersSortByTimeCreated ListClustersSortByEnum = "TIME_CREATED"
+)
+
+var mappingListClustersSortByEnum = map[string]ListClustersSortByEnum{
+	"ID":           ListClustersSortById,
+	"NAME":         ListClustersSortByName,
+	"TIME_CREATED": ListClustersSortByTimeCreated,
+}
+
+var mappingListClustersSortByEnumLowerCase = map[string]ListClustersSortByEnum{
+	"id":           ListClustersSortById,
+	"name":         ListClustersSortByName,
+	"time_created": ListClustersSortByTimeCreated,
+}
+
+// GetListClustersSortByEnumValues Enumerates the set of values for ListClustersSortByEnum
+func GetListClustersSortByEnumValues() []ListClustersSortByEnum {
+	values := make([]ListClustersSortByEnum, 0)
+	for _, v := range mappingListClustersSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListClustersSortByEnumStringValues Enumerates the set of values in String for ListClustersSortByEnum
+func GetListClustersSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListClustersSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListClustersSortByEnum(val string) (ListClustersSortByEnum, bool) {
+	enum, ok := mappingListClustersSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_node_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_node_pools_request_response.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListNodePoolsRequest wrapper for the ListNodePools operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListNodePools.go.html to see an example of how to use ListNodePoolsRequest.
+type ListNodePoolsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListNodePoolsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListNodePoolsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A list of nodepool lifecycle states on which to filter on, matching any of the list items (OR logic). eg. [ACTIVE, DELETING]
+	LifecycleState []NodePoolLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListNodePoolsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListNodePoolsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListNodePoolsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListNodePoolsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListNodePoolsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListNodePoolsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListNodePoolsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListNodePoolsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListNodePoolsSortByEnumStringValues(), ",")))
+	}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingNodePoolLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListNodePoolsResponse wrapper for the ListNodePools operation
+type ListNodePoolsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []NodePoolSummary instances
+	Items []NodePoolSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListNodePoolsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListNodePoolsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListNodePoolsSortOrderEnum Enum with underlying type: string
+type ListNodePoolsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListNodePoolsSortOrderEnum
+const (
+	ListNodePoolsSortOrderAsc  ListNodePoolsSortOrderEnum = "ASC"
+	ListNodePoolsSortOrderDesc ListNodePoolsSortOrderEnum = "DESC"
+)
+
+var mappingListNodePoolsSortOrderEnum = map[string]ListNodePoolsSortOrderEnum{
+	"ASC":  ListNodePoolsSortOrderAsc,
+	"DESC": ListNodePoolsSortOrderDesc,
+}
+
+var mappingListNodePoolsSortOrderEnumLowerCase = map[string]ListNodePoolsSortOrderEnum{
+	"asc":  ListNodePoolsSortOrderAsc,
+	"desc": ListNodePoolsSortOrderDesc,
+}
+
+// GetListNodePoolsSortOrderEnumValues Enumerates the set of values for ListNodePoolsSortOrderEnum
+func GetListNodePoolsSortOrderEnumValues() []ListNodePoolsSortOrderEnum {
+	values := make([]ListNodePoolsSortOrderEnum, 0)
+	for _, v := range mappingListNodePoolsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNodePoolsSortOrderEnumStringValues Enumerates the set of values in String for ListNodePoolsSortOrderEnum
+func GetListNodePoolsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListNodePoolsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNodePoolsSortOrderEnum(val string) (ListNodePoolsSortOrderEnum, bool) {
+	enum, ok := mappingListNodePoolsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListNodePoolsSortByEnum Enum with underlying type: string
+type ListNodePoolsSortByEnum string
+
+// Set of constants representing the allowable values for ListNodePoolsSortByEnum
+const (
+	ListNodePoolsSortById          ListNodePoolsSortByEnum = "ID"
+	ListNodePoolsSortByName        ListNodePoolsSortByEnum = "NAME"
+	ListNodePoolsSortByTimeCreated ListNodePoolsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListNodePoolsSortByEnum = map[string]ListNodePoolsSortByEnum{
+	"ID":           ListNodePoolsSortById,
+	"NAME":         ListNodePoolsSortByName,
+	"TIME_CREATED": ListNodePoolsSortByTimeCreated,
+}
+
+var mappingListNodePoolsSortByEnumLowerCase = map[string]ListNodePoolsSortByEnum{
+	"id":           ListNodePoolsSortById,
+	"name":         ListNodePoolsSortByName,
+	"time_created": ListNodePoolsSortByTimeCreated,
+}
+
+// GetListNodePoolsSortByEnumValues Enumerates the set of values for ListNodePoolsSortByEnum
+func GetListNodePoolsSortByEnumValues() []ListNodePoolsSortByEnum {
+	values := make([]ListNodePoolsSortByEnum, 0)
+	for _, v := range mappingListNodePoolsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNodePoolsSortByEnumStringValues Enumerates the set of values in String for ListNodePoolsSortByEnum
+func GetListNodePoolsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListNodePoolsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNodePoolsSortByEnum(val string) (ListNodePoolsSortByEnum, bool) {
+	enum, ok := mappingListNodePoolsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_pod_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_pod_shapes_request_response.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListPodShapesRequest wrapper for the ListPodShapes operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListPodShapes.go.html to see an example of how to use ListPodShapesRequest.
+type ListPodShapesRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The availability domain of the pod shape.
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListPodShapesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListPodShapesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPodShapesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPodShapesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListPodShapesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPodShapesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListPodShapesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListPodShapesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListPodShapesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListPodShapesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListPodShapesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListPodShapesResponse wrapper for the ListPodShapes operation
+type ListPodShapesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []PodShapeSummary instances
+	Items []PodShapeSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListPodShapesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPodShapesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPodShapesSortOrderEnum Enum with underlying type: string
+type ListPodShapesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPodShapesSortOrderEnum
+const (
+	ListPodShapesSortOrderAsc  ListPodShapesSortOrderEnum = "ASC"
+	ListPodShapesSortOrderDesc ListPodShapesSortOrderEnum = "DESC"
+)
+
+var mappingListPodShapesSortOrderEnum = map[string]ListPodShapesSortOrderEnum{
+	"ASC":  ListPodShapesSortOrderAsc,
+	"DESC": ListPodShapesSortOrderDesc,
+}
+
+var mappingListPodShapesSortOrderEnumLowerCase = map[string]ListPodShapesSortOrderEnum{
+	"asc":  ListPodShapesSortOrderAsc,
+	"desc": ListPodShapesSortOrderDesc,
+}
+
+// GetListPodShapesSortOrderEnumValues Enumerates the set of values for ListPodShapesSortOrderEnum
+func GetListPodShapesSortOrderEnumValues() []ListPodShapesSortOrderEnum {
+	values := make([]ListPodShapesSortOrderEnum, 0)
+	for _, v := range mappingListPodShapesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListPodShapesSortOrderEnumStringValues Enumerates the set of values in String for ListPodShapesSortOrderEnum
+func GetListPodShapesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListPodShapesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListPodShapesSortOrderEnum(val string) (ListPodShapesSortOrderEnum, bool) {
+	enum, ok := mappingListPodShapesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListPodShapesSortByEnum Enum with underlying type: string
+type ListPodShapesSortByEnum string
+
+// Set of constants representing the allowable values for ListPodShapesSortByEnum
+const (
+	ListPodShapesSortById          ListPodShapesSortByEnum = "ID"
+	ListPodShapesSortByName        ListPodShapesSortByEnum = "NAME"
+	ListPodShapesSortByTimeCreated ListPodShapesSortByEnum = "TIME_CREATED"
+)
+
+var mappingListPodShapesSortByEnum = map[string]ListPodShapesSortByEnum{
+	"ID":           ListPodShapesSortById,
+	"NAME":         ListPodShapesSortByName,
+	"TIME_CREATED": ListPodShapesSortByTimeCreated,
+}
+
+var mappingListPodShapesSortByEnumLowerCase = map[string]ListPodShapesSortByEnum{
+	"id":           ListPodShapesSortById,
+	"name":         ListPodShapesSortByName,
+	"time_created": ListPodShapesSortByTimeCreated,
+}
+
+// GetListPodShapesSortByEnumValues Enumerates the set of values for ListPodShapesSortByEnum
+func GetListPodShapesSortByEnumValues() []ListPodShapesSortByEnum {
+	values := make([]ListPodShapesSortByEnum, 0)
+	for _, v := range mappingListPodShapesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListPodShapesSortByEnumStringValues Enumerates the set of values in String for ListPodShapesSortByEnum
+func GetListPodShapesSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListPodShapesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListPodShapesSortByEnum(val string) (ListPodShapesSortByEnum, bool) {
+	enum, ok := mappingListPodShapesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_node_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_node_pools_request_response.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListVirtualNodePoolsRequest wrapper for the ListVirtualNodePools operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodePools.go.html to see an example of how to use ListVirtualNodePoolsRequest.
+type ListVirtualNodePoolsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListVirtualNodePoolsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListVirtualNodePoolsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// A virtual node pool lifecycle state to filter on. Can have multiple parameters of this name.
+	LifecycleState []VirtualNodePoolLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVirtualNodePoolsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVirtualNodePoolsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListVirtualNodePoolsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVirtualNodePoolsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListVirtualNodePoolsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListVirtualNodePoolsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListVirtualNodePoolsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListVirtualNodePoolsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListVirtualNodePoolsSortByEnumStringValues(), ",")))
+	}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListVirtualNodePoolsResponse wrapper for the ListVirtualNodePools operation
+type ListVirtualNodePoolsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VirtualNodePoolSummary instances
+	Items []VirtualNodePoolSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListVirtualNodePoolsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVirtualNodePoolsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVirtualNodePoolsSortOrderEnum Enum with underlying type: string
+type ListVirtualNodePoolsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodePoolsSortOrderEnum
+const (
+	ListVirtualNodePoolsSortOrderAsc  ListVirtualNodePoolsSortOrderEnum = "ASC"
+	ListVirtualNodePoolsSortOrderDesc ListVirtualNodePoolsSortOrderEnum = "DESC"
+)
+
+var mappingListVirtualNodePoolsSortOrderEnum = map[string]ListVirtualNodePoolsSortOrderEnum{
+	"ASC":  ListVirtualNodePoolsSortOrderAsc,
+	"DESC": ListVirtualNodePoolsSortOrderDesc,
+}
+
+var mappingListVirtualNodePoolsSortOrderEnumLowerCase = map[string]ListVirtualNodePoolsSortOrderEnum{
+	"asc":  ListVirtualNodePoolsSortOrderAsc,
+	"desc": ListVirtualNodePoolsSortOrderDesc,
+}
+
+// GetListVirtualNodePoolsSortOrderEnumValues Enumerates the set of values for ListVirtualNodePoolsSortOrderEnum
+func GetListVirtualNodePoolsSortOrderEnumValues() []ListVirtualNodePoolsSortOrderEnum {
+	values := make([]ListVirtualNodePoolsSortOrderEnum, 0)
+	for _, v := range mappingListVirtualNodePoolsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodePoolsSortOrderEnumStringValues Enumerates the set of values in String for ListVirtualNodePoolsSortOrderEnum
+func GetListVirtualNodePoolsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListVirtualNodePoolsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodePoolsSortOrderEnum(val string) (ListVirtualNodePoolsSortOrderEnum, bool) {
+	enum, ok := mappingListVirtualNodePoolsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListVirtualNodePoolsSortByEnum Enum with underlying type: string
+type ListVirtualNodePoolsSortByEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodePoolsSortByEnum
+const (
+	ListVirtualNodePoolsSortById          ListVirtualNodePoolsSortByEnum = "ID"
+	ListVirtualNodePoolsSortByName        ListVirtualNodePoolsSortByEnum = "NAME"
+	ListVirtualNodePoolsSortByTimeCreated ListVirtualNodePoolsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListVirtualNodePoolsSortByEnum = map[string]ListVirtualNodePoolsSortByEnum{
+	"ID":           ListVirtualNodePoolsSortById,
+	"NAME":         ListVirtualNodePoolsSortByName,
+	"TIME_CREATED": ListVirtualNodePoolsSortByTimeCreated,
+}
+
+var mappingListVirtualNodePoolsSortByEnumLowerCase = map[string]ListVirtualNodePoolsSortByEnum{
+	"id":           ListVirtualNodePoolsSortById,
+	"name":         ListVirtualNodePoolsSortByName,
+	"time_created": ListVirtualNodePoolsSortByTimeCreated,
+}
+
+// GetListVirtualNodePoolsSortByEnumValues Enumerates the set of values for ListVirtualNodePoolsSortByEnum
+func GetListVirtualNodePoolsSortByEnumValues() []ListVirtualNodePoolsSortByEnum {
+	values := make([]ListVirtualNodePoolsSortByEnum, 0)
+	for _, v := range mappingListVirtualNodePoolsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodePoolsSortByEnumStringValues Enumerates the set of values in String for ListVirtualNodePoolsSortByEnum
+func GetListVirtualNodePoolsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListVirtualNodePoolsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodePoolsSortByEnum(val string) (ListVirtualNodePoolsSortByEnum, bool) {
+	enum, ok := mappingListVirtualNodePoolsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_nodes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_nodes_request_response.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListVirtualNodesRequest wrapper for the ListVirtualNodes operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodes.go.html to see an example of how to use ListVirtualNodesRequest.
+type ListVirtualNodesRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListVirtualNodesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListVirtualNodesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVirtualNodesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVirtualNodesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListVirtualNodesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVirtualNodesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListVirtualNodesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListVirtualNodesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListVirtualNodesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListVirtualNodesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListVirtualNodesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListVirtualNodesResponse wrapper for the ListVirtualNodes operation
+type ListVirtualNodesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VirtualNodeSummary instances
+	Items []VirtualNodeSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListVirtualNodesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVirtualNodesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVirtualNodesSortOrderEnum Enum with underlying type: string
+type ListVirtualNodesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodesSortOrderEnum
+const (
+	ListVirtualNodesSortOrderAsc  ListVirtualNodesSortOrderEnum = "ASC"
+	ListVirtualNodesSortOrderDesc ListVirtualNodesSortOrderEnum = "DESC"
+)
+
+var mappingListVirtualNodesSortOrderEnum = map[string]ListVirtualNodesSortOrderEnum{
+	"ASC":  ListVirtualNodesSortOrderAsc,
+	"DESC": ListVirtualNodesSortOrderDesc,
+}
+
+var mappingListVirtualNodesSortOrderEnumLowerCase = map[string]ListVirtualNodesSortOrderEnum{
+	"asc":  ListVirtualNodesSortOrderAsc,
+	"desc": ListVirtualNodesSortOrderDesc,
+}
+
+// GetListVirtualNodesSortOrderEnumValues Enumerates the set of values for ListVirtualNodesSortOrderEnum
+func GetListVirtualNodesSortOrderEnumValues() []ListVirtualNodesSortOrderEnum {
+	values := make([]ListVirtualNodesSortOrderEnum, 0)
+	for _, v := range mappingListVirtualNodesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodesSortOrderEnumStringValues Enumerates the set of values in String for ListVirtualNodesSortOrderEnum
+func GetListVirtualNodesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListVirtualNodesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodesSortOrderEnum(val string) (ListVirtualNodesSortOrderEnum, bool) {
+	enum, ok := mappingListVirtualNodesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListVirtualNodesSortByEnum Enum with underlying type: string
+type ListVirtualNodesSortByEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodesSortByEnum
+const (
+	ListVirtualNodesSortById          ListVirtualNodesSortByEnum = "ID"
+	ListVirtualNodesSortByName        ListVirtualNodesSortByEnum = "NAME"
+	ListVirtualNodesSortByTimeCreated ListVirtualNodesSortByEnum = "TIME_CREATED"
+)
+
+var mappingListVirtualNodesSortByEnum = map[string]ListVirtualNodesSortByEnum{
+	"ID":           ListVirtualNodesSortById,
+	"NAME":         ListVirtualNodesSortByName,
+	"TIME_CREATED": ListVirtualNodesSortByTimeCreated,
+}
+
+var mappingListVirtualNodesSortByEnumLowerCase = map[string]ListVirtualNodesSortByEnum{
+	"id":           ListVirtualNodesSortById,
+	"name":         ListVirtualNodesSortByName,
+	"time_created": ListVirtualNodesSortByTimeCreated,
+}
+
+// GetListVirtualNodesSortByEnumValues Enumerates the set of values for ListVirtualNodesSortByEnum
+func GetListVirtualNodesSortByEnumValues() []ListVirtualNodesSortByEnum {
+	values := make([]ListVirtualNodesSortByEnum, 0)
+	for _, v := range mappingListVirtualNodesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodesSortByEnumStringValues Enumerates the set of values in String for ListVirtualNodesSortByEnum
+func GetListVirtualNodesSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListVirtualNodesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodesSortByEnum(val string) (ListVirtualNodesSortByEnum, bool) {
+	enum, ok := mappingListVirtualNodesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_errors_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestErrorsRequest wrapper for the ListWorkRequestErrors operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrorsRequest.
+type ListWorkRequestErrorsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestErrorsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestErrorsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestErrorsResponse wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The []WorkRequestError instance
+	Items []WorkRequestError `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestErrorsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestErrorsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_logs_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestLogsRequest wrapper for the ListWorkRequestLogs operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogsRequest.
+type ListWorkRequestLogsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestLogsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestLogsResponse wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The []WorkRequestLogEntry instance
+	Items []WorkRequestLogEntry `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_requests_request_response.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestsRequest wrapper for the ListWorkRequests operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequests.go.html to see an example of how to use ListWorkRequestsRequest.
+type ListWorkRequestsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The OCID of the resource associated with a work request
+	ResourceId *string `mandatory:"false" contributesTo:"query" name:"resourceId"`
+
+	// Type of the resource associated with a work request
+	ResourceType ListWorkRequestsResourceTypeEnum `mandatory:"false" contributesTo:"query" name:"resourceType" omitEmpty:"true"`
+
+	// A work request status to filter on. Can have multiple parameters of this name.
+	Status []string `contributesTo:"query" name:"status" collectionFormat:"multi"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListWorkRequestsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListWorkRequestsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListWorkRequestsResourceTypeEnum(string(request.ResourceType)); !ok && request.ResourceType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ResourceType: %s. Supported values are: %s.", request.ResourceType, strings.Join(GetListWorkRequestsResourceTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWorkRequestsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListWorkRequestsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWorkRequestsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListWorkRequestsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestsResponse wrapper for the ListWorkRequests operation
+type ListWorkRequestsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestSummary instances
+	Items []WorkRequestSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkRequestsResourceTypeEnum Enum with underlying type: string
+type ListWorkRequestsResourceTypeEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsResourceTypeEnum
+const (
+	ListWorkRequestsResourceTypeCluster  ListWorkRequestsResourceTypeEnum = "CLUSTER"
+	ListWorkRequestsResourceTypeNodepool ListWorkRequestsResourceTypeEnum = "NODEPOOL"
+)
+
+var mappingListWorkRequestsResourceTypeEnum = map[string]ListWorkRequestsResourceTypeEnum{
+	"CLUSTER":  ListWorkRequestsResourceTypeCluster,
+	"NODEPOOL": ListWorkRequestsResourceTypeNodepool,
+}
+
+var mappingListWorkRequestsResourceTypeEnumLowerCase = map[string]ListWorkRequestsResourceTypeEnum{
+	"cluster":  ListWorkRequestsResourceTypeCluster,
+	"nodepool": ListWorkRequestsResourceTypeNodepool,
+}
+
+// GetListWorkRequestsResourceTypeEnumValues Enumerates the set of values for ListWorkRequestsResourceTypeEnum
+func GetListWorkRequestsResourceTypeEnumValues() []ListWorkRequestsResourceTypeEnum {
+	values := make([]ListWorkRequestsResourceTypeEnum, 0)
+	for _, v := range mappingListWorkRequestsResourceTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsResourceTypeEnumStringValues Enumerates the set of values in String for ListWorkRequestsResourceTypeEnum
+func GetListWorkRequestsResourceTypeEnumStringValues() []string {
+	return []string{
+		"CLUSTER",
+		"NODEPOOL",
+	}
+}
+
+// GetMappingListWorkRequestsResourceTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsResourceTypeEnum(val string) (ListWorkRequestsResourceTypeEnum, bool) {
+	enum, ok := mappingListWorkRequestsResourceTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWorkRequestsSortOrderEnum Enum with underlying type: string
+type ListWorkRequestsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortOrderEnum
+const (
+	ListWorkRequestsSortOrderAsc  ListWorkRequestsSortOrderEnum = "ASC"
+	ListWorkRequestsSortOrderDesc ListWorkRequestsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkRequestsSortOrderEnum = map[string]ListWorkRequestsSortOrderEnum{
+	"ASC":  ListWorkRequestsSortOrderAsc,
+	"DESC": ListWorkRequestsSortOrderDesc,
+}
+
+var mappingListWorkRequestsSortOrderEnumLowerCase = map[string]ListWorkRequestsSortOrderEnum{
+	"asc":  ListWorkRequestsSortOrderAsc,
+	"desc": ListWorkRequestsSortOrderDesc,
+}
+
+// GetListWorkRequestsSortOrderEnumValues Enumerates the set of values for ListWorkRequestsSortOrderEnum
+func GetListWorkRequestsSortOrderEnumValues() []ListWorkRequestsSortOrderEnum {
+	values := make([]ListWorkRequestsSortOrderEnum, 0)
+	for _, v := range mappingListWorkRequestsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsSortOrderEnumStringValues Enumerates the set of values in String for ListWorkRequestsSortOrderEnum
+func GetListWorkRequestsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListWorkRequestsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsSortOrderEnum(val string) (ListWorkRequestsSortOrderEnum, bool) {
+	enum, ok := mappingListWorkRequestsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWorkRequestsSortByEnum Enum with underlying type: string
+type ListWorkRequestsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortByEnum
+const (
+	ListWorkRequestsSortById            ListWorkRequestsSortByEnum = "ID"
+	ListWorkRequestsSortByOperationType ListWorkRequestsSortByEnum = "OPERATION_TYPE"
+	ListWorkRequestsSortByStatus        ListWorkRequestsSortByEnum = "STATUS"
+	ListWorkRequestsSortByTimeAccepted  ListWorkRequestsSortByEnum = "TIME_ACCEPTED"
+	ListWorkRequestsSortByTimeStarted   ListWorkRequestsSortByEnum = "TIME_STARTED"
+	ListWorkRequestsSortByTimeFinished  ListWorkRequestsSortByEnum = "TIME_FINISHED"
+)
+
+var mappingListWorkRequestsSortByEnum = map[string]ListWorkRequestsSortByEnum{
+	"ID":             ListWorkRequestsSortById,
+	"OPERATION_TYPE": ListWorkRequestsSortByOperationType,
+	"STATUS":         ListWorkRequestsSortByStatus,
+	"TIME_ACCEPTED":  ListWorkRequestsSortByTimeAccepted,
+	"TIME_STARTED":   ListWorkRequestsSortByTimeStarted,
+	"TIME_FINISHED":  ListWorkRequestsSortByTimeFinished,
+}
+
+var mappingListWorkRequestsSortByEnumLowerCase = map[string]ListWorkRequestsSortByEnum{
+	"id":             ListWorkRequestsSortById,
+	"operation_type": ListWorkRequestsSortByOperationType,
+	"status":         ListWorkRequestsSortByStatus,
+	"time_accepted":  ListWorkRequestsSortByTimeAccepted,
+	"time_started":   ListWorkRequestsSortByTimeStarted,
+	"time_finished":  ListWorkRequestsSortByTimeFinished,
+}
+
+// GetListWorkRequestsSortByEnumValues Enumerates the set of values for ListWorkRequestsSortByEnum
+func GetListWorkRequestsSortByEnumValues() []ListWorkRequestsSortByEnum {
+	values := make([]ListWorkRequestsSortByEnum, 0)
+	for _, v := range mappingListWorkRequestsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsSortByEnumStringValues Enumerates the set of values in String for ListWorkRequestsSortByEnum
+func GetListWorkRequestsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"OPERATION_TYPE",
+		"STATUS",
+		"TIME_ACCEPTED",
+		"TIME_STARTED",
+		"TIME_FINISHED",
+	}
+}
+
+// GetMappingListWorkRequestsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsSortByEnum(val string) (ListWorkRequestsSortByEnum, bool) {
+	enum, ok := mappingListWorkRequestsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Node The properties that define a node.
+type Node struct {
+
+	// The OCID of the compute instance backing this node.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the node.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes this node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this node is placed.
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The OCID of the subnet in which this node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// The OCID of the node pool to which this node belongs.
+	NodePoolId *string `mandatory:"false" json:"nodePoolId"`
+
+	// The fault domain of this node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The private IP address of this node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// The public IP address of this node.
+	PublicIp *string `mandatory:"false" json:"publicIp"`
+
+	// An error that may be associated with the node.
+	NodeError *NodeError `mandatory:"false" json:"nodeError"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The state of the node.
+	LifecycleState NodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+}
+
+func (m Node) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Node) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NodeLifecycleStateEnum Enum with underlying type: string
+type NodeLifecycleStateEnum string
+
+// Set of constants representing the allowable values for NodeLifecycleStateEnum
+const (
+	NodeLifecycleStateCreating NodeLifecycleStateEnum = "CREATING"
+	NodeLifecycleStateActive   NodeLifecycleStateEnum = "ACTIVE"
+	NodeLifecycleStateUpdating NodeLifecycleStateEnum = "UPDATING"
+	NodeLifecycleStateDeleting NodeLifecycleStateEnum = "DELETING"
+	NodeLifecycleStateDeleted  NodeLifecycleStateEnum = "DELETED"
+	NodeLifecycleStateFailing  NodeLifecycleStateEnum = "FAILING"
+	NodeLifecycleStateInactive NodeLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingNodeLifecycleStateEnum = map[string]NodeLifecycleStateEnum{
+	"CREATING": NodeLifecycleStateCreating,
+	"ACTIVE":   NodeLifecycleStateActive,
+	"UPDATING": NodeLifecycleStateUpdating,
+	"DELETING": NodeLifecycleStateDeleting,
+	"DELETED":  NodeLifecycleStateDeleted,
+	"FAILING":  NodeLifecycleStateFailing,
+	"INACTIVE": NodeLifecycleStateInactive,
+}
+
+var mappingNodeLifecycleStateEnumLowerCase = map[string]NodeLifecycleStateEnum{
+	"creating": NodeLifecycleStateCreating,
+	"active":   NodeLifecycleStateActive,
+	"updating": NodeLifecycleStateUpdating,
+	"deleting": NodeLifecycleStateDeleting,
+	"deleted":  NodeLifecycleStateDeleted,
+	"failing":  NodeLifecycleStateFailing,
+	"inactive": NodeLifecycleStateInactive,
+}
+
+// GetNodeLifecycleStateEnumValues Enumerates the set of values for NodeLifecycleStateEnum
+func GetNodeLifecycleStateEnumValues() []NodeLifecycleStateEnum {
+	values := make([]NodeLifecycleStateEnum, 0)
+	for _, v := range mappingNodeLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodeLifecycleStateEnumStringValues Enumerates the set of values in String for NodeLifecycleStateEnum
+func GetNodeLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILING",
+		"INACTIVE",
+	}
+}
+
+// GetMappingNodeLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodeLifecycleStateEnum(val string) (NodeLifecycleStateEnum, bool) {
+	enum, ok := mappingNodeLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_error.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeError The properties that define an upstream error while managing a node.
+type NodeError struct {
+
+	// A short error code that defines the upstream error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human-readable error string of the upstream error.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The status of the HTTP response encountered in the upstream error.
+	Status *string `mandatory:"false" json:"status"`
+
+	// Unique Oracle-assigned identifier for the upstream request. If you need to contact Oracle about a particular upstream request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" json:"opc-request-id"`
+}
+
+func (m NodeError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_eviction_node_pool_settings.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_eviction_node_pool_settings.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeEvictionNodePoolSettings Node Eviction Details configuration
+type NodeEvictionNodePoolSettings struct {
+
+	// Duration after which OKE will give up eviction of the pods on the node. PT0M will indicate you want to delete the node without cordon and drain.
+	// Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	EvictionGraceDuration *string `mandatory:"false" json:"evictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeleteAfterGraceDuration *bool `mandatory:"false" json:"isForceDeleteAfterGraceDuration"`
+}
+
+func (m NodeEvictionNodePoolSettings) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeEvictionNodePoolSettings) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePool A pool of compute nodes attached to a cluster. Avoid entering confidential information.
+type NodePool struct {
+
+	// The OCID of the node pool.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The state of the nodepool.
+	LifecycleState NodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the nodepool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"false" json:"clusterId"`
+
+	// The name of the node pool.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Deprecated. see `nodeSource`. The OCID of the image running on the nodes in the node pool.
+	NodeImageId *string `mandatory:"false" json:"nodeImageId"`
+
+	// Deprecated. see `nodeSource`. The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// The shape configuration of the nodes.
+	NodeShapeConfig *NodeShapeConfig `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
+	NodeSource NodeSourceOption `mandatory:"false" json:"nodeSource"`
+
+	// Source running on the nodes in the node pool.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The number of nodes in each subnet.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The nodes in the node pool.
+	Nodes []Node `mandatory:"false" json:"nodes"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+}
+
+func (m NodePool) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePool) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePool) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                           *string                           `json:"id"`
+		LifecycleState               NodePoolLifecycleStateEnum        `json:"lifecycleState"`
+		LifecycleDetails             *string                           `json:"lifecycleDetails"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeImageId                  *string                           `json:"nodeImageId"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeShapeConfig              *NodeShapeConfig                  `json:"nodeShapeConfig"`
+		NodeSource                   nodesourceoption                  `json:"nodeSource"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		Nodes                        []Node                            `json:"nodes"`
+		NodeConfigDetails            *NodePoolNodeConfigDetails        `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                   map[string]map[string]interface{} `json:"systemTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeMetadata = model.NodeMetadata
+
+	m.NodeImageId = model.NodeImageId
+
+	m.NodeImageName = model.NodeImageName
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	nn, e = model.NodeSource.UnmarshalPolymorphicJSON(model.NodeSource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSource = nn.(NodeSourceOption)
+	} else {
+		m.NodeSource = nil
+	}
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShape = model.NodeShape
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	for i, n := range model.InitialNodeLabels {
+		m.InitialNodeLabels[i] = n
+	}
+
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	for i, n := range model.SubnetIds {
+		m.SubnetIds[i] = n
+	}
+
+	m.Nodes = make([]Node, len(model.Nodes))
+	for i, n := range model.Nodes {
+		m.Nodes[i] = n
+	}
+
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_lifecycle_state.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// NodePoolLifecycleStateEnum Enum with underlying type: string
+type NodePoolLifecycleStateEnum string
+
+// Set of constants representing the allowable values for NodePoolLifecycleStateEnum
+const (
+	NodePoolLifecycleStateDeleted        NodePoolLifecycleStateEnum = "DELETED"
+	NodePoolLifecycleStateCreating       NodePoolLifecycleStateEnum = "CREATING"
+	NodePoolLifecycleStateActive         NodePoolLifecycleStateEnum = "ACTIVE"
+	NodePoolLifecycleStateUpdating       NodePoolLifecycleStateEnum = "UPDATING"
+	NodePoolLifecycleStateDeleting       NodePoolLifecycleStateEnum = "DELETING"
+	NodePoolLifecycleStateFailed         NodePoolLifecycleStateEnum = "FAILED"
+	NodePoolLifecycleStateInactive       NodePoolLifecycleStateEnum = "INACTIVE"
+	NodePoolLifecycleStateNeedsAttention NodePoolLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingNodePoolLifecycleStateEnum = map[string]NodePoolLifecycleStateEnum{
+	"DELETED":         NodePoolLifecycleStateDeleted,
+	"CREATING":        NodePoolLifecycleStateCreating,
+	"ACTIVE":          NodePoolLifecycleStateActive,
+	"UPDATING":        NodePoolLifecycleStateUpdating,
+	"DELETING":        NodePoolLifecycleStateDeleting,
+	"FAILED":          NodePoolLifecycleStateFailed,
+	"INACTIVE":        NodePoolLifecycleStateInactive,
+	"NEEDS_ATTENTION": NodePoolLifecycleStateNeedsAttention,
+}
+
+var mappingNodePoolLifecycleStateEnumLowerCase = map[string]NodePoolLifecycleStateEnum{
+	"deleted":         NodePoolLifecycleStateDeleted,
+	"creating":        NodePoolLifecycleStateCreating,
+	"active":          NodePoolLifecycleStateActive,
+	"updating":        NodePoolLifecycleStateUpdating,
+	"deleting":        NodePoolLifecycleStateDeleting,
+	"failed":          NodePoolLifecycleStateFailed,
+	"inactive":        NodePoolLifecycleStateInactive,
+	"needs_attention": NodePoolLifecycleStateNeedsAttention,
+}
+
+// GetNodePoolLifecycleStateEnumValues Enumerates the set of values for NodePoolLifecycleStateEnum
+func GetNodePoolLifecycleStateEnumValues() []NodePoolLifecycleStateEnum {
+	values := make([]NodePoolLifecycleStateEnum, 0)
+	for _, v := range mappingNodePoolLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodePoolLifecycleStateEnumStringValues Enumerates the set of values in String for NodePoolLifecycleStateEnum
+func GetNodePoolLifecycleStateEnumStringValues() []string {
+	return []string{
+		"DELETED",
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"FAILED",
+		"INACTIVE",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingNodePoolLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodePoolLifecycleStateEnum(val string) (NodePoolLifecycleStateEnum, bool) {
+	enum, ok := mappingNodePoolLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_node_config_details.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type NodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m NodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Size                            *int                              `json:"size"`
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Size = model.Size
+
+	m.NsgIds = make([]string, len(model.NsgIds))
+	for i, n := range model.NsgIds {
+		m.NsgIds[i] = n
+	}
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	for i, n := range model.PlacementConfigs {
+		m.PlacementConfigs[i] = n
+	}
+
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_options.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolOptions Options for creating or updating node pools.
+type NodePoolOptions struct {
+
+	// Available Kubernetes versions.
+	KubernetesVersions []string `mandatory:"false" json:"kubernetesVersions"`
+
+	// Available shapes for nodes.
+	Shapes []string `mandatory:"false" json:"shapes"`
+
+	// Deprecated. See sources.
+	// When creating a node pool using the `CreateNodePoolDetails` object, only image names contained in this
+	// property can be passed to the `nodeImageName` property.
+	Images []string `mandatory:"false" json:"images"`
+
+	// Available source of the node.
+	Sources []NodeSourceOption `mandatory:"false" json:"sources"`
+}
+
+func (m NodePoolOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolOptions) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersions []string           `json:"kubernetesVersions"`
+		Shapes             []string           `json:"shapes"`
+		Images             []string           `json:"images"`
+		Sources            []nodesourceoption `json:"sources"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersions = make([]string, len(model.KubernetesVersions))
+	for i, n := range model.KubernetesVersions {
+		m.KubernetesVersions[i] = n
+	}
+
+	m.Shapes = make([]string, len(model.Shapes))
+	for i, n := range model.Shapes {
+		m.Shapes[i] = n
+	}
+
+	m.Images = make([]string, len(model.Images))
+	for i, n := range model.Images {
+		m.Images[i] = n
+	}
+
+	m.Sources = make([]NodeSourceOption, len(model.Sources))
+	for i, n := range model.Sources {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Sources[i] = nn.(NodeSourceOption)
+		} else {
+			m.Sources[i] = nil
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_placement_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_placement_config_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolPlacementConfigDetails The location where a node pool will place nodes.
+type NodePoolPlacementConfigDetails struct {
+
+	// The availability domain in which to place nodes.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID of the subnet in which to place nodes.
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// The OCID of the compute capacity reservation in which to place the compute instance.
+	CapacityReservationId *string `mandatory:"false" json:"capacityReservationId"`
+
+	PreemptibleNodeConfig *PreemptibleNodeConfigDetails `mandatory:"false" json:"preemptibleNodeConfig"`
+
+	// A list of fault domains in which to place nodes.
+	FaultDomains []string `mandatory:"false" json:"faultDomains"`
+}
+
+func (m NodePoolPlacementConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolPlacementConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_pod_network_option_details.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolPodNetworkOptionDetails The CNI type and relevant network details for the pods of a given node pool
+type NodePoolPodNetworkOptionDetails interface {
+}
+
+type nodepoolpodnetworkoptiondetails struct {
+	JsonData []byte
+	CniType  string `json:"cniType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodepoolpodnetworkoptiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodepoolpodnetworkoptiondetails nodepoolpodnetworkoptiondetails
+	s := struct {
+		Model Unmarshalernodepoolpodnetworkoptiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CniType = s.Model.CniType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodepoolpodnetworkoptiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CniType {
+	case "OCI_VCN_IP_NATIVE":
+		mm := OciVcnIpNativeNodePoolPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FLANNEL_OVERLAY":
+		mm := FlannelOverlayNodePoolPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m nodepoolpodnetworkoptiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodepoolpodnetworkoptiondetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NodePoolPodNetworkOptionDetailsCniTypeEnum Enum with underlying type: string
+type NodePoolPodNetworkOptionDetailsCniTypeEnum string
+
+// Set of constants representing the allowable values for NodePoolPodNetworkOptionDetailsCniTypeEnum
+const (
+	NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative NodePoolPodNetworkOptionDetailsCniTypeEnum = "OCI_VCN_IP_NATIVE"
+	NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay NodePoolPodNetworkOptionDetailsCniTypeEnum = "FLANNEL_OVERLAY"
+)
+
+var mappingNodePoolPodNetworkOptionDetailsCniTypeEnum = map[string]NodePoolPodNetworkOptionDetailsCniTypeEnum{
+	"OCI_VCN_IP_NATIVE": NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"FLANNEL_OVERLAY":   NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+var mappingNodePoolPodNetworkOptionDetailsCniTypeEnumLowerCase = map[string]NodePoolPodNetworkOptionDetailsCniTypeEnum{
+	"oci_vcn_ip_native": NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"flannel_overlay":   NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+// GetNodePoolPodNetworkOptionDetailsCniTypeEnumValues Enumerates the set of values for NodePoolPodNetworkOptionDetailsCniTypeEnum
+func GetNodePoolPodNetworkOptionDetailsCniTypeEnumValues() []NodePoolPodNetworkOptionDetailsCniTypeEnum {
+	values := make([]NodePoolPodNetworkOptionDetailsCniTypeEnum, 0)
+	for _, v := range mappingNodePoolPodNetworkOptionDetailsCniTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodePoolPodNetworkOptionDetailsCniTypeEnumStringValues Enumerates the set of values in String for NodePoolPodNetworkOptionDetailsCniTypeEnum
+func GetNodePoolPodNetworkOptionDetailsCniTypeEnumStringValues() []string {
+	return []string{
+		"OCI_VCN_IP_NATIVE",
+		"FLANNEL_OVERLAY",
+	}
+}
+
+// GetMappingNodePoolPodNetworkOptionDetailsCniTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodePoolPodNetworkOptionDetailsCniTypeEnum(val string) (NodePoolPodNetworkOptionDetailsCniTypeEnum, bool) {
+	enum, ok := mappingNodePoolPodNetworkOptionDetailsCniTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_summary.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolSummary The properties that define a node pool summary.
+type NodePoolSummary struct {
+
+	// The OCID of the node pool.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The state of the nodepool.
+	LifecycleState NodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the nodepool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"false" json:"clusterId"`
+
+	// The name of the node pool.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// Deprecated. see `nodeSource`. The OCID of the image running on the nodes in the node pool.
+	NodeImageId *string `mandatory:"false" json:"nodeImageId"`
+
+	// Deprecated. see `nodeSource`. The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// The shape configuration of the nodes.
+	NodeShapeConfig *NodeShapeConfig `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
+	NodeSource NodeSourceOption `mandatory:"false" json:"nodeSource"`
+
+	// Source running on the nodes in the node pool.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The number of nodes in each subnet.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+}
+
+func (m NodePoolSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                           *string                           `json:"id"`
+		LifecycleState               NodePoolLifecycleStateEnum        `json:"lifecycleState"`
+		LifecycleDetails             *string                           `json:"lifecycleDetails"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeImageId                  *string                           `json:"nodeImageId"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeShapeConfig              *NodeShapeConfig                  `json:"nodeShapeConfig"`
+		NodeSource                   nodesourceoption                  `json:"nodeSource"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *NodePoolNodeConfigDetails        `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                   map[string]map[string]interface{} `json:"systemTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeImageId = model.NodeImageId
+
+	m.NodeImageName = model.NodeImageName
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	nn, e = model.NodeSource.UnmarshalPolymorphicJSON(model.NodeSource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSource = nn.(NodeSourceOption)
+	} else {
+		m.NodeSource = nil
+	}
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShape = model.NodeShape
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	for i, n := range model.InitialNodeLabels {
+		m.InitialNodeLabels[i] = n
+	}
+
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	for i, n := range model.SubnetIds {
+		m.SubnetIds[i] = n
+	}
+
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_shape_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_shape_config.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeShapeConfig The shape configuration of the nodes.
+type NodeShapeConfig struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m NodeShapeConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeShapeConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_details.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceDetails The details of the node's source.
+type NodeSourceDetails interface {
+}
+
+type nodesourcedetails struct {
+	JsonData   []byte
+	SourceType string `json:"sourceType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodesourcedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodesourcedetails nodesourcedetails
+	s := struct {
+		Model Unmarshalernodesourcedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.SourceType = s.Model.SourceType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodesourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.SourceType {
+	case "IMAGE":
+		mm := NodeSourceViaImageDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m nodesourcedetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodesourcedetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_option.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceOption The source option for the node.
+type NodeSourceOption interface {
+
+	// The user-friendly name of the entity corresponding to the OCID.
+	GetSourceName() *string
+}
+
+type nodesourceoption struct {
+	JsonData   []byte
+	SourceName *string `mandatory:"false" json:"sourceName"`
+	SourceType string  `json:"sourceType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodesourceoption) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodesourceoption nodesourceoption
+	s := struct {
+		Model Unmarshalernodesourceoption
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.SourceName = s.Model.SourceName
+	m.SourceType = s.Model.SourceType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodesourceoption) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.SourceType {
+	case "IMAGE":
+		mm := NodeSourceViaImageOption{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetSourceName returns SourceName
+func (m nodesourceoption) GetSourceName() *string {
+	return m.SourceName
+}
+
+func (m nodesourceoption) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodesourceoption) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_type.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// NodeSourceTypeEnum Enum with underlying type: string
+type NodeSourceTypeEnum string
+
+// Set of constants representing the allowable values for NodeSourceTypeEnum
+const (
+	NodeSourceTypeImage NodeSourceTypeEnum = "IMAGE"
+)
+
+var mappingNodeSourceTypeEnum = map[string]NodeSourceTypeEnum{
+	"IMAGE": NodeSourceTypeImage,
+}
+
+var mappingNodeSourceTypeEnumLowerCase = map[string]NodeSourceTypeEnum{
+	"image": NodeSourceTypeImage,
+}
+
+// GetNodeSourceTypeEnumValues Enumerates the set of values for NodeSourceTypeEnum
+func GetNodeSourceTypeEnumValues() []NodeSourceTypeEnum {
+	values := make([]NodeSourceTypeEnum, 0)
+	for _, v := range mappingNodeSourceTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodeSourceTypeEnumStringValues Enumerates the set of values in String for NodeSourceTypeEnum
+func GetNodeSourceTypeEnumStringValues() []string {
+	return []string{
+		"IMAGE",
+	}
+}
+
+// GetMappingNodeSourceTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodeSourceTypeEnum(val string) (NodeSourceTypeEnum, bool) {
+	enum, ok := mappingNodeSourceTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_details.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceViaImageDetails Details of the image running on the node.
+type NodeSourceViaImageDetails struct {
+
+	// The OCID of the image used to boot the node.
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The size of the boot volume in GBs. Minimum value is 50 GB. See here (https://docs.cloud.oracle.com/en-us/iaas/Content/Block/Concepts/bootvolumes.htm) for max custom boot volume sizing and OS-specific requirements.
+	BootVolumeSizeInGBs *int64 `mandatory:"false" json:"bootVolumeSizeInGBs"`
+}
+
+func (m NodeSourceViaImageDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeSourceViaImageDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NodeSourceViaImageDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNodeSourceViaImageDetails NodeSourceViaImageDetails
+	s := struct {
+		DiscriminatorParam string `json:"sourceType"`
+		MarshalTypeNodeSourceViaImageDetails
+	}{
+		"IMAGE",
+		(MarshalTypeNodeSourceViaImageDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_option.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceViaImageOption An image can be specified as the source of nodes when launching a node pool using the `nodeSourceDetails` object.
+type NodeSourceViaImageOption struct {
+
+	// The user-friendly name of the entity corresponding to the OCID.
+	SourceName *string `mandatory:"false" json:"sourceName"`
+
+	// The OCID of the image.
+	ImageId *string `mandatory:"false" json:"imageId"`
+}
+
+//GetSourceName returns SourceName
+func (m NodeSourceViaImageOption) GetSourceName() *string {
+	return m.SourceName
+}
+
+func (m NodeSourceViaImageOption) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeSourceViaImageOption) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NodeSourceViaImageOption) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNodeSourceViaImageOption NodeSourceViaImageOption
+	s := struct {
+		DiscriminatorParam string `json:"sourceType"`
+		MarshalTypeNodeSourceViaImageOption
+	}{
+		"IMAGE",
+		(MarshalTypeNodeSourceViaImageOption)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_cluster_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// OciVcnIpNativeClusterPodNetworkOptionDetails Network options specific to using the OCI VCN Native CNI
+type OciVcnIpNativeClusterPodNetworkOptionDetails struct {
+}
+
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails OciVcnIpNativeClusterPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails
+	}{
+		"OCI_VCN_IP_NATIVE",
+		(MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_node_pool_pod_network_option_details.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// OciVcnIpNativeNodePoolPodNetworkOptionDetails Network options specific to using the OCI VCN Native CNI
+type OciVcnIpNativeNodePoolPodNetworkOptionDetails struct {
+
+	// The OCIDs of the subnets in which to place pods for this node pool. This can be one of the node pool subnet IDs
+	PodSubnetIds []string `mandatory:"true" json:"podSubnetIds"`
+
+	// The max number of pods per node in the node pool. This value will be limited by the number of VNICs attachable to the node pool shape
+	MaxPodsPerNode *int `mandatory:"false" json:"maxPodsPerNode"`
+
+	// The OCIDs of the Network Security Group(s) to associate pods for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	PodNsgIds []string `mandatory:"false" json:"podNsgIds"`
+}
+
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails OciVcnIpNativeNodePoolPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails
+	}{
+		"OCI_VCN_IP_NATIVE",
+		(MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/persistent_volume_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/persistent_volume_config_details.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PersistentVolumeConfigDetails Configuration to be applied to block volumes created by Kubernetes Persistent Volume Claims (PVC)
+type PersistentVolumeConfigDetails struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m PersistentVolumeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PersistentVolumeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/placement_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/placement_configuration.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PlacementConfiguration The information of virtual node placement in the virtual node pool.
+type PlacementConfiguration struct {
+
+	// The availability domain in which to place virtual nodes.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain []string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which to place virtual nodes.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+}
+
+func (m PlacementConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PlacementConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_configuration.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodConfiguration The pod configuration for pods run on virtual nodes of this virtual node pool.
+type PodConfiguration struct {
+
+	// The regional subnet where pods' VNIC will be placed.
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// Shape of the pods.
+	Shape *string `mandatory:"true" json:"shape"`
+
+	// List of network security group IDs applied to the Pod VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+}
+
+func (m PodConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodShape Pod shape.
+type PodShape struct {
+
+	// The name of the identifying shape.
+	Name *string `mandatory:"true" json:"name"`
+
+	// A short description of the VM's processor (CPU).
+	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
+
+	// Options for OCPU shape.
+	OcpuOptions []ShapeOcpuOptions `mandatory:"false" json:"ocpuOptions"`
+
+	// ShapeMemoryOptions.
+	MemoryOptions []ShapeMemoryOptions `mandatory:"false" json:"memoryOptions"`
+
+	// ShapeNetworkBandwidthOptions.
+	NetworkBandwidthOptions []ShapeNetworkBandwidthOptions `mandatory:"false" json:"networkBandwidthOptions"`
+}
+
+func (m PodShape) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodShape) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape_summary.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodShapeSummary Pod shape.
+type PodShapeSummary struct {
+
+	// The name of the identifying shape.
+	Name *string `mandatory:"true" json:"name"`
+
+	// A short description of the VM's processor (CPU).
+	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
+
+	// Options for OCPU shape.
+	OcpuOptions []ShapeOcpuOptions `mandatory:"false" json:"ocpuOptions"`
+
+	// ShapeMemoryOptions.
+	MemoryOptions []ShapeMemoryOptions `mandatory:"false" json:"memoryOptions"`
+
+	// ShapeNetworkBandwidthOptions.
+	NetworkBandwidthOptions []ShapeNetworkBandwidthOptions `mandatory:"false" json:"networkBandwidthOptions"`
+}
+
+func (m PodShapeSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodShapeSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemptible_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemptible_node_config_details.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PreemptibleNodeConfigDetails Configuration options for preemptible nodes.
+type PreemptibleNodeConfigDetails struct {
+	PreemptionAction PreemptionAction `mandatory:"true" json:"preemptionAction"`
+}
+
+func (m PreemptibleNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PreemptibleNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *PreemptibleNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		PreemptionAction preemptionaction `json:"preemptionAction"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.PreemptionAction.UnmarshalPolymorphicJSON(model.PreemptionAction.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.PreemptionAction = nn.(PreemptionAction)
+	} else {
+		m.PreemptionAction = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemption_action.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PreemptionAction The action to run when the preemptible node is interrupted for eviction.
+type PreemptionAction interface {
+}
+
+type preemptionaction struct {
+	JsonData []byte
+	Type     string `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *preemptionaction) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpreemptionaction preemptionaction
+	s := struct {
+		Model Unmarshalerpreemptionaction
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *preemptionaction) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "TERMINATE":
+		mm := TerminatePreemptionAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m preemptionaction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m preemptionaction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// PreemptionActionTypeEnum Enum with underlying type: string
+type PreemptionActionTypeEnum string
+
+// Set of constants representing the allowable values for PreemptionActionTypeEnum
+const (
+	PreemptionActionTypeTerminate PreemptionActionTypeEnum = "TERMINATE"
+)
+
+var mappingPreemptionActionTypeEnum = map[string]PreemptionActionTypeEnum{
+	"TERMINATE": PreemptionActionTypeTerminate,
+}
+
+var mappingPreemptionActionTypeEnumLowerCase = map[string]PreemptionActionTypeEnum{
+	"terminate": PreemptionActionTypeTerminate,
+}
+
+// GetPreemptionActionTypeEnumValues Enumerates the set of values for PreemptionActionTypeEnum
+func GetPreemptionActionTypeEnumValues() []PreemptionActionTypeEnum {
+	values := make([]PreemptionActionTypeEnum, 0)
+	for _, v := range mappingPreemptionActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetPreemptionActionTypeEnumStringValues Enumerates the set of values in String for PreemptionActionTypeEnum
+func GetPreemptionActionTypeEnumStringValues() []string {
+	return []string{
+		"TERMINATE",
+	}
+}
+
+// GetMappingPreemptionActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingPreemptionActionTypeEnum(val string) (PreemptionActionTypeEnum, bool) {
+	enum, ok := mappingPreemptionActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/service_lb_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/service_lb_config_details.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ServiceLbConfigDetails Configuration to be applied to load balancers created by Kubernetes services
+type ServiceLbConfigDetails struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m ServiceLbConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ServiceLbConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_memory_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_memory_options.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeMemoryOptions Memory properties.
+type ShapeMemoryOptions struct {
+
+	// The minimum amount of memory, in gigabytes.
+	MinInGBs *float32 `mandatory:"false" json:"minInGBs"`
+
+	// The maximum amount of memory, in gigabytes.
+	MaxInGBs *float32 `mandatory:"false" json:"maxInGBs"`
+
+	// The default amount of memory per OCPU available for this shape, in gigabytes.
+	DefaultPerOcpuInGBs *float32 `mandatory:"false" json:"defaultPerOcpuInGBs"`
+
+	// The minimum amount of memory per OCPU available for this shape, in gigabytes.
+	MinPerOcpuInGBs *float32 `mandatory:"false" json:"minPerOcpuInGBs"`
+
+	// The maximum amount of memory per OCPU available for this shape, in gigabytes.
+	MaxPerOcpuInGBs *float32 `mandatory:"false" json:"maxPerOcpuInGBs"`
+}
+
+func (m ShapeMemoryOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeMemoryOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_network_bandwidth_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_network_bandwidth_options.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeNetworkBandwidthOptions Properties of network bandwidth.
+type ShapeNetworkBandwidthOptions struct {
+
+	// The minimum amount of networking bandwidth, in gigabits per second.
+	MinInGbps *float32 `mandatory:"false" json:"minInGbps"`
+
+	// The maximum amount of networking bandwidth, in gigabits per second.
+	MaxInGbps *float32 `mandatory:"false" json:"maxInGbps"`
+
+	// The default amount of networking bandwidth per OCPU, in gigabits per second.
+	DefaultPerOcpuInGbps *float32 `mandatory:"false" json:"defaultPerOcpuInGbps"`
+}
+
+func (m ShapeNetworkBandwidthOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeNetworkBandwidthOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_ocpu_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_ocpu_options.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeOcpuOptions Properties of OCPUs.
+type ShapeOcpuOptions struct {
+
+	// The minimum number of OCPUs.
+	Min *float32 `mandatory:"false" json:"min"`
+
+	// The maximum number of OCPUs.
+	Max *float32 `mandatory:"false" json:"max"`
+}
+
+func (m ShapeOcpuOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeOcpuOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/sort_order.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/sort_order.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// SortOrderEnum Enum with underlying type: string
+type SortOrderEnum string
+
+// Set of constants representing the allowable values for SortOrderEnum
+const (
+	SortOrderAsc  SortOrderEnum = "ASC"
+	SortOrderDesc SortOrderEnum = "DESC"
+)
+
+var mappingSortOrderEnum = map[string]SortOrderEnum{
+	"ASC":  SortOrderAsc,
+	"DESC": SortOrderDesc,
+}
+
+var mappingSortOrderEnumLowerCase = map[string]SortOrderEnum{
+	"asc":  SortOrderAsc,
+	"desc": SortOrderDesc,
+}
+
+// GetSortOrderEnumValues Enumerates the set of values for SortOrderEnum
+func GetSortOrderEnumValues() []SortOrderEnum {
+	values := make([]SortOrderEnum, 0)
+	for _, v := range mappingSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetSortOrderEnumStringValues Enumerates the set of values in String for SortOrderEnum
+func GetSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingSortOrderEnum(val string) (SortOrderEnum, bool) {
+	enum, ok := mappingSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/taint.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/taint.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Taint taints
+type Taint struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+
+	// The effect of the pair.
+	Effect *string `mandatory:"false" json:"effect"`
+}
+
+func (m Taint) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Taint) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/terminate_preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/terminate_preemption_action.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// TerminatePreemptionAction Terminates the preemptible instance when it is interrupted for eviction.
+type TerminatePreemptionAction struct {
+
+	// Whether to preserve the boot volume that was used to launch the preemptible instance when the instance is terminated. Defaults to false if not specified.
+	IsPreserveBootVolume *bool `mandatory:"false" json:"isPreserveBootVolume"`
+}
+
+func (m TerminatePreemptionAction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m TerminatePreemptionAction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m TerminatePreemptionAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTerminatePreemptionAction TerminatePreemptionAction
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeTerminatePreemptionAction
+	}{
+		"TERMINATE",
+		(MarshalTypeTerminatePreemptionAction)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateAddonDetails The properties that define to update addon details.
+type UpdateAddonDetails struct {
+
+	// The version of the installed addon.
+	Version *string `mandatory:"false" json:"version"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m UpdateAddonDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateAddonDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateAddonRequest wrapper for the UpdateAddon operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateAddon.go.html to see an example of how to use UpdateAddonRequest.
+type UpdateAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// The details of the addon to be updated.
+	UpdateAddonDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateAddonResponse wrapper for the UpdateAddon operation
+type UpdateAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_details.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterDetails The properties that define a request to update a cluster.
+type UpdateClusterDetails struct {
+
+	// The new name for the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes to which the cluster masters should be upgraded.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	Options *UpdateClusterOptionsDetails `mandatory:"false" json:"options"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *UpdateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m UpdateClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterEndpointConfigDetails The properties that define a request to update a cluster endpoint config.
+type UpdateClusterEndpointConfigDetails struct {
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster update will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m UpdateClusterEndpointConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterEndpointConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateClusterEndpointConfigRequest wrapper for the UpdateClusterEndpointConfig operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateClusterEndpointConfig.go.html to see an example of how to use UpdateClusterEndpointConfigRequest.
+type UpdateClusterEndpointConfigRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the cluster's endpoint to update.
+	UpdateClusterEndpointConfigDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateClusterEndpointConfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateClusterEndpointConfigRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateClusterEndpointConfigRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateClusterEndpointConfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateClusterEndpointConfigRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateClusterEndpointConfigResponse wrapper for the UpdateClusterEndpointConfig operation
+type UpdateClusterEndpointConfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateClusterEndpointConfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateClusterEndpointConfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_options_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_options_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterOptionsDetails The properties that define extra options updating a cluster.
+type UpdateClusterOptionsDetails struct {
+
+	// Configurable cluster admission controllers
+	AdmissionControllerOptions *AdmissionControllerOptions `mandatory:"false" json:"admissionControllerOptions"`
+
+	PersistentVolumeConfig *PersistentVolumeConfigDetails `mandatory:"false" json:"persistentVolumeConfig"`
+
+	ServiceLbConfig *ServiceLbConfigDetails `mandatory:"false" json:"serviceLbConfig"`
+}
+
+func (m UpdateClusterOptionsDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterOptionsDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateClusterRequest wrapper for the UpdateCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateCluster.go.html to see an example of how to use UpdateClusterRequest.
+type UpdateClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the cluster to update.
+	UpdateClusterDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateClusterResponse wrapper for the UpdateCluster operation
+type UpdateClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_image_policy_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_image_policy_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateImagePolicyConfigDetails The properties that define a image verification policy.
+type UpdateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m UpdateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateImagePolicyConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_details.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodePoolDetails The properties that define a request to update a node pool.
+type UpdateNodePoolDetails struct {
+
+	// The new name for the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes to which the nodes in the node pool should be upgraded.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The number of nodes to have in each subnet specified in the subnetIds property. This property is deprecated,
+	// use nodeConfigDetails instead. If the current value of quantityPerSubnet is greater than 0, you can only
+	// use quantityPerSubnet to scale the node pool. If the current value of quantityPerSubnet is equal to 0 and
+	// the current value of size in nodeConfigDetails is greater than 0, before you can use quantityPerSubnet,
+	// you must first scale the node pool to 0 nodes using nodeConfigDetails.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. This property is deprecated,
+	// use nodeConfigDetails instead. Only one of the subnetIds or nodeConfigDetails
+	// properties can be specified.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Only one of the subnetIds or nodeConfigDetails
+	// properties should be specified. If the current value of quantityPerSubnet is greater than 0, the node
+	// pool may still be scaled using quantityPerSubnet. Before you can use nodeConfigDetails,
+	// you must first scale the node pool to 0 nodes using quantityPerSubnet.
+	NodeConfigDetails *UpdateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The SSH public key to add to each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The name of the node shape of the nodes in the node pool used on launch.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// Specify the configuration of the shape to launch nodes in the node pool.
+	NodeShapeConfig *UpdateNodeShapeConfigDetails `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+}
+
+func (m UpdateNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateNodePoolDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *UpdateNodePoolNodeConfigDetails  `json:"nodeConfigDetails"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		NodeShapeConfig              *UpdateNodeShapeConfigDetails     `json:"nodeShapeConfig"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	for i, n := range model.InitialNodeLabels {
+		m.InitialNodeLabels[i] = n
+	}
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	for i, n := range model.SubnetIds {
+		m.SubnetIds[i] = n
+	}
+
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.NodeMetadata = model.NodeMetadata
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.SshPublicKey = model.SshPublicKey
+
+	m.NodeShape = model.NodeShape
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_node_config_details.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type UpdateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m UpdateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateNodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Size                            *int                              `json:"size"`
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Size = model.Size
+
+	m.NsgIds = make([]string, len(model.NsgIds))
+	for i, n := range model.NsgIds {
+		m.NsgIds[i] = n
+	}
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	for i, n := range model.PlacementConfigs {
+		m.PlacementConfigs[i] = n
+	}
+
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_request_response.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateNodePoolRequest wrapper for the UpdateNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateNodePool.go.html to see an example of how to use UpdateNodePoolRequest.
+type UpdateNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// The fields to update in a node pool.
+	UpdateNodePoolDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateNodePoolResponse wrapper for the UpdateNodePool operation
+type UpdateNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_shape_config_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodeShapeConfigDetails The shape configuration of the nodes.
+type UpdateNodeShapeConfigDetails struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m UpdateNodeShapeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodeShapeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateVirtualNodeDetails The properties that define a request to update a virtual node.
+type UpdateVirtualNodeDetails struct {
+
+	// The state of the Virtual Node.
+	LifecycleState VirtualNodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+}
+
+func (m UpdateVirtualNodeDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateVirtualNodeDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_details.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateVirtualNodePoolDetails The properties that define a request to update a virtual node pool.
+type UpdateVirtualNodePoolDetails struct {
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"false" json:"placementConfigurations"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m UpdateVirtualNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateVirtualNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateVirtualNodePoolRequest wrapper for the UpdateVirtualNodePool operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateVirtualNodePool.go.html to see an example of how to use UpdateVirtualNodePoolRequest.
+type UpdateVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// The fields to update in a virtual node pool.
+	UpdateVirtualNodePoolDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateVirtualNodePoolResponse wrapper for the UpdateVirtualNodePool operation
+type UpdateVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNode The properties that define a virtual node.
+type VirtualNode struct {
+
+	// The ocid of the virtual node.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the virtual node.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The ocid of the virtual node pool this virtual node belongs to.
+	VirtualNodePoolId *string `mandatory:"true" json:"virtualNodePoolId"`
+
+	// The version of Kubernetes this virtual node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this virtual node is placed
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which this Virtual Node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// NSG Ids applied to virtual node vnic.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The private IP address of this Virtual Node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// An error that may be associated with the virtual node.
+	VirtualNodeError *string `mandatory:"false" json:"virtualNodeError"`
+
+	// The state of the Virtual Node.
+	LifecycleState VirtualNodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time at which the virtual node was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m VirtualNode) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNode) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// VirtualNodeLifecycleStateEnum Enum with underlying type: string
+type VirtualNodeLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VirtualNodeLifecycleStateEnum
+const (
+	VirtualNodeLifecycleStateCreating       VirtualNodeLifecycleStateEnum = "CREATING"
+	VirtualNodeLifecycleStateActive         VirtualNodeLifecycleStateEnum = "ACTIVE"
+	VirtualNodeLifecycleStateUpdating       VirtualNodeLifecycleStateEnum = "UPDATING"
+	VirtualNodeLifecycleStateDeleting       VirtualNodeLifecycleStateEnum = "DELETING"
+	VirtualNodeLifecycleStateDeleted        VirtualNodeLifecycleStateEnum = "DELETED"
+	VirtualNodeLifecycleStateFailed         VirtualNodeLifecycleStateEnum = "FAILED"
+	VirtualNodeLifecycleStateNeedsAttention VirtualNodeLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingVirtualNodeLifecycleStateEnum = map[string]VirtualNodeLifecycleStateEnum{
+	"CREATING":        VirtualNodeLifecycleStateCreating,
+	"ACTIVE":          VirtualNodeLifecycleStateActive,
+	"UPDATING":        VirtualNodeLifecycleStateUpdating,
+	"DELETING":        VirtualNodeLifecycleStateDeleting,
+	"DELETED":         VirtualNodeLifecycleStateDeleted,
+	"FAILED":          VirtualNodeLifecycleStateFailed,
+	"NEEDS_ATTENTION": VirtualNodeLifecycleStateNeedsAttention,
+}
+
+var mappingVirtualNodeLifecycleStateEnumLowerCase = map[string]VirtualNodeLifecycleStateEnum{
+	"creating":        VirtualNodeLifecycleStateCreating,
+	"active":          VirtualNodeLifecycleStateActive,
+	"updating":        VirtualNodeLifecycleStateUpdating,
+	"deleting":        VirtualNodeLifecycleStateDeleting,
+	"deleted":         VirtualNodeLifecycleStateDeleted,
+	"failed":          VirtualNodeLifecycleStateFailed,
+	"needs_attention": VirtualNodeLifecycleStateNeedsAttention,
+}
+
+// GetVirtualNodeLifecycleStateEnumValues Enumerates the set of values for VirtualNodeLifecycleStateEnum
+func GetVirtualNodeLifecycleStateEnumValues() []VirtualNodeLifecycleStateEnum {
+	values := make([]VirtualNodeLifecycleStateEnum, 0)
+	for _, v := range mappingVirtualNodeLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetVirtualNodeLifecycleStateEnumStringValues Enumerates the set of values in String for VirtualNodeLifecycleStateEnum
+func GetVirtualNodeLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingVirtualNodeLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingVirtualNodeLifecycleStateEnum(val string) (VirtualNodeLifecycleStateEnum, bool) {
+	enum, ok := mappingVirtualNodeLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodePool A pool of virtual nodes attached to a cluster.
+type VirtualNodePool struct {
+
+	// The OCID of the virtual node pool.
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers. This is the same as virtualNodePool resources.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// The state of the Virtual Node Pool.
+	LifecycleState VirtualNodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node Pool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time the virtual node pool was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the virtual node pool was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m VirtualNodePool) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodePool) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// VirtualNodePoolLifecycleStateEnum Enum with underlying type: string
+type VirtualNodePoolLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VirtualNodePoolLifecycleStateEnum
+const (
+	VirtualNodePoolLifecycleStateCreating       VirtualNodePoolLifecycleStateEnum = "CREATING"
+	VirtualNodePoolLifecycleStateActive         VirtualNodePoolLifecycleStateEnum = "ACTIVE"
+	VirtualNodePoolLifecycleStateUpdating       VirtualNodePoolLifecycleStateEnum = "UPDATING"
+	VirtualNodePoolLifecycleStateDeleting       VirtualNodePoolLifecycleStateEnum = "DELETING"
+	VirtualNodePoolLifecycleStateDeleted        VirtualNodePoolLifecycleStateEnum = "DELETED"
+	VirtualNodePoolLifecycleStateFailed         VirtualNodePoolLifecycleStateEnum = "FAILED"
+	VirtualNodePoolLifecycleStateNeedsAttention VirtualNodePoolLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingVirtualNodePoolLifecycleStateEnum = map[string]VirtualNodePoolLifecycleStateEnum{
+	"CREATING":        VirtualNodePoolLifecycleStateCreating,
+	"ACTIVE":          VirtualNodePoolLifecycleStateActive,
+	"UPDATING":        VirtualNodePoolLifecycleStateUpdating,
+	"DELETING":        VirtualNodePoolLifecycleStateDeleting,
+	"DELETED":         VirtualNodePoolLifecycleStateDeleted,
+	"FAILED":          VirtualNodePoolLifecycleStateFailed,
+	"NEEDS_ATTENTION": VirtualNodePoolLifecycleStateNeedsAttention,
+}
+
+var mappingVirtualNodePoolLifecycleStateEnumLowerCase = map[string]VirtualNodePoolLifecycleStateEnum{
+	"creating":        VirtualNodePoolLifecycleStateCreating,
+	"active":          VirtualNodePoolLifecycleStateActive,
+	"updating":        VirtualNodePoolLifecycleStateUpdating,
+	"deleting":        VirtualNodePoolLifecycleStateDeleting,
+	"deleted":         VirtualNodePoolLifecycleStateDeleted,
+	"failed":          VirtualNodePoolLifecycleStateFailed,
+	"needs_attention": VirtualNodePoolLifecycleStateNeedsAttention,
+}
+
+// GetVirtualNodePoolLifecycleStateEnumValues Enumerates the set of values for VirtualNodePoolLifecycleStateEnum
+func GetVirtualNodePoolLifecycleStateEnumValues() []VirtualNodePoolLifecycleStateEnum {
+	values := make([]VirtualNodePoolLifecycleStateEnum, 0)
+	for _, v := range mappingVirtualNodePoolLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetVirtualNodePoolLifecycleStateEnumStringValues Enumerates the set of values in String for VirtualNodePoolLifecycleStateEnum
+func GetVirtualNodePoolLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingVirtualNodePoolLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingVirtualNodePoolLifecycleStateEnum(val string) (VirtualNodePoolLifecycleStateEnum, bool) {
+	enum, ok := mappingVirtualNodePoolLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_summary.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodePoolSummary The properties that define a virtual node pool summary.
+type VirtualNodePoolSummary struct {
+
+	// The OCID of the virtual node pool.
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers. This is the same as virtualNodePool resources.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// The state of the Virtual Node Pool.
+	LifecycleState VirtualNodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node Pool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time the virtual node pool was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the virtual node pool was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m VirtualNodePoolSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodePoolSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_summary.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodeSummary The properties that define a virtual node summary.
+type VirtualNodeSummary struct {
+
+	// The ocid of the virtual node.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the virtual node.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The ocid of the virtual node pool this virtual node belongs to.
+	VirtualNodePoolId *string `mandatory:"true" json:"virtualNodePoolId"`
+
+	// The version of Kubernetes this virtual node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this virtual node is placed
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which this Virtual Node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// NSG Ids applied to virtual node vnic.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The private IP address of this Virtual Node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// An error that may be associated with the virtual node.
+	VirtualNodeError *string `mandatory:"false" json:"virtualNodeError"`
+
+	// The state of the Virtual Node.
+	LifecycleState VirtualNodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time at which the virtual node was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m VirtualNodeSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodeSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_tags.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_tags.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodeTags The tags associated to the virtual nodes in this virtual node pool.
+type VirtualNodeTags struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VirtualNodeTags) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodeTags) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequest An asynchronous work request.
+type WorkRequest struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The type of work the work request is doing.
+	OperationType WorkRequestOperationTypeEnum `mandatory:"false" json:"operationType,omitempty"`
+
+	// The current status of the work request.
+	Status WorkRequestStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// The OCID of the compartment in which the work request exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// The time the work request was accepted.
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// The time the work request was started.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The time the work request was finished.
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestOperationTypeEnum(string(m.OperationType)); !ok && m.OperationType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for OperationType: %s. Supported values are: %s.", m.OperationType, strings.Join(GetWorkRequestOperationTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingWorkRequestStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetWorkRequestStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestError Errors related to a specific work request.
+type WorkRequestError struct {
+
+	// A short error code that defines the error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human-readable error string.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The date and time the error occurred.
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_log_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_log_entry.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestLogEntry Log entries related to a specific work request.
+type WorkRequestLogEntry struct {
+
+	// The description of an action that occurred.
+	Message *string `mandatory:"false" json:"message"`
+
+	// The date and time the log entry occurred.
+	Timestamp *string `mandatory:"false" json:"timestamp"`
+}
+
+func (m WorkRequestLogEntry) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestLogEntry) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_operation_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_operation_type.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// WorkRequestOperationTypeEnum Enum with underlying type: string
+type WorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+const (
+	WorkRequestOperationTypeClusterCreate         WorkRequestOperationTypeEnum = "CLUSTER_CREATE"
+	WorkRequestOperationTypeClusterUpdate         WorkRequestOperationTypeEnum = "CLUSTER_UPDATE"
+	WorkRequestOperationTypeClusterDelete         WorkRequestOperationTypeEnum = "CLUSTER_DELETE"
+	WorkRequestOperationTypeNodepoolCreate        WorkRequestOperationTypeEnum = "NODEPOOL_CREATE"
+	WorkRequestOperationTypeNodepoolUpdate        WorkRequestOperationTypeEnum = "NODEPOOL_UPDATE"
+	WorkRequestOperationTypeNodepoolDelete        WorkRequestOperationTypeEnum = "NODEPOOL_DELETE"
+	WorkRequestOperationTypeNodepoolReconcile     WorkRequestOperationTypeEnum = "NODEPOOL_RECONCILE"
+	WorkRequestOperationTypeWorkrequestCancel     WorkRequestOperationTypeEnum = "WORKREQUEST_CANCEL"
+	WorkRequestOperationTypeVirtualnodepoolCreate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_CREATE"
+	WorkRequestOperationTypeVirtualnodepoolUpdate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_UPDATE"
+	WorkRequestOperationTypeVirtualnodepoolDelete WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_DELETE"
+	WorkRequestOperationTypeVirtualnodeDelete     WorkRequestOperationTypeEnum = "VIRTUALNODE_DELETE"
+	WorkRequestOperationTypeEnableAddon           WorkRequestOperationTypeEnum = "ENABLE_ADDON"
+	WorkRequestOperationTypeUpdateAddon           WorkRequestOperationTypeEnum = "UPDATE_ADDON"
+	WorkRequestOperationTypeDisableAddon          WorkRequestOperationTypeEnum = "DISABLE_ADDON"
+	WorkRequestOperationTypeReconcileAddon        WorkRequestOperationTypeEnum = "RECONCILE_ADDON"
+)
+
+var mappingWorkRequestOperationTypeEnum = map[string]WorkRequestOperationTypeEnum{
+	"CLUSTER_CREATE":         WorkRequestOperationTypeClusterCreate,
+	"CLUSTER_UPDATE":         WorkRequestOperationTypeClusterUpdate,
+	"CLUSTER_DELETE":         WorkRequestOperationTypeClusterDelete,
+	"NODEPOOL_CREATE":        WorkRequestOperationTypeNodepoolCreate,
+	"NODEPOOL_UPDATE":        WorkRequestOperationTypeNodepoolUpdate,
+	"NODEPOOL_DELETE":        WorkRequestOperationTypeNodepoolDelete,
+	"NODEPOOL_RECONCILE":     WorkRequestOperationTypeNodepoolReconcile,
+	"WORKREQUEST_CANCEL":     WorkRequestOperationTypeWorkrequestCancel,
+	"VIRTUALNODEPOOL_CREATE": WorkRequestOperationTypeVirtualnodepoolCreate,
+	"VIRTUALNODEPOOL_UPDATE": WorkRequestOperationTypeVirtualnodepoolUpdate,
+	"VIRTUALNODEPOOL_DELETE": WorkRequestOperationTypeVirtualnodepoolDelete,
+	"VIRTUALNODE_DELETE":     WorkRequestOperationTypeVirtualnodeDelete,
+	"ENABLE_ADDON":           WorkRequestOperationTypeEnableAddon,
+	"UPDATE_ADDON":           WorkRequestOperationTypeUpdateAddon,
+	"DISABLE_ADDON":          WorkRequestOperationTypeDisableAddon,
+	"RECONCILE_ADDON":        WorkRequestOperationTypeReconcileAddon,
+}
+
+var mappingWorkRequestOperationTypeEnumLowerCase = map[string]WorkRequestOperationTypeEnum{
+	"cluster_create":         WorkRequestOperationTypeClusterCreate,
+	"cluster_update":         WorkRequestOperationTypeClusterUpdate,
+	"cluster_delete":         WorkRequestOperationTypeClusterDelete,
+	"nodepool_create":        WorkRequestOperationTypeNodepoolCreate,
+	"nodepool_update":        WorkRequestOperationTypeNodepoolUpdate,
+	"nodepool_delete":        WorkRequestOperationTypeNodepoolDelete,
+	"nodepool_reconcile":     WorkRequestOperationTypeNodepoolReconcile,
+	"workrequest_cancel":     WorkRequestOperationTypeWorkrequestCancel,
+	"virtualnodepool_create": WorkRequestOperationTypeVirtualnodepoolCreate,
+	"virtualnodepool_update": WorkRequestOperationTypeVirtualnodepoolUpdate,
+	"virtualnodepool_delete": WorkRequestOperationTypeVirtualnodepoolDelete,
+	"virtualnode_delete":     WorkRequestOperationTypeVirtualnodeDelete,
+	"enable_addon":           WorkRequestOperationTypeEnableAddon,
+	"update_addon":           WorkRequestOperationTypeUpdateAddon,
+	"disable_addon":          WorkRequestOperationTypeDisableAddon,
+	"reconcile_addon":        WorkRequestOperationTypeReconcileAddon,
+}
+
+// GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumValues() []WorkRequestOperationTypeEnum {
+	values := make([]WorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestOperationTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestOperationTypeEnumStringValues Enumerates the set of values in String for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumStringValues() []string {
+	return []string{
+		"CLUSTER_CREATE",
+		"CLUSTER_UPDATE",
+		"CLUSTER_DELETE",
+		"NODEPOOL_CREATE",
+		"NODEPOOL_UPDATE",
+		"NODEPOOL_DELETE",
+		"NODEPOOL_RECONCILE",
+		"WORKREQUEST_CANCEL",
+		"VIRTUALNODEPOOL_CREATE",
+		"VIRTUALNODEPOOL_UPDATE",
+		"VIRTUALNODEPOOL_DELETE",
+		"VIRTUALNODE_DELETE",
+		"ENABLE_ADDON",
+		"UPDATE_ADDON",
+		"DISABLE_ADDON",
+		"RECONCILE_ADDON",
+	}
+}
+
+// GetMappingWorkRequestOperationTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestOperationTypeEnum(val string) (WorkRequestOperationTypeEnum, bool) {
+	enum, ok := mappingWorkRequestOperationTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_resource.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestResource The properties that define a work request resource.
+type WorkRequestResource struct {
+
+	// The way in which this resource was affected by the work tracked by the work request.
+	ActionType WorkRequestResourceActionTypeEnum `mandatory:"false" json:"actionType,omitempty"`
+
+	// The resource type the work request affects.
+	EntityType *string `mandatory:"false" json:"entityType"`
+
+	// The OCID of the resource the work request affects.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The URI path on which the user can issue a GET request to access the resource metadata.
+	EntityUri *string `mandatory:"false" json:"entityUri"`
+}
+
+func (m WorkRequestResource) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestResource) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestResourceActionTypeEnum(string(m.ActionType)); !ok && m.ActionType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ActionType: %s. Supported values are: %s.", m.ActionType, strings.Join(GetWorkRequestResourceActionTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestResourceActionTypeEnum Enum with underlying type: string
+type WorkRequestResourceActionTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestResourceActionTypeEnum
+const (
+	WorkRequestResourceActionTypeCreated        WorkRequestResourceActionTypeEnum = "CREATED"
+	WorkRequestResourceActionTypeUpdated        WorkRequestResourceActionTypeEnum = "UPDATED"
+	WorkRequestResourceActionTypeDeleted        WorkRequestResourceActionTypeEnum = "DELETED"
+	WorkRequestResourceActionTypeRelated        WorkRequestResourceActionTypeEnum = "RELATED"
+	WorkRequestResourceActionTypeInProgress     WorkRequestResourceActionTypeEnum = "IN_PROGRESS"
+	WorkRequestResourceActionTypeFailed         WorkRequestResourceActionTypeEnum = "FAILED"
+	WorkRequestResourceActionTypeCanceledCreate WorkRequestResourceActionTypeEnum = "CANCELED_CREATE"
+	WorkRequestResourceActionTypeCanceledUpdate WorkRequestResourceActionTypeEnum = "CANCELED_UPDATE"
+	WorkRequestResourceActionTypeCanceledDelete WorkRequestResourceActionTypeEnum = "CANCELED_DELETE"
+)
+
+var mappingWorkRequestResourceActionTypeEnum = map[string]WorkRequestResourceActionTypeEnum{
+	"CREATED":         WorkRequestResourceActionTypeCreated,
+	"UPDATED":         WorkRequestResourceActionTypeUpdated,
+	"DELETED":         WorkRequestResourceActionTypeDeleted,
+	"RELATED":         WorkRequestResourceActionTypeRelated,
+	"IN_PROGRESS":     WorkRequestResourceActionTypeInProgress,
+	"FAILED":          WorkRequestResourceActionTypeFailed,
+	"CANCELED_CREATE": WorkRequestResourceActionTypeCanceledCreate,
+	"CANCELED_UPDATE": WorkRequestResourceActionTypeCanceledUpdate,
+	"CANCELED_DELETE": WorkRequestResourceActionTypeCanceledDelete,
+}
+
+var mappingWorkRequestResourceActionTypeEnumLowerCase = map[string]WorkRequestResourceActionTypeEnum{
+	"created":         WorkRequestResourceActionTypeCreated,
+	"updated":         WorkRequestResourceActionTypeUpdated,
+	"deleted":         WorkRequestResourceActionTypeDeleted,
+	"related":         WorkRequestResourceActionTypeRelated,
+	"in_progress":     WorkRequestResourceActionTypeInProgress,
+	"failed":          WorkRequestResourceActionTypeFailed,
+	"canceled_create": WorkRequestResourceActionTypeCanceledCreate,
+	"canceled_update": WorkRequestResourceActionTypeCanceledUpdate,
+	"canceled_delete": WorkRequestResourceActionTypeCanceledDelete,
+}
+
+// GetWorkRequestResourceActionTypeEnumValues Enumerates the set of values for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumValues() []WorkRequestResourceActionTypeEnum {
+	values := make([]WorkRequestResourceActionTypeEnum, 0)
+	for _, v := range mappingWorkRequestResourceActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestResourceActionTypeEnumStringValues Enumerates the set of values in String for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumStringValues() []string {
+	return []string{
+		"CREATED",
+		"UPDATED",
+		"DELETED",
+		"RELATED",
+		"IN_PROGRESS",
+		"FAILED",
+		"CANCELED_CREATE",
+		"CANCELED_UPDATE",
+		"CANCELED_DELETE",
+	}
+}
+
+// GetMappingWorkRequestResourceActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestResourceActionTypeEnum(val string) (WorkRequestResourceActionTypeEnum, bool) {
+	enum, ok := mappingWorkRequestResourceActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_status.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// WorkRequestStatusEnum Enum with underlying type: string
+type WorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+const (
+	WorkRequestStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestStatusEnum = map[string]WorkRequestStatusEnum{
+	"ACCEPTED":    WorkRequestStatusAccepted,
+	"IN_PROGRESS": WorkRequestStatusInProgress,
+	"FAILED":      WorkRequestStatusFailed,
+	"SUCCEEDED":   WorkRequestStatusSucceeded,
+	"CANCELING":   WorkRequestStatusCanceling,
+	"CANCELED":    WorkRequestStatusCanceled,
+}
+
+var mappingWorkRequestStatusEnumLowerCase = map[string]WorkRequestStatusEnum{
+	"accepted":    WorkRequestStatusAccepted,
+	"in_progress": WorkRequestStatusInProgress,
+	"failed":      WorkRequestStatusFailed,
+	"succeeded":   WorkRequestStatusSucceeded,
+	"canceling":   WorkRequestStatusCanceling,
+	"canceled":    WorkRequestStatusCanceled,
+}
+
+// GetWorkRequestStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumValues() []WorkRequestStatusEnum {
+	values := make([]WorkRequestStatusEnum, 0)
+	for _, v := range mappingWorkRequestStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestStatusEnumStringValues Enumerates the set of values in String for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumStringValues() []string {
+	return []string{
+		"ACCEPTED",
+		"IN_PROGRESS",
+		"FAILED",
+		"SUCCEEDED",
+		"CANCELING",
+		"CANCELED",
+	}
+}
+
+// GetMappingWorkRequestStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestStatusEnum(val string) (WorkRequestStatusEnum, bool) {
+	enum, ok := mappingWorkRequestStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_summary.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestSummary The properties that define a work request summary.
+type WorkRequestSummary struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The type of work the work request is doing.
+	OperationType WorkRequestOperationTypeEnum `mandatory:"false" json:"operationType,omitempty"`
+
+	// The current status of the work request.
+	Status WorkRequestStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// The OCID of the compartment in which the work request exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// The time the work request was accepted.
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// The time the work request was started.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The time the work request was finished.
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequestSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestOperationTypeEnum(string(m.OperationType)); !ok && m.OperationType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for OperationType: %s. Supported values are: %s.", m.OperationType, strings.Join(GetWorkRequestOperationTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingWorkRequestStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetWorkRequestStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestSummaryOperationTypeEnum is an alias to type: WorkRequestOperationTypeEnum
+// Consider using WorkRequestOperationTypeEnum instead
+// Deprecated
+type WorkRequestSummaryOperationTypeEnum = WorkRequestOperationTypeEnum
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+// Deprecated
+const (
+	WorkRequestSummaryOperationTypeClusterCreate         WorkRequestOperationTypeEnum = "CLUSTER_CREATE"
+	WorkRequestSummaryOperationTypeClusterUpdate         WorkRequestOperationTypeEnum = "CLUSTER_UPDATE"
+	WorkRequestSummaryOperationTypeClusterDelete         WorkRequestOperationTypeEnum = "CLUSTER_DELETE"
+	WorkRequestSummaryOperationTypeNodepoolCreate        WorkRequestOperationTypeEnum = "NODEPOOL_CREATE"
+	WorkRequestSummaryOperationTypeNodepoolUpdate        WorkRequestOperationTypeEnum = "NODEPOOL_UPDATE"
+	WorkRequestSummaryOperationTypeNodepoolDelete        WorkRequestOperationTypeEnum = "NODEPOOL_DELETE"
+	WorkRequestSummaryOperationTypeNodepoolReconcile     WorkRequestOperationTypeEnum = "NODEPOOL_RECONCILE"
+	WorkRequestSummaryOperationTypeWorkrequestCancel     WorkRequestOperationTypeEnum = "WORKREQUEST_CANCEL"
+	WorkRequestSummaryOperationTypeVirtualnodepoolCreate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_CREATE"
+	WorkRequestSummaryOperationTypeVirtualnodepoolUpdate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_UPDATE"
+	WorkRequestSummaryOperationTypeVirtualnodepoolDelete WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_DELETE"
+	WorkRequestSummaryOperationTypeVirtualnodeDelete     WorkRequestOperationTypeEnum = "VIRTUALNODE_DELETE"
+	WorkRequestSummaryOperationTypeEnableAddon           WorkRequestOperationTypeEnum = "ENABLE_ADDON"
+	WorkRequestSummaryOperationTypeUpdateAddon           WorkRequestOperationTypeEnum = "UPDATE_ADDON"
+	WorkRequestSummaryOperationTypeDisableAddon          WorkRequestOperationTypeEnum = "DISABLE_ADDON"
+	WorkRequestSummaryOperationTypeReconcileAddon        WorkRequestOperationTypeEnum = "RECONCILE_ADDON"
+)
+
+// GetWorkRequestSummaryOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+// Consider using GetWorkRequestOperationTypeEnumValue
+// Deprecated
+var GetWorkRequestSummaryOperationTypeEnumValues = GetWorkRequestOperationTypeEnumValues
+
+// WorkRequestSummaryStatusEnum is an alias to type: WorkRequestStatusEnum
+// Consider using WorkRequestStatusEnum instead
+// Deprecated
+type WorkRequestSummaryStatusEnum = WorkRequestStatusEnum
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+// Deprecated
+const (
+	WorkRequestSummaryStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestSummaryStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestSummaryStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestSummaryStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestSummaryStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestSummaryStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+// GetWorkRequestSummaryStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+// Consider using GetWorkRequestStatusEnumValue
+// Deprecated
+var GetWorkRequestSummaryStatusEnumValues = GetWorkRequestStatusEnumValues

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,6 +114,7 @@ github.com/oracle/oci-go-sdk/v65/certificatesmanagement
 github.com/oracle/oci-go-sdk/v65/common
 github.com/oracle/oci-go-sdk/v65/common/auth
 github.com/oracle/oci-go-sdk/v65/common/utils
+github.com/oracle/oci-go-sdk/v65/containerengine
 github.com/oracle/oci-go-sdk/v65/loadbalancer
 github.com/oracle/oci-go-sdk/v65/waf
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Added support for flannel CNI. Accepts Nodeport Service for Flannel CNI and adds nodes as backend based on externalTrafficPolicy set on service.
Added a new parameter in deployment - `cluster-id` to check for cluster details.