### PR TITLE
Avoid ingress state build failure when ingresses reference non-existe…

### DIFF
--- a/pkg/state/ingressstate.go
+++ b/pkg/state/ingressstate.go
@@ -90,11 +90,9 @@ func (s *StateStore) BuildState(ingressClass *networkingv1.IngressClass) error {
 
 	var ingressGroup []*networkingv1.Ingress
 	for _, ing := range ingressList {
-		ingIc, err := util.GetIngressClass(ing, s.IngressClassLister)
-		if err != nil {
-			return errors.Wrap(err, "error getting ingress class")
-		}
-		if ingIc != nil && ingressClass.Name == ingIc.Name && !util.IsIngressDeleting(ing) {
+		if ((ing.Spec.IngressClassName == nil && ingressClass.Annotations[util.IngressClassIsDefault] == "true") ||
+			(ing.Spec.IngressClassName != nil && ingressClass.Name == *ing.Spec.IngressClassName)) &&
+			!util.IsIngressDeleting(ing) {
 			ingressGroup = append(ingressGroup, ing)
 		}
 	}

--- a/pkg/state/ingressstate_test.go
+++ b/pkg/state/ingressstate_test.go
@@ -34,6 +34,7 @@ const (
 	ListenerProtocolConfigValidationsFilePath = "validate-listener-protocol-config.yaml"
 	TestIngressStateFilePath                  = "test-ingress-state.yaml"
 	TestIngressStateWithPortNameFilePath      = "test-ingress-state_withportname.yaml"
+	TestIngressStateWithNamedClassesFilePath  = "test-ingress-state_withnamedclasses.yaml"
 )
 
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList, ingressList *networkingv1.IngressList, testService *v1.ServiceList) (networkinglisters.IngressClassLister, networkinglisters.IngressLister, corelisters.ServiceLister) {
@@ -215,6 +216,25 @@ func TestIngressStateWithPortName(t *testing.T) {
 	ingressClassList := testutil.GetIngressClassList()
 
 	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateWithPortNameFilePath)
+
+	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
+	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
+
+	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
+	err := stateStore.BuildState(&ingressClassList.Items[0])
+	Expect(err).NotTo(HaveOccurred())
+
+	assertCases(stateStore)
+}
+
+func TestIngressStateWithNamedClasses(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ingressClassList := testutil.GetIngressClassList()
+
+	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateWithNamedClassesFilePath)
 
 	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)

--- a/pkg/state/test-ingress-state_withnamedclasses.yaml
+++ b/pkg/state/test-ingress-state_withnamedclasses.yaml
@@ -1,0 +1,122 @@
+#
+# OCI Native Ingress Controller
+#
+# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state
+  namespace: default
+spec:
+  ingressClassName: default-ingress-class
+  tls:
+  - hosts:
+      - foo.bar.com
+    secretName: secret_name
+  rules:
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/PrefixEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 80
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/ExactEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 70
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state-new
+  namespace: default
+spec:
+  ingressClassName: default-ingress-class
+  tls:
+  - hosts:
+      - foo.bar.com
+    secretName: secret_name
+  rules:
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/PrefixEcho1/aa"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 80
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/ExactEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 90
+  - http:
+      paths:
+      - pathType: Prefix
+        path: "/PrefixEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 100
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state-excluded
+  namespace: default
+spec:
+  ingressClassName: missing-ingress-class
+  tls:
+    - hosts:
+        - foo.bar.com
+      secretName: secret_name
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1/aa"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 80
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/ExactEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 90
+    - http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 100

--- a/pkg/state/test-ingress-state_withnamedclasses.yaml
+++ b/pkg/state/test-ingress-state_withnamedclasses.yaml
@@ -37,48 +37,7 @@ spec:
             port:
               number: 70
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress-state-new
-  namespace: default
-spec:
-  ingressClassName: default-ingress-class
-  tls:
-  - hosts:
-      - foo.bar.com
-    secretName: secret_name
-  rules:
-  - host: "foo.bar.com"
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/PrefixEcho1/aa"
-        backend:
-          service:
-            name: tls-test
-            port:
-              number: 80
-  - host: "foo.bar.com"
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/ExactEcho1"
-        backend:
-          service:
-            name: tls-test
-            port:
-              number: 90
-  - http:
-      paths:
-      - pathType: Prefix
-        path: "/PrefixEcho1"
-        backend:
-          service:
-            name: tls-test
-            port:
-              number: 100
----
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -120,3 +79,45 @@ spec:
                 name: tls-test
                 port:
                   number: 100
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state-new
+  namespace: default
+spec:
+  ingressClassName: default-ingress-class
+  tls:
+  - hosts:
+      - foo.bar.com
+    secretName: secret_name
+  rules:
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/PrefixEcho1/aa"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 80
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/ExactEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 90
+  - http:
+      paths:
+      - pathType: Prefix
+        path: "/PrefixEcho1"
+        backend:
+          service:
+            name: tls-test
+            port:
+              number: 100


### PR DESCRIPTION
…nt ingress classes

### Problem
If any Ingress exists that references a non-existent IngressClass, oci-native-ingress-controller will no longer be able to build the ingress state for any IngressClass, rendering it non-functional

### Cause
When building the ingress state for a given IngressClass, [this code](https://github.com/oracle/oci-native-ingress-controller/blob/main/pkg/state/ingressstate.go#L93) lists and iterates through all Ingress objects, and tries to determine if the Ingress is tied to the IngressClass being processed (i.e. via ingressClassName, or, if the Ingress has no ingressClassName defined, if the IngressClass is the default ingress class).

In doing this, for each Ingress object, it's calling [util.GetIngressClass](https://github.com/oracle/oci-native-ingress-controller/blob/main/pkg/state/ingressstate.go#L93C17-L93C37), which internally lists all IngressClasses and returns the IngressClass that is tied to the Ingress. However, if the Ingress in question references an IngressClass by name that doesn't exist, `util.GetIngressClass` will return an error (ingress class not found for ingress). The state building code will then exit early and return that error up the stack, meaning no Ingress state will be built and no load balancer will be updated. As long as ANY Ingress object exists that references an IngressClass that doesn't exist, no state can ever be built.

### Solution
Since the ingress state building code is already operating on a specific IngressClass, we don't need to use the `util.GetIngressClass` code which lists all IngressClasses for every Ingress being processed. Instead, we can just compare the ingressClassName of each ingress against the name of the IngressClass being processed. If it matches, we include it in the group. If the ingressClassName is nil, we only include it if the IngressClass being processed is the default ingress class