### PR TITLE
OKE-29394 Ingress state build failure when ingress reference non-existent ingress class

### DIFF
--- a/pkg/state/ingressstate.go
+++ b/pkg/state/ingressstate.go
@@ -92,10 +92,11 @@ func (s *StateStore) BuildState(ingressClass *networkingv1.IngressClass) error {
 	for _, ing := range ingressList {
 		ingIc, err := util.GetIngressClass(ing, s.IngressClassLister)
 		if err != nil {
-			return errors.Wrap(err, "error getting ingress class")
-		}
-		if ingIc != nil && ingressClass.Name == ingIc.Name && !util.IsIngressDeleting(ing) {
-			ingressGroup = append(ingressGroup, ing)
+			klog.Errorf("IngressClass not found for ingress: %s. Skipping ingress.", ing.Name)
+		} else {
+			if ingIc != nil && ingressClass.Name == ingIc.Name && !util.IsIngressDeleting(ing) {
+				ingressGroup = append(ingressGroup, ing)
+			}
 		}
 	}
 

--- a/pkg/state/ingressstate_test.go
+++ b/pkg/state/ingressstate_test.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	TlsConfigValidationsFilePath              = "validate-tls-config.yaml"
-	HealthCheckerConfigValidationsFilePath    = "validate-hc-config.yaml"
-	BackendSetPolicyConfigValidationsFilePath = "validate-bs-policy-config.yaml"
-	ListenerProtocolConfigValidationsFilePath = "validate-listener-protocol-config.yaml"
-	TestIngressStateFilePath                  = "test-ingress-state.yaml"
-	TestIngressStateWithPortNameFilePath      = "test-ingress-state_withportname.yaml"
+	TlsConfigValidationsFilePath                = "validate-tls-config.yaml"
+	HealthCheckerConfigValidationsFilePath      = "validate-hc-config.yaml"
+	BackendSetPolicyConfigValidationsFilePath   = "validate-bs-policy-config.yaml"
+	ListenerProtocolConfigValidationsFilePath   = "validate-listener-protocol-config.yaml"
+	TestIngressStateFilePath                    = "test-ingress-state.yaml"
+	TestIngressStateFilePathMissingIngressClass = "test-ingress-state-missing-class.yaml"
+	TestIngressStateWithPortNameFilePath        = "test-ingress-state_withportname.yaml"
 )
 
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList, ingressList *networkingv1.IngressList, testService *v1.ServiceList) (networkinglisters.IngressClassLister, networkinglisters.IngressLister, corelisters.ServiceLister) {
@@ -397,4 +398,23 @@ func TestValidateProtocolConfigWithConflict(t *testing.T) {
 	Expect(err).Should(HaveOccurred())
 
 	Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf(ProtocolConflictMessage, 900)))
+}
+
+func TestIngressStateWithMissingIngressClass(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ingressClassList := testutil.GetIngressClassList()
+
+	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateFilePathMissingIngressClass)
+
+	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
+	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
+
+	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
+	err := stateStore.BuildState(&ingressClassList.Items[0])
+	Expect(err).NotTo(HaveOccurred())
+
+	assertCases(stateStore)
 }

--- a/pkg/state/test-ingress-state-missing-class.yaml
+++ b/pkg/state/test-ingress-state-missing-class.yaml
@@ -1,0 +1,122 @@
+#
+# OCI Native Ingress Controller
+#
+# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state
+  namespace: default
+spec:
+  ingressClassName: default-ingress-class
+  tls:
+    - hosts:
+        - foo.bar.com
+      secretName: secret_name
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 80
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/ExactEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 70
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state-new
+  namespace: default
+spec:
+  ingressClassName: default-ingress-class
+  tls:
+    - hosts:
+        - foo.bar.com
+      secretName: secret_name
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1/aa"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 80
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/ExactEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 90
+    - http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 100
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-state-excluded
+  namespace: default
+spec:
+  ingressClassName: missing-ingress-class
+  tls:
+    - hosts:
+        - foo.bar.com
+      secretName: secret_name
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1/aa"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 80
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/ExactEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 90
+    - http:
+        paths:
+          - pathType: Prefix
+            path: "/PrefixEcho1"
+            backend:
+              service:
+                name: tls-test
+                port:
+                  number: 100


### PR DESCRIPTION
- Added code to skip ingress if no usable ingressclass is found.