### PR TITLE
Specify region in values.yaml instead of hardcoding in deployment.yaml

### DIFF
--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION
               value: "2.2"
             - name: OCI_RESOURCE_PRINCIPAL_REGION
-              value: "us-phoenix-1"
+              value: {{ .Values.region }}
             - name: OCI_SDK_DEFAULT_RETRY_ENABLED
               value: "true"
           ports:

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -97,6 +97,8 @@ webhookBindPort: 9443
 # Supported auths - instance(default), user
 authType: instance
 authSecretName: oci-config
+# Region where OKE cluster is deployed
+region: ""
 
 # objectSelector for webhook
 objectSelector:


### PR DESCRIPTION
Instead of hardcoding the region within the deployment file, it might be easier to allow the user to specify it within values.yaml. This will make it easier to override the region value when deploying the ingress controller in other regions. 