### PR TITLE
Mtls verify annotation support in native ingress controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ build: ./main.go
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on go build -mod vendor -a -o dist/onic ./main.go
 
 image:
+
+	docker build --platform linux/amd64 --build-arg goos=$(GOOS) --build-arg goarch=$(GOARCH) -t ${IMAGE_PATH} -f Dockerfile .
 	docker build --build-arg goos=$(GOOS) --build-arg goarch=$(GOARCH) -t ${IMAGE_PATH} -f Dockerfile .
 
 push:

--- a/pkg/controllers/ingress/util.go
+++ b/pkg/controllers/ingress/util.go
@@ -337,7 +337,9 @@ func GetSSLConfigForListener(namespace string, listener *ociloadbalancer.Listene
 		}
 		newCertificateId = *cId
 	}
-
+	// //TODO add VerifyPeerCertificate here
+	//   https://github.com/oracle/oci-go-sdk/blob/master/example/example_loadbalancer_test.go
+	// listenerSslConfig.VerifyPeerCertificate(common.Bool(true))
 	if newCertificateId != "" {
 		certificateIds := []string{newCertificateId}
 		listenerSslConfig = &ociloadbalancer.SslConfigurationDetails{CertificateIds: certificateIds}

--- a/pkg/state/validate-mutual-tls-authentication.yaml
+++ b/pkg/state/validate-mutual-tls-authentication.yaml
@@ -1,0 +1,24 @@
+#
+# OCI Native Ingress Controller
+#
+# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-mutual-authentication-annotation-one
+  namespace: default
+  annotations:
+    oci-native-ingress.oraclecloud.com/mutual-tls-authentication: '[{"port": 80, "mode": "passthrough"}, {"port": 443, "mode": "verify","depth":1 }]'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Exact
+        path: "/HCPath"
+        backend:
+          service:
+            name: test-health-checker-annotation
+            port:
+              number: 800

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -52,6 +52,12 @@ const (
 	IngressListenerTlsCertificateAnnotation = "oci-native-ingress.oraclecloud.com/certificate-ocid"
 	IngressBackendTlsEnabledAnnotation      = "oci-native-ingress.oraclecloud.com/backend-tls-enabled"
 
+	//verify client certificate , only use the lisentner bound CA certificate to verify the client certificate .
+	/*
+	 mutual-tls-authentication: '[{"port": 80, "mode": "passthrough"}, {"port": 443, "mode": "verify","depth":1 }]'
+	*/
+	IngressListenerMutualTlsVerifyAnnotation = "oci-native-ingress.oraclecloud.com/mutual-tls-authentication"
+
 	// IngressProtocolAnntoation - HTTP only for now
 	// HTTP, HTTP2 - accepted.
 	IngressProtocolAnnotation = "oci-native-ingress.oraclecloud.com/protocol"
@@ -598,4 +604,13 @@ func RetrievePods(endpointLister corelisters.EndpointsLister, podLister corelist
 		pods = append(pods, pod)
 	}
 	return pods, nil
+}
+
+func GetMutualTlsVerifyAnnotation(i *networkingv1.Ingress) string {
+	mtlsVerifyPorts, ok := i.Annotations[IngressListenerMutualTlsVerifyAnnotation]
+	if !ok {
+		return ""
+	}
+
+	return strings.ToLower(mtlsVerifyPorts)
 }


### PR DESCRIPTION
Added an annotation in ingress to support client and LB mTLS authentication. By default, ca.crt in secret is used as TrustedCertificateAuthority .

`    oci-native-ingress.oraclecloud.com/mutual-tls-authentication: '[{"port": 80, "mode": "passthrough"}, {"port": 443, "mode": "verify","depth":1 }]'
`