### PR TITLE
Fix namespace deletion on helm upgrade

### DIFF
--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -4,7 +4,8 @@
 # Copyright (c) 2023 Oracle America, Inc. and its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-{{- if not (lookup "v1" "Namespace" "" .Values.deploymentNamespace)}}
+{{- $ns := lookup "v1" "Namespace" "" .Values.deploymentNamespace }}
+{{- if or (not $ns) (eq (get $ns.metadata.labels "app.kubernetes.io/managed-by") "Helm") }}
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
- Currently `helm upgrade` deletes the NIC namespace if it was created by a helm install. Bug introduced in #55 
- If the required namespace already exists and is managed by helm, we include it in the desired maifest in deployment.yaml to preserve it during `helm upgrade`