### PR TITLE
Add metadata env variable

### DIFF
--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
               value: {{ .Values.region }}
             - name: OCI_SDK_DEFAULT_RETRY_ENABLED
               value: "true"
+            - name: OCI_REGION_METADATA
+              value: {{ squote .Values.ociRegionMetadataEnvString }}
           ports:
             - name: webhook-server
               containerPort: {{.Values.webhookBindPort}}

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -28,6 +28,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# OCI_REGION_METADATA Env variable string, to specify region metadata for regions not listed in oci-go-sdk
+# Reference - https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_adding_new_region_endpoints.htm#SDK_Adding_Regions_Environment_Variable
+# Example - ociRegionMetadataEnvString: '{"realmKey":"OC1","realmDomainComponent":"oraclecloud.com","regionKey":"SYD","regionIdentifier":"ap-sydney-1"}'
+# Note that single quote wrap is necessary
+ociRegionMetadataEnvString: ''
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Adding OCI_REGION_METADATA env var for missing regions in oci-go-sdk