### PR TITLE
Added support for ingress-level listener port annotations

### DIFF
--- a/pkg/controllers/backend/backend.go
+++ b/pkg/controllers/backend/backend.go
@@ -217,7 +217,7 @@ func (c *Controller) getDefaultBackends(ingresses []*networkingv1.Ingress) ([]oc
 
 	for _, ingress := range ingresses {
 		if ingress.Spec.DefaultBackend != nil {
-			if backend != nil && backend != ingress.Spec.DefaultBackend {
+			if backend != nil && !util.IsBackendServiceEqual(backend, ingress.Spec.DefaultBackend) {
 				return nil, fmt.Errorf("conflict in default backend resource, only one is permitted")
 			}
 			backend = ingress.Spec.DefaultBackend

--- a/pkg/controllers/nodeBackend/nodeBackend.go
+++ b/pkg/controllers/nodeBackend/nodeBackend.go
@@ -283,7 +283,7 @@ func (c *Controller) getDefaultBackends(ingresses []*networkingv1.Ingress) ([]oc
 
 	for _, ingress := range ingresses {
 		if ingress.Spec.DefaultBackend != nil {
-			if backend != nil && backend != ingress.Spec.DefaultBackend {
+			if backend != nil && !util.IsBackendServiceEqual(backend, ingress.Spec.DefaultBackend) {
 				return nil, fmt.Errorf("conflict in default backend resource, only one is permitted")
 			}
 			backend = ingress.Spec.DefaultBackend


### PR DESCRIPTION
- Added Ingress level listener port annotations, allowing users to specify a single port to multiplex their http(s) traffic through for an ingress
- Fixed default backend determination