### PR TITLE
Extract CA chain from tls.crt if ca.crt is missing for secret-type tls artifact

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -443,7 +443,7 @@ We will be able to configure ingress routes those are HTTPS enabled. Customers c
 - Customer can use the same credentials in their pods to make this an end to end SSL support.
 
 ##### Sample configuration : Using Secret
-We create OCI certificate service certificates and cabundles for each kubernetes secret. Hence the content of the secret (ca.crt, tls.crt, tlskey) should conform to the certificate service standards.
+We create OCI certificate service certificates and cabundles for each kubernetes secret. Hence the content of the secret (ca.crt, tls.crt, tls.key) should conform to the certificate service standards.
 Ref Documents:
 - [Validation of Certificate chain](https://docs.oracle.com/en-us/iaas/Content/certificates/invalidcertificatechain.htm)
 - [Validation of CA Bundle](https://docs.oracle.com/en-us/iaas/Content/certificates/invalidcabundlepem.htm)
@@ -461,6 +461,8 @@ metadata:
   name: demo-tls-secret
 type: kubernetes.io/tls
 ```
+Note: If `ca.crt` field is missing/empty, the entire certificate chain is expected to be present in `tls.crt`. The server certificate MUST be first, followed by chain of CAs.
+
 Ingress Format: 
 ```
 apiVersion: networking.k8s.io/v1

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -548,21 +548,22 @@ func GetSampleSecret(configName string, privateKey string, data string, privateK
 	return secret
 }
 
-func GetSampleCertSecret() *v1.Secret {
-	namespace := "test"
-	name := "oci-cert"
-	s := "some-random"
+func GetSampleCertSecret(namespace, name, caChain, cert, key string) *v1.Secret {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
 		Data: map[string][]byte{
-			"ca.crt":  []byte(s),
-			"tls.crt": []byte(s),
-			"tls.key": []byte(s),
+			"tls.crt": []byte(cert),
+			"tls.key": []byte(key),
 		},
 	}
+
+	if caChain != "" {
+		secret.Data["ca.crt"] = []byte(caChain)
+	}
+
 	return secret
 }
 


### PR DESCRIPTION
This resolves Issue #60  and is derivative of PR #61 

### Changes
- Extract CA cert chain from tls.crt if ca.crt is missing/empty
- Added a note in GettingStarted.md for the same