### PR TITLE
Sync with Internal Repo for bug fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,8 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          go test -covermode=count -coverprofile=profile.cov  $(go list ./pkg/... | grep -v /server | grep -v /testutil)
+          go test -covermode=count -coverprofile=profile.cov.tmp  $(go list ./pkg/... | grep -v /server)
+          cat profile.cov.tmp | grep -v /pkg/util/testutil.go  > profile.cov
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/auth/auth_service_test.go
+++ b/pkg/auth/auth_service_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/types"
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -24,7 +24,7 @@ func setUp(secret *v1.Secret, setClient bool) *fakeclientset.Clientset {
 		action := "get"
 		resource := "secrets"
 		obj := secret
-		testutil.FakeClientGetCall(client, action, resource, obj)
+		util.FakeClientGetCall(client, action, resource, obj)
 	}
 	return client
 }
@@ -38,7 +38,7 @@ func TestGetConfigurationProviderSuccess(t *testing.T) {
 	}
 	configName := "config"
 	privateKey := "private-key"
-	secret := testutil.GetSampleSecret(configName, privateKey, data, PrivateKey)
+	secret := util.GetSampleSecret(configName, privateKey, data, PrivateKey)
 	client := setUp(secret, true)
 
 	auth, err := GetConfigurationProvider(ctx, opts, client)
@@ -53,7 +53,7 @@ func TestGetConfigurationProviderFailSecret(t *testing.T) {
 		AuthType:       "user",
 		AuthSecretName: "oci-config",
 	}
-	secret := testutil.GetSampleSecret("test", "error", data, PrivateKey)
+	secret := util.GetSampleSecret("test", "error", data, PrivateKey)
 
 	client := setUp(secret, false)
 	auth, err := GetConfigurationProvider(ctx, opts, client)
@@ -67,14 +67,14 @@ func TestGetConfigurationProviderFailSecret(t *testing.T) {
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("auth config data is empty: oci-config"))
 
-	secret = testutil.GetSampleSecret("config", "error", data, PrivateKey)
+	secret = util.GetSampleSecret("config", "error", data, PrivateKey)
 	client = setUp(secret, true)
 	auth, err = GetConfigurationProvider(ctx, opts, client)
 	Expect(auth == nil).Should(BeTrue())
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("missing auth config data: invalid user auth config data: oci-config"))
 
-	secret = testutil.GetSampleSecret("configs", "error", data, PrivateKey)
+	secret = util.GetSampleSecret("configs", "error", data, PrivateKey)
 	client = setUp(secret, true)
 	auth, err = GetConfigurationProvider(ctx, opts, client)
 	Expect(auth == nil).Should(BeTrue())
@@ -108,7 +108,7 @@ func TestParseAuthConfig(t *testing.T) {
 	RegisterTestingT(t)
 	configName := "config"
 	privateKey := "private-key"
-	secret := testutil.GetSampleSecret(configName, privateKey, data, PrivateKey)
+	secret := util.GetSampleSecret(configName, privateKey, data, PrivateKey)
 	authCfg, err := ParseAuthConfig(secret, "oci-config")
 	Expect(err == nil).Should(BeTrue())
 	Expect(authCfg.TenancyID).Should(Equal("ocid1.tenancy.oc1..aaaaaaaa_example"))
@@ -121,12 +121,12 @@ func TestParseAuthConfig(t *testing.T) {
 
 func TestParseAuthConfigWithError(t *testing.T) {
 	RegisterTestingT(t)
-	secret := testutil.GetSampleSecret("error", "", data, PrivateKey)
+	secret := util.GetSampleSecret("error", "", data, PrivateKey)
 	_, err := ParseAuthConfig(secret, "oci-configs")
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("invalid auth config data: oci-configs"))
 
-	secret = testutil.GetSampleSecret("config", "", data, PrivateKey)
+	secret = util.GetSampleSecret("config", "", data, PrivateKey)
 	_, err = ParseAuthConfig(secret, "oci-configs")
 	Expect(err != nil).Should(BeTrue())
 	Expect(err.Error()).Should(Equal("invalid user auth config data: oci-configs"))

--- a/pkg/controllers/backend/backendPathWithNamedTargetPortDefaultBackend.yaml
+++ b/pkg/controllers/backend/backendPathWithNamedTargetPortDefaultBackend.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+  namespace: default
+spec:
+  defaultBackend:
+    service:
+      name: service-with-named-target-port
+      port:
+        number: 8081
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho1"
+            backend:
+              service:
+                name: testecho1
+                port:
+                  number: 80

--- a/pkg/controllers/backend/backendPathWithNamedTargetPortService.yaml
+++ b/pkg/controllers/backend/backendPathWithNamedTargetPortService.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+  namespace: default
+spec:
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/service-with-named-target-port"
+            backend:
+              service:
+                name: service-with-named-target-port
+                port:
+                  number: 8081
+    - host: "foo.bar.com1"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/service-with-numeric-target-port"
+            backend:
+              service:
+                name: service-with-named-target-port
+                port:
+                  name: "port_8082"

--- a/pkg/controllers/backend/backend_test.go
+++ b/pkg/controllers/backend/backend_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	backendPath                   = "backendPath.yaml"
-	backendPathWithDefaultBackend = "backendPathWithDefaultBackend.yaml"
-	namespace                     = "default"
+	backendPath                                  = "backendPath.yaml"
+	backendPathWithDefaultBackend                = "backendPathWithDefaultBackend.yaml"
+	backendPathWithNamedTargetPortService        = "backendPathWithNamedTargetPortService.yaml"
+	backendPathWithNamedTargetPortDefaultBackend = "backendPathWithNamedTargetPortDefaultBackend.yaml"
+	namespace                                    = "default"
 )
 
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList, ingressList *networkingv1.IngressList, testService *corev1.ServiceList, endpoints *corev1.EndpointsList, pod *corev1.PodList) (networkinginformers.IngressClassInformer, networkinginformers.IngressInformer, corelisters.ServiceLister, corelisters.EndpointsLister, corelisters.PodLister, *fakeclientset.Clientset) {
@@ -126,6 +128,7 @@ func TestNoDefaultBackends(t *testing.T) {
 	Expect(err == nil).Should(Equal(true))
 	Expect(len(backends)).Should(Equal(0))
 }
+
 func TestDefaultBackends(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -136,6 +139,28 @@ func TestDefaultBackends(t *testing.T) {
 	backends, err := c.getDefaultBackends(ingresses)
 	Expect(err == nil).Should(Equal(true))
 	Expect(len(backends)).Should(Equal(1))
+}
+
+func TestDefaultBackendsWithNamedTargetPort(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingressClassList := util.GetIngressClassList()
+	c := inits(ctx, ingressClassList, backendPathWithNamedTargetPortDefaultBackend)
+	ingresses, _ := util.GetIngressesForClass(c.ingressLister, &ingressClassList.Items[0])
+	backends, err := c.getDefaultBackends(ingresses)
+	Expect(err == nil).Should(Equal(true))
+	Expect(len(backends)).Should(Equal(1))
+}
+
+func TestEnsureBackendWithNamedTargetPort(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingressClassList := util.GetIngressClassList()
+	c := inits(ctx, ingressClassList, backendPathWithNamedTargetPortService)
+	err := c.ensureBackends(&ingressClassList.Items[0], "id")
+	Expect(err == nil).Should(Equal(true))
 }
 
 func TestEnsurePodReadinessConditionWithExistingReadiness(t *testing.T) {

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -258,7 +258,10 @@ func (m MockLoadBalancerClient) UpdateBackendSet(ctx context.Context, request oc
 }
 
 func (m MockLoadBalancerClient) DeleteBackendSet(ctx context.Context, request ociloadbalancer.DeleteBackendSetRequest) (ociloadbalancer.DeleteBackendSetResponse, error) {
-	return ociloadbalancer.DeleteBackendSetResponse{}, nil
+	return ociloadbalancer.DeleteBackendSetResponse{
+		OpcRequestId:     common.String("OpcRequestId"),
+		OpcWorkRequestId: common.String("OpcWorkRequestId"),
+	}, nil
 }
 
 func (m MockLoadBalancerClient) GetBackendSetHealth(ctx context.Context, request ociloadbalancer.GetBackendSetHealthRequest) (ociloadbalancer.GetBackendSetHealthResponse, error) {

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/informers"
@@ -33,12 +33,12 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 	action := "list"
 
-	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	testutil.UpdateFakeClientCall(client, "get", "ingresses", &ingressList.Items[0])
-	testutil.UpdateFakeClientCall(client, "update", "ingresses", &ingressList.Items[0])
-	testutil.UpdateFakeClientCall(client, "patch", "ingresses", &ingressList.Items[0])
-	testutil.UpdateFakeClientCall(client, action, "services", testService)
+	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	util.UpdateFakeClientCall(client, "get", "ingresses", &ingressList.Items[0])
+	util.UpdateFakeClientCall(client, "update", "ingresses", &ingressList.Items[0])
+	util.UpdateFakeClientCall(client, "patch", "ingresses", &ingressList.Items[0])
+	util.UpdateFakeClientCall(client, action, "services", testService)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -58,7 +58,7 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 
 func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList, ingressList *networkingv1.IngressList) *Controller {
 
-	testService := testutil.GetServiceListResource(namespace, "testecho1", 80)
+	testService := util.GetServiceListResource(namespace, "testecho1", 80)
 	lbClient := GetLoadBalancerClient()
 	certClient := GetCertClient()
 	certManageClient := GetCertManageClient()
@@ -87,8 +87,8 @@ func TestSync(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPath)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPath)
 	c := inits(ctx, ingressClassList, ingressList)
 	err := c.sync("default/ingress-readiness")
 
@@ -100,8 +100,8 @@ func TestEnsureIngressSuccess(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPath)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPath)
 	c := inits(ctx, ingressClassList, ingressList)
 	err := c.ensureIngress(&ingressList.Items[0], &ingressClassList.Items[0])
 
@@ -111,8 +111,8 @@ func TestEnsureLoadBalancerIP(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPath)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPath)
 	c := inits(ctx, ingressClassList, ingressList)
 	err := c.ensureLoadBalancerIP("ip", &ingressList.Items[0])
 	Expect(err == nil).Should(Equal(true))
@@ -122,8 +122,8 @@ func TestEnsureFinalizer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPathWithFinalizer)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
 	err := c.ensureFinalizer(&ingressList.Items[0])
 	Expect(err == nil).Should(Equal(true))
@@ -135,8 +135,8 @@ func TestDeleteIngress(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPathWithFinalizer)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
 	err := c.deleteIngress(&ingressList.Items[0])
 	Expect(err == nil).Should(Equal(true))
@@ -148,8 +148,8 @@ func TestIngressAdd(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPath)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPath)
 	c := inits(ctx, ingressClassList, ingressList)
 	queueSize := c.queue.Len()
 	c.ingressAdd(&ingressList.Items[0])
@@ -160,8 +160,8 @@ func TestIngressUpdate(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPathWithFinalizer)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
 	queueSize := c.queue.Len()
 	c.ingressUpdate(&ingressList.Items[0], &ingressList.Items[1])
@@ -171,8 +171,8 @@ func TestIngressDelete(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
-	ingressList := testutil.ReadResourceAsIngressList(ingressPathWithFinalizer)
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
 	queueSize := c.queue.Len()
 	c.ingressDelete(&ingressList.Items[0])
@@ -183,8 +183,8 @@ func TestProcessNextItem(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassListWithLBSet("id")
-	ingressList := testutil.ReadResourceAsIngressList(ingressPathWithFinalizer)
+	ingressClassList := util.GetIngressClassListWithLBSet("id")
+	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
 
 	c.queue.Add("default-ingress-class")
@@ -200,7 +200,7 @@ type MockLoadBalancerClient struct {
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := testutil.SampleLoadBalancerResponse()
+	res := util.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/controllers/ingress/util_test.go
+++ b/pkg/controllers/ingress/util_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/state"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -131,11 +130,11 @@ const (
 
 func initsUtil() (*client.ClientProvider, ociloadbalancer.LoadBalancer) {
 	k8client := fakeclientset.NewSimpleClientset()
-	secret := testutil.GetSampleCertSecret("test", "oci-cert", "chain", "cert", "key")
+	secret := util.GetSampleCertSecret("test", "oci-cert", "chain", "cert", "key")
 	action := "get"
 	resource := "secrets"
 	obj := secret
-	testutil.FakeClientGetCall(k8client, action, resource, obj)
+	util.FakeClientGetCall(k8client, action, resource, obj)
 
 	certClient := GetCertClient()
 	certManageClient := GetCertManageClient()
@@ -298,13 +297,13 @@ func TestGetTlsSecretContent(t *testing.T) {
 
 	testCaChain, testCert, testKey := generateTestCertsAndKey()
 
-	secretWithCaCrt := testutil.GetSampleCertSecret("test", "secretWithCaCrt", testCaChain, testCert, testKey)
-	secretWithCorrectChain := testutil.GetSampleCertSecret("test", "secretWithCorrectChain", "", testCert+testCaChain, testKey)
-	secretWithWrongChain := testutil.GetSampleCertSecret("test", "secretWithWrongChain", "", testCaChain+testCert, testKey)
-	secretWithoutCaCrt := testutil.GetSampleCertSecret("test", "secretWithoutCaCrt", "", testCert, testKey)
+	secretWithCaCrt := util.GetSampleCertSecret("test", "secretWithCaCrt", testCaChain, testCert, testKey)
+	secretWithCorrectChain := util.GetSampleCertSecret("test", "secretWithCorrectChain", "", testCert+testCaChain, testKey)
+	secretWithWrongChain := util.GetSampleCertSecret("test", "secretWithWrongChain", "", testCaChain+testCert, testKey)
+	secretWithoutCaCrt := util.GetSampleCertSecret("test", "secretWithoutCaCrt", "", testCert, testKey)
 
 	k8client := fakeclientset.NewSimpleClientset()
-	testutil.FakeClientGetCall(k8client, "get", "secrets", secretWithCaCrt)
+	util.FakeClientGetCall(k8client, "get", "secrets", secretWithCaCrt)
 
 	secretData1, err := getTlsSecretContent("test", "secretWithCaCrt", k8client)
 	Expect(err).ToNot(HaveOccurred())
@@ -312,18 +311,18 @@ func TestGetTlsSecretContent(t *testing.T) {
 	Expect(*secretData1.ServerCertificate).To(Equal(testCert))
 	Expect(*secretData1.PrivateKey).To(Equal(testKey))
 
-	testutil.FakeClientGetCall(k8client, "get", "secrets", secretWithCorrectChain)
+	util.FakeClientGetCall(k8client, "get", "secrets", secretWithCorrectChain)
 	secretData2, err := getTlsSecretContent("test", "secretWithCorrectChain", k8client)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(*secretData2.CaCertificateChain).To(Equal(testCaChain))
 	Expect(*secretData2.ServerCertificate).To(Equal(testCert))
 	Expect(*secretData2.PrivateKey).To(Equal(testKey))
 
-	testutil.FakeClientGetCall(k8client, "get", "secrets", secretWithWrongChain)
+	util.FakeClientGetCall(k8client, "get", "secrets", secretWithWrongChain)
 	_, err = getTlsSecretContent("test", "secretWithWrongChain", k8client)
 	Expect(err).To(HaveOccurred())
 
-	testutil.FakeClientGetCall(k8client, "get", "secrets", secretWithoutCaCrt)
+	util.FakeClientGetCall(k8client, "get", "secrets", secretWithoutCaCrt)
 	_, err = getTlsSecretContent("test", "secretWithoutCaCrt", k8client)
 	Expect(err).To(HaveOccurred())
 }

--- a/pkg/controllers/ingressclass/ingressclass_test.go
+++ b/pkg/controllers/ingressclass/ingressclass_test.go
@@ -9,11 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
-
 	"github.com/oracle/oci-go-sdk/v65/waf"
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
 
 	"github.com/oracle/oci-native-ingress-controller/api/v1beta1"
 
@@ -33,7 +31,7 @@ import (
 func TestEnsureLoadBalancer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -44,7 +42,7 @@ func TestEnsureLoadBalancerWithLbIdSet(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := testutil.GetIngressClassListWithLBSet("id")
+	ingressClassList := util.GetIngressClassListWithLBSet("id")
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -55,7 +53,7 @@ func TestEnsureLoadBalancerWithNotFound(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := testutil.GetIngressClassListWithLBSet("notfound")
+	ingressClassList := util.GetIngressClassListWithLBSet("notfound")
 	c := inits(ctx, ingressClassList)
 
 	ic := &ingressClassList.Items[0]
@@ -68,7 +66,7 @@ func TestEnsureLoadBalancerWithNetworkError(t *testing.T) {
 	RegisterTestingT(t)
 	ctx := context.TODO()
 
-	ingressClassList := testutil.GetIngressClassListWithLBSet("networkerror")
+	ingressClassList := util.GetIngressClassListWithLBSet("networkerror")
 	c := inits(ctx, ingressClassList)
 
 	err := c.ensureLoadBalancer(&ingressClassList.Items[0])
@@ -80,7 +78,7 @@ func TestIngressClassAdd(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassAdd(&ingressClassList.Items[0])
@@ -91,7 +89,7 @@ func TestIngressUpdate(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassUpdate(&ingressClassList.Items[0], &ingressClassList.Items[0])
@@ -101,7 +99,7 @@ func TestIngressClassDelete(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	queueSize := c.queue.Len()
 	c.ingressClassDelete(&ingressClassList.Items[0])
@@ -112,7 +110,7 @@ func TestDeleteIngressClass(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.deleteIngressClass(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -122,7 +120,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.deleteLoadBalancer(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -132,7 +130,7 @@ func TestEnsureFinalizer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.ensureFinalizer(&ingressClassList.Items[0])
 	Expect(err).Should(BeNil())
@@ -145,7 +143,7 @@ func TestSetupWebApplicationFirewall_WithPolicySet(t *testing.T) {
 	id := "id"
 	compartmentId := "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: "ocid1.webappfirewallpolicy.oc1.phx.amaaaaaah4gjgpya3siqywzdmre3mv4op3rzpo"}
-	ingressClassList := testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	c := inits(ctx, ingressClassList)
 	err := c.setupWebApplicationFirewall(&ingressClassList.Items[0], &compartmentId, &id)
 	Expect(err).Should(BeNil())
@@ -158,7 +156,7 @@ func TestSetupWebApplicationFirewall_NoPolicySet(t *testing.T) {
 	id := "id"
 	compartmentId := "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	err := c.setupWebApplicationFirewall(&ingressClassList.Items[0], &compartmentId, &id)
 	Expect(err).Should(BeNil())
@@ -168,7 +166,7 @@ func TestCheckForIngressClassParameterUpdates(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	loadBalancer, _, _ := c.client.GetLbClient().GetLoadBalancer(context.TODO(), "id")
 	icp := v1beta1.IngressClassParameters{
@@ -189,7 +187,7 @@ func TestDeleteFinalizer(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList)
 	var finalizers []string
 	finalizer := "oci.oraclecloud.com/ingress-controller-protection"
@@ -236,8 +234,8 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList)
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList) (networkinginformers.IngressClassInformer, *fakeclientset.Clientset) {
 	client := fakeclientset.NewSimpleClientset()
 
-	testutil.UpdateFakeClientCall(client, "list", "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(client, "patch", "ingressclasses", &ingressClassList.Items[0])
+	util.UpdateFakeClientCall(client, "list", "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(client, "patch", "ingressclasses", &ingressClassList.Items[0])
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -290,7 +288,7 @@ func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request oci
 		return ociloadbalancer.GetLoadBalancerResponse{}, &exception.NotFoundServiceError{}
 	}
 
-	res := testutil.SampleLoadBalancerResponse()
+	res := util.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/controllers/nodeBackend/nodeBackend.go
+++ b/pkg/controllers/nodeBackend/nodeBackend.go
@@ -173,7 +173,7 @@ func (c *Controller) ensureBackends(ingressClass *networkingv1.IngressClass, lbI
 					return err
 				}
 
-				svcName, svcPort, nodePort, err := util.PathToServiceAndTargetPort(svc, pSvc, ingress.Namespace, true)
+				svcName, svcPort, nodePort, err := util.PathToServiceAndTargetPort(c.endpointLister, svc, pSvc, ingress.Namespace, true)
 				if err != nil {
 					return err
 				}

--- a/pkg/controllers/nodeBackend/nodeBackend_test.go
+++ b/pkg/controllers/nodeBackend/nodeBackend_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -34,14 +33,14 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 
 	action := "list"
-	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	testutil.UpdateFakeClientCall(client, action, "services", testService)
-	testutil.UpdateFakeClientCall(client, action, "endpoints", endpoints)
-	testutil.UpdateFakeClientCall(client, "get", "endpoints", endpoints)
-	testutil.UpdateFakeClientCall(client, action, "pods", pod)
-	testutil.UpdateFakeClientCall(client, action, "nodes", nodes)
-	testutil.UpdateFakeClientCall(client, "get", "nodes", &nodes.Items[0])
+	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	util.UpdateFakeClientCall(client, action, "services", testService)
+	util.UpdateFakeClientCall(client, action, "endpoints", endpoints)
+	util.UpdateFakeClientCall(client, "get", "endpoints", endpoints)
+	util.UpdateFakeClientCall(client, action, "pods", pod)
+	util.UpdateFakeClientCall(client, action, "nodes", nodes)
+	util.UpdateFakeClientCall(client, "get", "nodes", &nodes.Items[0])
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -76,7 +75,7 @@ func TestEnsureBackend(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 
 	err := c.ensureBackends(&ingressClassList.Items[0], "id")
@@ -87,7 +86,7 @@ func TestRunPusher(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 
 	c.runPusher()
@@ -98,7 +97,7 @@ func TestProcessNextItem(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 
 	c.queue.Add("default-ingress-class")
@@ -112,7 +111,7 @@ func TestProcessNextItemWithNginx(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassListWithNginx()
+	ingressClassList := util.GetIngressClassListWithNginx()
 	c := inits(ctx, ingressClassList, backendPath, false)
 
 	c.queue.Add("nginx-ingress-class")
@@ -125,7 +124,7 @@ func TestNoDefaultBackends(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 	ingresses, _ := util.GetIngressesForClass(c.ingressLister, &ingressClassList.Items[0])
 	backends, err := c.getDefaultBackends(ingresses)
@@ -136,7 +135,7 @@ func TestDefaultBackends(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPathWithDefaultBackend, false)
 	ingresses, _ := util.GetIngressesForClass(c.ingressLister, &ingressClassList.Items[0])
 	backends, err := c.getDefaultBackends(ingresses)
@@ -149,7 +148,7 @@ func TestGetEndpoints(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, true)
 
 	endpoints, err := util.GetEndpoints(c.endpointLister, "test", "testecho1")
@@ -164,11 +163,11 @@ func TestGetEndpoints(t *testing.T) {
 
 func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList, yamlPath string, allCase bool) *Controller {
 
-	ingressList := testutil.ReadResourceAsIngressList(yamlPath)
-	testService := testutil.GetServiceListResource(namespace, "testecho1", 80)
-	endpoints := testutil.GetEndpointsResourceList("testecho1", namespace, allCase)
-	pod := testutil.GetPodResourceList("testpod", "echoserver")
-	nodes := testutil.GetNodesList()
+	ingressList := util.ReadResourceAsIngressList(yamlPath)
+	testService := util.GetServiceListResource(namespace, "testecho1", 80)
+	endpoints := util.GetEndpointsResourceList("testecho1", namespace, allCase)
+	pod := util.GetPodResourceList("testpod", "echoserver")
+	nodes := util.GetNodesList()
 	lbClient := getLoadBalancerClient()
 
 	loadBalancerClient := &lb.LoadBalancerClient{
@@ -188,7 +187,7 @@ func TestListWithPredicate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 
 	nodes, err := filterNodes(c.nodeLister)
@@ -202,7 +201,7 @@ func TestGetIngressesForClass(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, backendPath, false)
 	ic, err := util.GetIngressesForClass(c.ingressLister, &ingressClassList.Items[0])
 	Expect(err == nil).Should(Equal(true))
@@ -235,7 +234,7 @@ func (m MockLoadBalancerClient) UpdateLoadBalancerShape(ctx context.Context, req
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := testutil.SampleLoadBalancerResponse()
+	res := util.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/controllers/routingpolicy/routingpolicy_test.go
+++ b/pkg/controllers/routingpolicy/routingpolicy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ func TestEnsureRoutingRules(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	err := c.ensureRoutingRules(&ingressClassList.Items[0])
@@ -38,7 +38,7 @@ func TestProcessRoutingPolicy(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	listenerPaths := map[string][]*listenerPath{}
@@ -133,7 +133,7 @@ func TestRunPusher(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 	c := inits(ctx, ingressClassList, "routePath.yaml")
 
 	c.runPusher()
@@ -142,8 +142,8 @@ func TestRunPusher(t *testing.T) {
 
 func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList, yamlPath string) *Controller {
 
-	ingressList := testutil.ReadResourceAsIngressList(yamlPath)
-	testService := testutil.GetServiceListResource("test", "testecho1", 80)
+	ingressList := util.ReadResourceAsIngressList(yamlPath)
+	testService := util.GetServiceListResource("test", "testecho1", 80)
 	lbClient := getLoadBalancerClient()
 
 	loadBalancerClient := &lb.LoadBalancerClient{
@@ -163,9 +163,9 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 
 	action := "list"
-	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	testutil.UpdateFakeClientCall(client, action, "services", testService)
+	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	util.UpdateFakeClientCall(client, action, "services", testService)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -192,7 +192,7 @@ type MockLoadBalancerClient struct {
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := testutil.SampleLoadBalancerResponse()
+	res := util.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/controllers/routingpolicy/util_test.go
+++ b/pkg/controllers/routingpolicy/util_test.go
@@ -11,7 +11,6 @@ package routingpolicy
 import (
 	"fmt"
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
@@ -269,20 +268,20 @@ type TestPathToRoutingPolicy struct {
 func TestFilterIngressesForRoutingPolicy(t *testing.T) {
 	RegisterTestingT(t)
 
-	defaultIngressClass := testutil.GetIngressClassResource("default_ingressclass", true, "")
-	otherIngressClass := testutil.GetIngressClassResource("other_ingressclass", false, "")
+	defaultIngressClass := util.GetIngressClassResource("default_ingressclass", true, "")
+	otherIngressClass := util.GetIngressClassResource("other_ingressclass", false, "")
 
-	ingressWithoutIngressClass := testutil.GetIngressResource("ingress_without_ingressclass")
-	ingressWithDefaultIngressClass := testutil.GetIngressResource("ingress_with_default_ingressclass")
+	ingressWithoutIngressClass := util.GetIngressResource("ingress_without_ingressclass")
+	ingressWithDefaultIngressClass := util.GetIngressResource("ingress_with_default_ingressclass")
 	ingressWithDefaultIngressClass.Spec.IngressClassName = common.String("default_ingressclass")
 
-	ingressWithOtherIngressClass := testutil.GetIngressResource("ingress_with_other_ingressclass")
+	ingressWithOtherIngressClass := util.GetIngressResource("ingress_with_other_ingressclass")
 	ingressWithOtherIngressClass.Spec.IngressClassName = common.String("other_ingressclass")
 
-	deletingIngress := testutil.GetIngressResource("deleting_ingress")
+	deletingIngress := util.GetIngressResource("deleting_ingress")
 	deletingIngress.DeletionTimestamp = &v1.Time{Time: time.Now()}
 
-	ingressWithTCP := testutil.GetIngressResource("ingress_with_tcp")
+	ingressWithTCP := util.GetIngressResource("ingress_with_tcp")
 	ingressWithTCP.Annotations = map[string]string{
 		"oci-native-ingress.oraclecloud.com/protocol": "TCP",
 	}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -640,6 +640,10 @@ func (lbc *LoadBalancerClient) CreateListener(ctx context.Context, lbID string, 
 	}
 
 	if listenerProtocol == util.ProtocolHTTP2 {
+		if sslConfig == nil {
+			return fmt.Errorf("no TLS configuration provided for a HTTP2 listener at port %d", listenerPort)
+		}
+		
 		sslConfig.CipherSuiteName = common.String(util.ProtocolHTTP2DefaultCipherSuite)
 	}
 

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -213,7 +212,7 @@ func (m MockLoadBalancerClient) UpdateLoadBalancerShape(ctx context.Context, req
 }
 
 func (m MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
-	res := testutil.SampleLoadBalancerResponse()
+	res := util.SampleLoadBalancerResponse()
 	return res, nil
 }
 

--- a/pkg/podreadiness/webhook_test.go
+++ b/pkg/podreadiness/webhook_test.go
@@ -14,9 +14,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
+
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -80,8 +81,8 @@ func TestHandle(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressList := testutil.ReadResourceAsIngressList(podReadinessPath)
-	testService := testutil.GetServiceListResource("default", "testecho1", 80)
+	ingressList := util.ReadResourceAsIngressList(podReadinessPath)
+	testService := util.GetServiceListResource("default", "testecho1", 80)
 	ingressLister, serviceLister, client := setUp(ctx, ingressList, testService)
 	wb := NewWebhook(ingressLister, serviceLister, client)
 
@@ -175,7 +176,7 @@ func TestHandle(t *testing.T) {
 							Image: "echoserver",
 						},
 					},
-					ReadinessGates: testutil.GetPodReadinessGates("ingress-readiness", "foo.bar.com"),
+					ReadinessGates: util.GetPodReadinessGates("ingress-readiness", "foo.bar.com"),
 				},
 			},
 			op:            admissionv1.Create,

--- a/pkg/state/ingressstate_test.go
+++ b/pkg/state/ingressstate_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -43,9 +42,9 @@ func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	client := fakeclientset.NewSimpleClientset()
 
 	action := "list"
-	testutil.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(client, action, "ingresses", ingressList)
-	testutil.UpdateFakeClientCall(client, action, "services", testService)
+	util.UpdateFakeClientCall(client, action, "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(client, action, "ingresses", ingressList)
+	util.UpdateFakeClientCall(client, action, "services", testService)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
@@ -69,10 +68,10 @@ func TestListenerWithDifferentSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -86,15 +85,15 @@ func TestListenerWithSameSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	secretName := "same_secret_name"
 	ingressList.Items[0].Spec.TLS[0].SecretName = secretName
 	ingressList.Items[1].Spec.TLS[0].SecretName = secretName
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -118,14 +117,14 @@ func TestListenerWithSecretAndCertificate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "certificateId"}
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -140,16 +139,16 @@ func TestListenerWithDifferentCertificates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	ingressList.Items[0].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[0].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "certificateId"}
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: "differentCertificateId"}
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -163,9 +162,9 @@ func TestListenerWithSameCertificate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(TlsConfigValidationsFilePath)
 
 	certificateId := "certificateId"
 	ingressList.Items[0].Spec.TLS = []networkingv1.IngressTLS{}
@@ -174,7 +173,7 @@ func TestListenerWithSameCertificate(t *testing.T) {
 	ingressList.Items[1].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[1].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: certificateId}
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -196,11 +195,11 @@ func TestIngressState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateFilePath)
+	ingressList := util.ReadResourceAsIngressList(TestIngressStateFilePath)
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 943)
+	testService := util.GetServiceListResource("default", "tls-test", 943)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -215,11 +214,11 @@ func TestIngressStateWithPortName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateWithPortNameFilePath)
+	ingressList := util.ReadResourceAsIngressList(TestIngressStateWithPortNameFilePath)
 
-	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
+	testService := util.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -234,11 +233,11 @@ func TestIngressStateWithNamedClasses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TestIngressStateWithNamedClassesFilePath)
+	ingressList := util.ReadResourceAsIngressList(TestIngressStateWithNamedClassesFilePath)
 
-	testService := testutil.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
+	testService := util.GetServiceListResourceWithPortName("default", "tls-test", 80, "tls-port")
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -285,11 +284,11 @@ func TestValidateHealthCheckerConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
 
-	testService := testutil.GetServiceListResource("default", "test-health-checker-annotation", 800)
+	testService := util.GetServiceListResource("default", "test-health-checker-annotation", 800)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -321,13 +320,13 @@ func TestValidateHealthCheckerConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(HealthCheckerConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressHealthCheckPortAnnotation] = "9090"
 
-	testService := testutil.GetServiceListResource("default", "test-health-checker-annotation", 800)
+	testService := util.GetServiceListResource("default", "test-health-checker-annotation", 800)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -342,11 +341,11 @@ func TestValidatePolicyConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
 
-	testService := testutil.GetServiceListResource("default", "test-policy-annotation", 900)
+	testService := util.GetServiceListResource("default", "test-policy-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -365,13 +364,13 @@ func TestValidatePolicyConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(BackendSetPolicyConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressPolicyAnnotation] = "LEAST_CONNECTIONS"
 
-	testService := testutil.GetServiceListResource("default", "test-policy-annotation", 900)
+	testService := util.GetServiceListResource("default", "test-policy-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -386,11 +385,11 @@ func TestValidateProtocolConfig(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
 
-	testService := testutil.GetServiceListResource("default", "test-protocol-annotation", 900)
+	testService := util.GetServiceListResource("default", "test-protocol-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -405,13 +404,13 @@ func TestValidateProtocolConfigWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(ListenerProtocolConfigValidationsFilePath)
 
 	ingressList.Items[1].Annotations[util.IngressProtocolAnnotation] = "HTTP"
 
-	testService := testutil.GetServiceListResource("default", "test-protocol-annotation", 900)
+	testService := util.GetServiceListResource("default", "test-protocol-annotation", 900)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -426,15 +425,15 @@ func TestSslTerminationAtLB(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(TestSslTerminationAtLb)
+	ingressList := util.ReadResourceAsIngressList(TestSslTerminationAtLb)
 
 	certificateId := "certificateId"
 	ingressList.Items[0].Spec.TLS = []networkingv1.IngressTLS{}
 	ingressList.Items[0].Annotations = map[string]string{util.IngressListenerTlsCertificateAnnotation: certificateId}
 
-	testService := testutil.GetServiceListResource("default", "tls-test", 443)
+	testService := util.GetServiceListResource("default", "tls-test", 443)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -456,11 +455,11 @@ func TestValidateListenerDefaultBackendSet(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(DefaultBackendSetValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(DefaultBackendSetValidationsFilePath)
 
-	testService := testutil.GetServiceListResource("default", "tcp-test", 8080)
+	testService := util.GetServiceListResource("default", "tcp-test", 8080)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	stateStore := NewStateStore(ingressClassLister, ingressLister, serviceLister, nil)
@@ -476,11 +475,11 @@ func TestValidateListenerDefaultBackendSetWithConflict(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ingressClassList := testutil.GetIngressClassList()
+	ingressClassList := util.GetIngressClassList()
 
-	ingressList := testutil.ReadResourceAsIngressList(DefaultBackendSetValidationsFilePath)
+	ingressList := util.ReadResourceAsIngressList(DefaultBackendSetValidationsFilePath)
 
-	testService := testutil.GetServiceListResource("default", "tcp-test", 8080)
+	testService := util.GetServiceListResource("default", "tcp-test", 8080)
 	ingressClassLister, ingressLister, serviceLister := setUp(ctx, ingressClassList, ingressList, testService)
 
 	ingressList.Items[1].Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "tcp-test"

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -1,4 +1,4 @@
-package testutil
+package util
 
 import (
 	"encoding/base64"
@@ -9,7 +9,6 @@ import (
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
-	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,7 +146,7 @@ func GetIngressClassResource(name string, isDefault bool, controller string) *ne
 	return &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{util.IngressClassIsDefault: fmt.Sprint(isDefault)},
+			Annotations: map[string]string{IngressClassIsDefault: fmt.Sprint(isDefault)},
 		},
 		Spec: networkingv1.IngressClassSpec{
 			Controller: controller,
@@ -176,7 +175,7 @@ func GetIngressClassResourceWithLbId(name string, isDefault bool, controller str
 	return &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{util.IngressClassIsDefault: fmt.Sprint(isDefault), util.IngressClassLoadBalancerIdAnnotation: lbid},
+			Annotations: map[string]string{IngressClassIsDefault: fmt.Sprint(isDefault), IngressClassLoadBalancerIdAnnotation: lbid},
 		},
 		Spec: networkingv1.IngressClassSpec{
 			Controller: controller,
@@ -367,7 +366,7 @@ func GetPodResourceWithReadiness(name string, image string, ingressName string, 
 func GetPodReadinessGates(name string, host string) []v1.PodReadinessGate {
 	var gates []v1.PodReadinessGate
 
-	cond := util.GetPodReadinessCondition(name, host, GetHTTPPath())
+	cond := GetPodReadinessCondition(name, host, GetHTTPPath())
 	gates = append(gates, v1.PodReadinessGate{
 		ConditionType: cond,
 	})
@@ -432,7 +431,7 @@ func UpdateFakeClientCall(client *fakeclientset.Clientset, action string, resour
 func SampleLoadBalancerResponse() ociloadbalancer.GetLoadBalancerResponse {
 	etag := "testTag"
 	lbId := "id"
-	backendSetName := util.GenerateBackendSetName("default", "testecho1", 80)
+	backendSetName := GenerateBackendSetName("default", "testecho1", 80)
 	name := "testecho1-999"
 	port := 80
 	ip := "127.89.90.90"
@@ -449,7 +448,7 @@ func SampleLoadBalancerResponse() ociloadbalancer.GetLoadBalancerResponse {
 	backends = append(backends, backend)
 
 	healthChecker := &ociloadbalancer.HealthChecker{
-		Protocol:          common.String(util.ProtocolHTTP),
+		Protocol:          common.String(ProtocolHTTP),
 		UrlPath:           common.String("/health"),
 		Port:              common.Int(8080),
 		ReturnCode:        common.Int(200),
@@ -486,10 +485,10 @@ func SampleLoadBalancerResponse() ociloadbalancer.GetLoadBalancerResponse {
 	policies := map[string]ociloadbalancer.RoutingPolicy{
 		routeN: plcy,
 	}
-	proto := util.ProtocolHTTP
+	proto := ProtocolHTTP
 	listener := ociloadbalancer.Listener{
 		Name:                    &routeN,
-		DefaultBackendSetName:   common.String(util.DefaultBackendSetName),
+		DefaultBackendSetName:   common.String(DefaultBackendSetName),
 		Port:                    &port,
 		Protocol:                &proto,
 		HostnameNames:           nil,

--- a/pkg/waf/waf_test.go
+++ b/pkg/waf/waf_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/oracle/oci-native-ingress-controller/pkg/testutil"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	networkingv1 "k8s.io/api/networking/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -30,10 +29,10 @@ func setupClient() (*fakeclientset.Clientset, *Client, *networkingv1.IngressClas
 
 	k8client := fakeclientset.NewSimpleClientset()
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId}
-	ingressClassList := testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList := util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 
-	testutil.UpdateFakeClientCall(k8client, "list", "ingressclasses", ingressClassList)
-	testutil.UpdateFakeClientCall(k8client, "patch", "ingressclasses", &ingressClassList.Items[0])
+	util.UpdateFakeClientCall(k8client, "list", "ingressclasses", ingressClassList)
+	util.UpdateFakeClientCall(k8client, "patch", "ingressclasses", &ingressClassList.Items[0])
 
 	return k8client, wafClient, ingressClassList
 }
@@ -49,16 +48,16 @@ func TestClient_GetFireWallId(t *testing.T) {
 
 	// PolicyId and FireWall Set
 	annotations := map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassWafPolicyAnnotation: policyId, util.IngressClassFireWallIdAnnotation: "SetFirewall"}
-	ingressClassList = testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// Only FireWall Set
 	annotations = map[string]string{util.IngressClassIsDefault: fmt.Sprint(false), util.IngressClassFireWallIdAnnotation: "SetFirewall"}
-	ingressClassList = testutil.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
+	ingressClassList = util.GetIngressClassResourceWithAnnotation("ingressclass-withPolicy", annotations, "oci.oraclecloud.com/native-ingress-controller")
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 	// None Set
-	ingressClassList = testutil.GetIngressClassList()
+	ingressClassList = util.GetIngressClassList()
 	wafClient.GetFireWallId(k8client, &ingressClassList.Items[0], common.String(compartmentId), common.String("id"))
 
 }


### PR DESCRIPTION
Commits in this PR -
1. [fixed panic on no tls configuration for http2 annotated ingresses](https://github.com/oracle/oci-native-ingress-controller/pull/83/commits/63c702105d8c1a2b1e643baede92648fc89c4fd6) fixes a scenario where NIC panics if no TLS configuration is specified for an HTTP2 annotated Ingress. We return an error instead if we detect this while creating LB Listener.
2. [refactor testutil/testutil.go into util package](https://github.com/oracle/oci-native-ingress-controller/pull/83/commits/8990a097d68e476f4a2cde3e246989942b9b5ee3) refactors testutil/testutil.go to util/testutil.go to remove cyclic dependency with util package
3. [fix targetPort fetch logic for NPN backends](https://github.com/oracle/oci-native-ingress-controller/pull/83/commits/d4606c928a4779b773de60c03858c7862005958a) fixes Issue #78 
4. [updated build.yaml to exclude pkg/util/testutil.go from coverage profile](https://github.com/oracle/oci-native-ingress-controller/pull/83/commits/0bf044d751bf3aa978b908f940c76fff3b5f3f54) exludes pkg/util/testutil.go from coverage profile, as it only has helper functions for other unit tests