### PR TITLE
Fix finalizer removal logic for ingresses

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -201,7 +201,13 @@ func (c *Controller) sync(key string) error {
 
 	if ingressClass == nil || ingressClass.Spec.Controller != c.controllerClass {
 		klog.V(4).InfoS("skipping ingress class, not for this controller", "ingress", klog.KRef(namespace, name))
-		// skipping since ingress class is not applicable to this controller
+		// skipping since ingress class is not applicable to this controller, we remove our finalizer if it exists
+		deleteFinalizerErr := c.deleteFinalizer(ingress)
+		if deleteFinalizerErr != nil {
+			klog.V(4).Infof("Found Ingress %s/%s with finalizer %s, but not managed by this controller. Unable to delete"+
+				" finalizer due to error: %s", ingress.Namespace, ingress.Name, util.IngressControllerFinalizer, deleteFinalizerErr.Error())
+		}
+
 		return nil
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -321,6 +321,7 @@ func GetPodReadinessCondition(ingressName string, host string, path networkingv1
 	return corev1.PodConditionType(fmt.Sprintf("%s/%s", PodReadinessConditionPrefix, PathToRoutePolicyName(ingressName, host, path)))
 }
 
+// GetIngressClass returns non-nil error only if it's unable to list IngressClass resources. Returns (nil, nil) if no matching IngressClass found.
 func GetIngressClass(ingress *networkingv1.Ingress, ingressClassLister networkinglisters.IngressClassLister) (*networkingv1.IngressClass, error) {
 	icList, err := ingressClassLister.List(labels.Everything())
 	if err != nil {
@@ -336,6 +337,7 @@ func GetIngressClass(ingress *networkingv1.Ingress, ingressClassLister networkin
 			}
 		}
 
+		klog.V(4).Infof("no IngressClassName set for %s, and no default IngressClass found", ingress.Name)
 		return nil, nil
 	}
 
@@ -345,7 +347,8 @@ func GetIngressClass(ingress *networkingv1.Ingress, ingressClassLister networkin
 		}
 	}
 
-	return nil, errors.New("ingress class not found for ingress")
+	klog.V(4).Infof("for Ingress %s, set IngressClass %s not found", ingress.Name, *ingress.Spec.IngressClassName)
+	return nil, nil
 }
 
 func PathToServiceAndPort(ingressNamespace string, path networkingv1.HTTPIngressPath, serviceLister corelisters.ServiceLister) (string, int32, error) {


### PR DESCRIPTION
Currently, OCI Native Ingress Controller does not remove its guarding finalizer from Ingresses in these scenarios -
- Change of `Ingress.Spec.IngressClassName` to an IngressClass that is not handled by OCI NIC
- Non-existence of IngressClass corresponding to `Ingress.Spec.IngressClassName`, possibly because the IngressClass was deleted before Ingresses attached to it were

This fix adds code to remove finalizers in such scenarios, marking the Ingress free to delete as the backing LB resources do not exist.