### PR TITLE
Doc update for v1.4.0

### DIFF
--- a/deploy/example/customresource/ingressclassparameter.yaml
+++ b/deploy/example/customresource/ingressclassparameter.yaml
@@ -8,6 +8,7 @@ apiVersion: "ingress.oraclecloud.com/v1beta1"
 kind: IngressClassParameters
 metadata:
   name: ingressparms-cr-test
+  namespace: test
 spec:
   compartmentId: "ocid1.compartment.oc1..aaaaaaaaxaq3szzikh7cb53arlkdgbi4wz4g73qpnuqhdhqckr2d5rvdffya"
   subnetId: "ocid1.subnet.oc1.iad.aaaaaaaauckenasusv5odnc4bqspi77hgnjeo6ydq33hidzadpkjvce7vkpa"

--- a/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
@@ -18,10 +18,10 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -55,7 +55,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "ghcr.io/oracle/oci-native-ingress-controller:v1.3.9"
+          image: "ghcr.io/oracle/oci-native-ingress-controller:v1.4.0"
           imagePullPolicy: Always
           args: 
           - --lease-lock-name=oci-native-ingress-controller

--- a/deploy/manifests/oci-native-ingress-controller/templates/rbac.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/rbac.yaml
@@ -11,10 +11,10 @@ kind: ClusterRole
 metadata:
   name: oci-native-ingress-controller-role
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: [""]
@@ -51,10 +51,10 @@ kind: ClusterRoleBinding
 metadata:
   name: oci-native-ingress-controller-rolebinding
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -72,10 +72,10 @@ metadata:
   name: oci-native-ingress-controller-leader-election-role
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups: ["coordination.k8s.io"]
@@ -93,10 +93,10 @@ metadata:
   name: oci-native-ingress-controller-leader-election-rolebinding
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/manifests/oci-native-ingress-controller/templates/service.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/service.yaml
@@ -12,10 +12,10 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/deploy/manifests/oci-native-ingress-controller/templates/serviceaccount.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/serviceaccount.yaml
@@ -12,8 +12,8 @@ metadata:
   name: oci-native-ingress-controller
   namespace: native-ingress-controller-system
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm

--- a/deploy/manifests/oci-native-ingress-controller/templates/webhook.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/webhook.yaml
@@ -36,10 +36,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: oci-native-ingress-controller-webhook
   labels:
-    helm.sh/chart: oci-native-ingress-controller-1.3.9
+    helm.sh/chart: oci-native-ingress-controller-1.4.0
     app.kubernetes.io/name: oci-native-ingress-controller
     app.kubernetes.io/instance: oci-native-ingress-controller
-    app.kubernetes.io/version: "1.3.9"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/inject-ca-from: native-ingress-controller-system/oci-native-ingress-controller-webhook-serving-cert

--- a/helm/oci-native-ingress-controller/Chart.yaml
+++ b/helm/oci-native-ingress-controller/Chart.yaml
@@ -8,8 +8,8 @@ apiVersion: v2
 name: oci-native-ingress-controller
 description: OCI Native Ingress Controller
 type: application
-version: 1.3.9
-appVersion: "1.3.9"
+version: 1.4.0
+appVersion: "1.4.0"
 
 maintainers:
   - name: OKE Foundations team

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -22,7 +22,7 @@ image:
   repository: ghcr.io/oracle/oci-native-ingress-controller
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.3.9"
+  tag: "v1.4.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Doc updates for v1.4.0 -

1. Update helm version number to 1.4.0
2. Update image version to v1.4.0
3. Add some instructions for NIC upgrade, which specify using the latest helm chart
4. Add info for NSG, tagging, and delete protection support
5. Update manifest files