### PR TITLE
Honor secret updates, change created certificate name to be uid-unique

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"context"
 	"flag"
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"os"
 	"os/signal"
@@ -144,7 +145,12 @@ func main() {
 		}
 	}()
 
-	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Minute)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute,
+		informers.WithCustomResyncConfig(
+			map[metav1.Object]time.Duration{
+				&corev1.Secret{}: 0,
+			},
+		))
 
 	// listen for interrupts or the Linux SIGTERM signal and cancel
 	// our context, which the leader election code will observe and
@@ -157,13 +163,13 @@ func main() {
 		cancel()
 	}()
 
-	ingressClassInformer, ingressInformer, serviceInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer := setupInformers(informerFactory, ctx, classParamInformer)
+	ingressClassInformer, ingressInformer, serviceInformer, secretInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer := setupInformers(informerFactory, ctx, classParamInformer)
 
 	server.SetupWebhookServer(ingressInformer, serviceInformer, client, ctx)
 	mux := http.NewServeMux()
 	reg, err := server.SetupMetricsServer(opts.MetricsBackend, opts.MetricsPort, mux, ctx)
 
-	run := server.SetUpControllers(opts, ingressClassInformer, ingressInformer, client, serviceInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer, c, reg)
+	run := server.SetUpControllers(opts, ingressClassInformer, ingressInformer, client, serviceInformer, secretInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer, c, reg)
 
 	metric.ServeMetrics(opts.MetricsPort, mux)
 	// we use the Lease lock type since edits to Leases are less common
@@ -214,7 +220,7 @@ func main() {
 	})
 }
 
-func setupInformers(informerFactory informers.SharedInformerFactory, ctx context.Context, classParamInformer ctrcache.Informer) (networkinginformers.IngressClassInformer, networkinginformers.IngressInformer, v1.ServiceInformer, v1.EndpointsInformer, v1.PodInformer, v1.NodeInformer, v1.ServiceAccountInformer) {
+func setupInformers(informerFactory informers.SharedInformerFactory, ctx context.Context, classParamInformer ctrcache.Informer) (networkinginformers.IngressClassInformer, networkinginformers.IngressInformer, v1.ServiceInformer, v1.SecretInformer, v1.EndpointsInformer, v1.PodInformer, v1.NodeInformer, v1.ServiceAccountInformer) {
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()
 	go ingressClassInformer.Informer().Run(ctx.Done())
 
@@ -223,6 +229,9 @@ func setupInformers(informerFactory informers.SharedInformerFactory, ctx context
 
 	serviceInformer := informerFactory.Core().V1().Services()
 	go serviceInformer.Informer().Run(ctx.Done())
+
+	secretInformer := informerFactory.Core().V1().Secrets()
+	go secretInformer.Informer().Run(ctx.Done())
 
 	endpointInformer := informerFactory.Core().V1().Endpoints()
 	go endpointInformer.Informer().Run(ctx.Done())
@@ -245,6 +254,7 @@ func setupInformers(informerFactory informers.SharedInformerFactory, ctx context
 		ingressClassInformer.Informer().HasSynced,
 		ingressInformer.Informer().HasSynced,
 		serviceInformer.Informer().HasSynced,
+		secretInformer.Informer().HasSynced,
 		endpointInformer.Informer().HasSynced,
 		podInformer.Informer().HasSynced,
 		classParamInformer.HasSynced,
@@ -253,5 +263,5 @@ func setupInformers(informerFactory informers.SharedInformerFactory, ctx context
 
 		klog.Fatal("failed to sync informers")
 	}
-	return ingressClassInformer, ingressInformer, serviceInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer
+	return ingressClassInformer, ingressInformer, serviceInformer, secretInformer, endpointInformer, podInformer, nodeInformer, serviceAccountInformer
 }

--- a/pkg/controllers/ingress/certificate_util.go
+++ b/pkg/controllers/ingress/certificate_util.go
@@ -1,0 +1,365 @@
+/*
+ *
+ * * OCI Native Ingress Controller
+ * *
+ * * Copyright (c) 2024 Oracle America, Inc. and its affiliates.
+ * * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ *
+ */
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-native-ingress-controller/pkg/certificate"
+	"github.com/oracle/oci-native-ingress-controller/pkg/util"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+// Interacting with OCI Cert service, opinionated for Ingress Controller
+
+func GetCertificate(certificateId *string, certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.Certificate, string, error) {
+	certCacheObj := certificatesClient.GetFromCertCache(*certificateId)
+	if certCacheObj != nil {
+		now := time.Now()
+		if now.Sub(certCacheObj.Age).Minutes() < util.CertificateCacheMaxAgeInMinutes {
+			return certCacheObj.Cert, certCacheObj.Etag, nil
+		}
+		klog.Infof("Refreshing certificate %s", *certificateId)
+	}
+	return getCertificateBustCache(*certificateId, certificatesClient)
+}
+
+func getCertificateBustCache(certificateId string, certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.Certificate, string, error) {
+	getCertificateRequest := certificatesmanagement.GetCertificateRequest{
+		CertificateId: &certificateId,
+	}
+
+	cert, etag, err := certificatesClient.GetCertificate(context.TODO(), getCertificateRequest)
+	if err == nil {
+		certificatesClient.SetCertCache(cert, etag)
+	}
+	return cert, etag, err
+}
+
+// VerifyOrGetCertificateIdByName verifies that cert with certificateId has name certificateName
+// If not, try to find certificate with matching name
+func VerifyOrGetCertificateIdByName(certificateId string, certificateName string, compartmentId string,
+	certificatesClient *certificate.CertificatesClient) (string, error) {
+	if certificateId != "" {
+		cert, _, err := GetCertificate(&certificateId, certificatesClient)
+		if err != nil {
+			return "", err
+		}
+
+		if *cert.Name == certificateName {
+			return certificateId, nil
+		}
+	}
+
+	return FindCertificateWithName(certificateName, compartmentId, certificatesClient)
+}
+
+func FindCertificateWithName(certificateName string, compartmentId string,
+	certificatesClient *certificate.CertificatesClient) (string, error) {
+	listCertificatesRequest := certificatesmanagement.ListCertificatesRequest{
+		Name:           &certificateName,
+		CompartmentId:  &compartmentId,
+		LifecycleState: certificatesmanagement.ListCertificatesLifecycleStateActive,
+	}
+
+	klog.Infof("Searching for certificates with name %s in compartment %s.", certificateName, compartmentId)
+	listCertificates, _, err := certificatesClient.ListCertificates(context.TODO(), listCertificatesRequest)
+	if err != nil {
+		return "", err
+	}
+
+	if listCertificates.Items != nil {
+		numberOfCertificates := len(listCertificates.Items)
+		klog.Infof("Found %d certificates with name %s in compartment %s.", numberOfCertificates, certificateName, compartmentId)
+		if numberOfCertificates > 0 {
+			return *listCertificates.Items[0].Id, nil
+		}
+	}
+	klog.Infof("Found no certificates with name %s in compartment %s.", certificateName, compartmentId)
+	return "", nil
+}
+
+func CreateImportedTypeCertificate(tlsSecretData *TLSSecretData, certificateName string, compartmentId string,
+	certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.Certificate, error) {
+	configDetails := certificatesmanagement.CreateCertificateByImportingConfigDetails{
+		CertChainPem:   tlsSecretData.CaCertificateChain,
+		CertificatePem: tlsSecretData.ServerCertificate,
+		PrivateKeyPem:  tlsSecretData.PrivateKey,
+	}
+
+	certificateDetails := certificatesmanagement.CreateCertificateDetails{
+		Name:              &certificateName,
+		CertificateConfig: configDetails,
+		CompartmentId:     &compartmentId,
+		FreeformTags: map[string]string{
+			certificateHashTagKey: hashPublicTlsData(tlsSecretData),
+		},
+	}
+	createCertificateRequest := certificatesmanagement.CreateCertificateRequest{
+		CreateCertificateDetails: certificateDetails,
+		OpcRetryToken:            &certificateName,
+	}
+
+	createCertificate, etag, err := certificatesClient.CreateCertificate(context.TODO(), createCertificateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	certificatesClient.SetCertCache(createCertificate, etag)
+	klog.Infof("Created a certificate with ocid %s", *createCertificate.Id)
+	return createCertificate, nil
+}
+
+func UpdateImportedTypeCertificate(certificateId *string, tlsSecretData *TLSSecretData,
+	certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.Certificate, error) {
+	_, etag, err := GetCertificate(certificateId, certificatesClient)
+	if err != nil {
+		return nil, err
+	}
+
+	configDetails := certificatesmanagement.UpdateCertificateByImportingConfigDetails{
+		CertChainPem:   tlsSecretData.CaCertificateChain,
+		CertificatePem: tlsSecretData.ServerCertificate,
+		PrivateKeyPem:  tlsSecretData.PrivateKey,
+	}
+
+	updateCertificateDetails := certificatesmanagement.UpdateCertificateDetails{
+		CertificateConfig: configDetails,
+		FreeformTags: map[string]string{
+			certificateHashTagKey: hashPublicTlsData(tlsSecretData),
+		},
+	}
+
+	updateCertificateRequest := certificatesmanagement.UpdateCertificateRequest{
+		CertificateId:            certificateId,
+		IfMatch:                  common.String(etag),
+		UpdateCertificateDetails: updateCertificateDetails,
+	}
+
+	updateCertificate, etag, err := certificatesClient.UpdateCertificate(context.TODO(), updateCertificateRequest)
+
+	// This can happen by create/update listener calls that cause the certificate etag to change because of a new association
+	if util.IsServiceError(err, 409) {
+		klog.Infof("Update certificate returned code %d for certificate %s. Refreshing cache.", 409, *certificateId)
+		getCertificateBustCache(*certificateId, certificatesClient)
+		return nil, fmt.Errorf("unable to update certificate %s due to conflict, controller will retry later", *certificateId)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	certificatesClient.SetCertCache(updateCertificate, etag)
+	return updateCertificate, nil
+}
+
+func ScheduleCertificateVersionDeletion(certificateId string, versionNumber int64, certificatesClient *certificate.CertificatesClient) error {
+	request := certificatesmanagement.ScheduleCertificateVersionDeletionRequest{
+		ScheduleCertificateVersionDeletionDetails: certificatesmanagement.ScheduleCertificateVersionDeletionDetails{
+			TimeOfDeletion: &common.SDKTime{
+				Time: time.Now().Add(time.Hour * 24 * 10),
+			},
+		},
+		CertificateId:            &certificateId,
+		CertificateVersionNumber: &versionNumber,
+	}
+
+	updatedCert, etag, err := certificatesClient.ScheduleCertificateVersionDeletion(context.TODO(), request)
+	if err != nil {
+		return err
+	}
+
+	certificatesClient.SetCertCache(updatedCert, etag)
+	return nil
+}
+
+func PruneCertificateVersions(certificateId string, currentVersion int64,
+	versionsToPreserveCount int, certificatesClient *certificate.CertificatesClient) error {
+	listCertificateVersionsRequest := certificatesmanagement.ListCertificateVersionsRequest{
+		CertificateId: &certificateId,
+		SortOrder:     certificatesmanagement.ListCertificateVersionsSortOrderDesc,
+	}
+
+	certificateVersionCollection, _, err := certificatesClient.ListCertificateVersions(context.TODO(), listCertificateVersionsRequest)
+	if err != nil {
+		return err
+	}
+
+	versionsToPreserveSeen := 0
+	for _, certVersionSummary := range certificateVersionCollection.Items {
+		if *certVersionSummary.VersionNumber > currentVersion {
+			continue
+		}
+
+		if (isCertificateVersionFailed(certVersionSummary.Stages) || versionsToPreserveSeen >= versionsToPreserveCount) &&
+			certVersionSummary.TimeOfDeletion == nil && !isCertificateVersionCurrent(certVersionSummary.Stages) {
+			err = ScheduleCertificateVersionDeletion(certificateId, *certVersionSummary.VersionNumber, certificatesClient)
+			if err != nil {
+				klog.Errorf("unable to delete certificate version number %d for certificate %s, skipping for now: %s",
+					*certVersionSummary.VersionNumber, certificateId, err.Error())
+			}
+			continue
+		}
+		versionsToPreserveSeen = versionsToPreserveSeen + 1
+	}
+
+	return nil
+}
+
+func isCertificateVersionFailed(certificateVersionStages []certificatesmanagement.VersionStageEnum) bool {
+	return certificateVersionStagesContainsStage(certificateVersionStages, certificatesmanagement.VersionStageFailed)
+}
+
+func isCertificateVersionCurrent(certificateVersionStages []certificatesmanagement.VersionStageEnum) bool {
+	return certificateVersionStagesContainsStage(certificateVersionStages, certificatesmanagement.VersionStageCurrent)
+}
+
+func certificateVersionStagesContainsStage(certificateVersionStages []certificatesmanagement.VersionStageEnum,
+	stage certificatesmanagement.VersionStageEnum) bool {
+	for _, value := range certificateVersionStages {
+		if stage == value {
+			return true
+		}
+	}
+	return false
+}
+
+func GetCaBundle(caBundleId string, certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.CaBundle, string, error) {
+	caBundleCacheObj := certificatesClient.GetFromCaBundleCache(caBundleId)
+	if caBundleCacheObj != nil {
+		now := time.Now()
+		if now.Sub(caBundleCacheObj.Age).Minutes() < util.CertificateCacheMaxAgeInMinutes {
+			return caBundleCacheObj.CaBundle, caBundleCacheObj.Etag, nil
+		}
+		klog.Infof("Refreshing ca bundle %s", caBundleId)
+	}
+
+	return getCaBundleBustCache(caBundleId, certificatesClient)
+}
+
+func getCaBundleBustCache(caBundleId string, certificatesClient *certificate.CertificatesClient) (*certificatesmanagement.CaBundle, string, error) {
+	klog.Infof("Getting ca bundle for id %s.", caBundleId)
+	getCaBundleRequest := certificatesmanagement.GetCaBundleRequest{
+		CaBundleId: &caBundleId,
+	}
+
+	caBundle, etag, err := certificatesClient.GetCaBundle(context.TODO(), getCaBundleRequest)
+
+	if err == nil {
+		certificatesClient.SetCaBundleCache(caBundle, etag)
+	}
+	return caBundle, etag, err
+}
+
+// VerifyOrGetCaBundleIdByName verifies that caBundle with caBundleId has name caBundleName
+// If not, try to find ca bundle with matching name
+func VerifyOrGetCaBundleIdByName(caBundleId string, caBundleName string, compartmentId string,
+	certificatesClient *certificate.CertificatesClient) (*string, error) {
+	if caBundleId != "" {
+		caBundle, _, err := GetCaBundle(caBundleId, certificatesClient)
+		if err != nil {
+			return nil, err
+		}
+
+		if *caBundle.Name == caBundleName {
+			return &caBundleId, nil
+		}
+	}
+
+	return FindCaBundleWithName(caBundleName, compartmentId, certificatesClient)
+}
+
+func FindCaBundleWithName(certificateName string, compartmentId string,
+	certificatesClient *certificate.CertificatesClient) (*string, error) {
+	listCaBundlesRequest := certificatesmanagement.ListCaBundlesRequest{
+		Name:           &certificateName,
+		CompartmentId:  &compartmentId,
+		LifecycleState: certificatesmanagement.ListCaBundlesLifecycleStateActive,
+	}
+
+	klog.Infof("Searching for ca bundles with name %s in compartment %s.", certificateName, compartmentId)
+	listCaBundles, err := certificatesClient.ListCaBundles(context.TODO(), listCaBundlesRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if listCaBundles.Items != nil {
+		numberOfCertificates := len(listCaBundles.Items)
+		klog.Infof("Found %d bundles with name %s in compartment %s.", numberOfCertificates, certificateName, compartmentId)
+		if numberOfCertificates > 0 {
+			return listCaBundles.Items[0].Id, nil
+		}
+	}
+	klog.Infof("Found no bundles with name %s in compartment %s.", certificateName, compartmentId)
+	return nil, nil
+}
+
+func CreateCaBundle(certificateName string, compartmentId string, certificatesClient *certificate.CertificatesClient,
+	certificateContents *string) (*certificatesmanagement.CaBundle, error) {
+	caBundleDetails := certificatesmanagement.CreateCaBundleDetails{
+		Name:          &certificateName,
+		CompartmentId: &compartmentId,
+		CaBundlePem:   certificateContents,
+		FreeformTags: map[string]string{
+			caBundleHashTagKey: hashString(certificateContents),
+		},
+	}
+	createCaBundleRequest := certificatesmanagement.CreateCaBundleRequest{
+		CreateCaBundleDetails: caBundleDetails,
+		OpcRetryToken:         &certificateName,
+	}
+	createCaBundle, etag, err := certificatesClient.CreateCaBundle(context.TODO(), createCaBundleRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	certificatesClient.SetCaBundleCache(createCaBundle, etag)
+	return createCaBundle, nil
+}
+
+func UpdateCaBundle(caBundleId string, certificatesClient *certificate.CertificatesClient,
+	certificateContents *string) (*certificatesmanagement.CaBundle, error) {
+	_, etag, err := GetCaBundle(caBundleId, certificatesClient)
+	if err != nil {
+		return nil, err
+	}
+
+	caBundleDetails := certificatesmanagement.UpdateCaBundleDetails{
+		CaBundlePem: certificateContents,
+		FreeformTags: map[string]string{
+			caBundleHashTagKey: hashString(certificateContents),
+		},
+	}
+
+	updateCaBundleRequest := certificatesmanagement.UpdateCaBundleRequest{
+		CaBundleId:            &caBundleId,
+		UpdateCaBundleDetails: caBundleDetails,
+		IfMatch:               &etag,
+	}
+
+	updateCaBundle, etag, err := certificatesClient.UpdateCaBundle(context.TODO(), updateCaBundleRequest)
+
+	// This can happen by create/update backend set calls that cause the certificate etag to change because of a new association
+	if util.IsServiceError(err, 409) {
+		klog.Infof("Update ca bundle returned code %d for ca bundle %s. Refreshing cache.", 409, caBundleId)
+		getCaBundleBustCache(caBundleId, certificatesClient)
+		return nil, fmt.Errorf("unable to update ca bundle %s due to conflict, controller will retry later", caBundleId)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	certificatesClient.SetCaBundleCache(updateCaBundle, etag)
+	return updateCaBundle, nil
+}

--- a/pkg/controllers/ingress/certificate_util_test.go
+++ b/pkg/controllers/ingress/certificate_util_test.go
@@ -1,0 +1,318 @@
+/*
+ *
+ * * OCI Native Ingress Controller
+ * *
+ * * Copyright (c) 2024 Oracle America, Inc. and its affiliates.
+ * * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ *
+ */
+
+package ingress
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestGetCertificate(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	certId := "id"
+	certId2 := "id2"
+
+	certificate, etag, err := GetCertificate(&certId, mockClient.GetCertClient())
+	Expect(certificate != nil).Should(BeTrue())
+	Expect(etag).Should(Equal("etag"))
+	Expect(err).Should(BeNil())
+
+	// cache fetch
+	certificate, etag, err = GetCertificate(&certId, mockClient.GetCertClient())
+	Expect(certificate != nil).Should(BeTrue())
+	Expect(etag).Should(Equal("etag"))
+	Expect(err).Should(BeNil())
+
+	certificate, etag, err = GetCertificate(&certId2, mockClient.GetCertClient())
+	Expect(certificate != nil).Should(BeTrue())
+	Expect(etag).Should(Equal("etag"))
+	Expect(err).Should(BeNil())
+}
+
+func TestVerifyOrGetCertificateIdByName(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	id := "id"
+	name := "cert"
+	compartmentId := "compartmentId"
+	actualCertificateId, err := VerifyOrGetCertificateIdByName(id, name, compartmentId, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(actualCertificateId).Should(Equal(id))
+
+	actualCertificateId, err = VerifyOrGetCertificateIdByName("", name, compartmentId, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(actualCertificateId).ShouldNot(Equal(""))
+}
+
+func TestFindCertificateWithName(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	name := "name"
+	compartmentId := "compartmentId"
+	certificateId, err := FindCertificateWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(certificateId).ShouldNot(Equal(""))
+	Expect(err).Should(BeNil())
+
+	name = "nonexistent"
+	certificateId, err = FindCertificateWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(certificateId).Should(Equal(""))
+	Expect(err).Should(BeNil())
+
+	name = "error"
+	certificateId, err = FindCertificateWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(certificateId).Should(Equal(""))
+	Expect(err).ShouldNot(BeNil())
+}
+
+func TestCreateImportedTypeCertificate(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	tlsSecretData := &TLSSecretData{
+		ServerCertificate:  common.String("serverCert"),
+		CaCertificateChain: common.String("certChain"),
+		PrivateKey:         common.String("privateKey"),
+	}
+	certificateName := "name"
+	compartmentId := "compartmentId"
+	cert, err := CreateImportedTypeCertificate(tlsSecretData, certificateName, compartmentId, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(cert).ShouldNot(BeNil())
+
+	certificateName = "error"
+	cert, err = CreateImportedTypeCertificate(tlsSecretData, certificateName, compartmentId, mockClient.GetCertClient())
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+}
+
+func TestUpdateImportedTypeCertificate(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	tlsSecretData := &TLSSecretData{
+		ServerCertificate:  common.String("serverCert"),
+		CaCertificateChain: common.String("certChain"),
+		PrivateKey:         common.String("privateKey"),
+	}
+	certificateId := common.String("id")
+	cert, err := UpdateImportedTypeCertificate(certificateId, tlsSecretData, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(cert).ShouldNot(BeNil())
+
+	*certificateId = "conflictError"
+	cert, err = UpdateImportedTypeCertificate(certificateId, tlsSecretData, mockClient.GetCertClient())
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+
+	*certificateId = "error"
+	cert, err = UpdateImportedTypeCertificate(certificateId, tlsSecretData, mockClient.GetCertClient())
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+}
+
+func TestScheduleCertificateVersionDeletion(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	certificateId := "id"
+	versionNumber := int64(2)
+	err = ScheduleCertificateVersionDeletion(certificateId, versionNumber, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+
+	certificateId = "error"
+	err = ScheduleCertificateVersionDeletion(certificateId, versionNumber, mockClient.GetCertClient())
+	Expect(err).ShouldNot(BeNil())
+}
+
+func TestPruneCertificateVersions(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	certificateId := "id"
+	currentVersion := int64(8)
+	err = PruneCertificateVersions(certificateId, currentVersion, 5, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+
+	certificateId = "error"
+	err = PruneCertificateVersions(certificateId, currentVersion, 5, mockClient.GetCertClient())
+	Expect(err).ShouldNot(BeNil())
+}
+
+func TestIsCertificateVersionFailed(t *testing.T) {
+	RegisterTestingT(t)
+
+	certVersionStages := []certificatesmanagement.VersionStageEnum{
+		certificatesmanagement.VersionStageLatest,
+		certificatesmanagement.VersionStageCurrent,
+	}
+	Expect(isCertificateVersionFailed(certVersionStages)).Should(BeFalse())
+
+	certVersionStages = []certificatesmanagement.VersionStageEnum{
+		certificatesmanagement.VersionStageLatest,
+		certificatesmanagement.VersionStageFailed,
+	}
+	Expect(isCertificateVersionFailed(certVersionStages)).Should(BeTrue())
+}
+
+func TestIsCertificateVersionCurrent(t *testing.T) {
+	RegisterTestingT(t)
+
+	certVersionStages := []certificatesmanagement.VersionStageEnum{
+		certificatesmanagement.VersionStageLatest,
+		certificatesmanagement.VersionStageCurrent,
+	}
+	Expect(isCertificateVersionCurrent(certVersionStages)).Should(BeTrue())
+
+	certVersionStages = []certificatesmanagement.VersionStageEnum{
+		certificatesmanagement.VersionStageLatest,
+		certificatesmanagement.VersionStageFailed,
+	}
+	Expect(isCertificateVersionCurrent(certVersionStages)).Should(BeFalse())
+}
+
+func TestCertificateVersionStagesContainsStage(t *testing.T) {
+	RegisterTestingT(t)
+
+	stages := []certificatesmanagement.VersionStageEnum{certificatesmanagement.VersionStageLatest, certificatesmanagement.VersionStageCurrent}
+	Expect(certificateVersionStagesContainsStage(stages, certificatesmanagement.VersionStageLatest)).Should(BeTrue())
+	Expect(certificateVersionStagesContainsStage(stages, certificatesmanagement.VersionStageCurrent)).Should(BeTrue())
+	Expect(certificateVersionStagesContainsStage(stages, certificatesmanagement.VersionStageFailed)).Should(BeFalse())
+	Expect(certificateVersionStagesContainsStage(stages, certificatesmanagement.VersionStagePrevious)).Should(BeFalse())
+}
+
+func TestGetCaBundle(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	caBundleId := "id"
+	caBundleErrorId := "error"
+
+	caBundle, etag, err := GetCaBundle(caBundleId, mockClient.GetCertClient())
+	Expect(caBundle != nil).Should(BeTrue())
+	Expect(etag).Should(Equal("etag"))
+	Expect(err).Should(BeNil())
+
+	// cache fetch
+	caBundle, etag, err = GetCaBundle(caBundleId, mockClient.GetCertClient())
+	Expect(caBundle != nil).Should(BeTrue())
+	Expect(etag).Should(Equal("etag"))
+	Expect(err).Should(BeNil())
+
+	caBundle, etag, err = GetCaBundle(caBundleErrorId, mockClient.GetCertClient())
+	Expect(caBundle).Should(BeNil())
+	Expect(etag).Should(Equal(""))
+	Expect(err).ShouldNot(BeNil())
+}
+
+func TestVerifyOrGetCaBundleIdByName(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	id := "id"
+	name := "caBundle"
+	compartmentId := "compartmentId"
+	actualCaBundleId, err := VerifyOrGetCaBundleIdByName(id, name, compartmentId, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(*actualCaBundleId).Should(Equal(id))
+
+	actualCaBundleId, err = VerifyOrGetCaBundleIdByName("", name, compartmentId, mockClient.GetCertClient())
+	Expect(err).Should(BeNil())
+	Expect(*actualCaBundleId).ShouldNot(Equal(""))
+}
+
+func TestFindCaBundleWithName(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	name := "name"
+	compartmentId := "compartmentId"
+	caBundleId, err := FindCaBundleWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(*caBundleId).ShouldNot(BeNil())
+	Expect(err).Should(BeNil())
+
+	name = "nonexistent"
+	caBundleId, err = FindCaBundleWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(caBundleId).Should(BeNil())
+	Expect(err).Should(BeNil())
+
+	name = "error"
+	caBundleId, err = FindCaBundleWithName(name, compartmentId, mockClient.GetCertClient())
+	Expect(caBundleId).Should(BeNil())
+	Expect(err).ShouldNot(BeNil())
+}
+
+func TestCreateCaBundle(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	certificatesContent := common.String("certChain")
+	caBundleName := "name"
+	compartmentId := "compartmentId"
+	cert, err := CreateCaBundle(caBundleName, compartmentId, mockClient.GetCertClient(), certificatesContent)
+	Expect(err).Should(BeNil())
+	Expect(cert).ShouldNot(BeNil())
+
+	caBundleName = "error"
+	cert, err = CreateCaBundle(caBundleName, compartmentId, mockClient.GetCertClient(), certificatesContent)
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+}
+
+func TestUpdateCaBundle(t *testing.T) {
+	RegisterTestingT(t)
+	c, _, _ := initsUtil(&corev1.SecretList{})
+	mockClient, err := c.GetClient(&MockConfigGetter{})
+	Expect(err).Should(BeNil())
+
+	certificatesContent := common.String("certChain")
+	caBundleId := "id"
+	cert, err := UpdateCaBundle(caBundleId, mockClient.GetCertClient(), certificatesContent)
+	Expect(err).Should(BeNil())
+	Expect(cert).ShouldNot(BeNil())
+
+	caBundleId = "conflictError"
+	cert, err = UpdateCaBundle(caBundleId, mockClient.GetCertClient(), certificatesContent)
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+
+	caBundleId = "error"
+	cert, err = UpdateCaBundle(caBundleId, mockClient.GetCertClient(), certificatesContent)
+	Expect(err).ShouldNot(BeNil())
+	Expect(cert).Should(BeNil())
+}

--- a/pkg/controllers/ingress/ingressPathWithTlsSecret.yaml
+++ b/pkg/controllers/ingress/ingressPathWithTlsSecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-readiness
+  namespace: default
+spec:
+  tls:
+    - hosts:
+        - foo.bar.com
+      secretName: tls-secret
+  rules:
+    - host: "foo.bar.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/testecho1"
+            backend:
+              service:
+                name: testecho1
+                port:
+                  number: 80

--- a/pkg/exception/util.go
+++ b/pkg/exception/util.go
@@ -34,3 +34,27 @@ func (e *NotFoundServiceError) GetOpcRequestID() string {
 func (e *NotFoundServiceError) Error() string {
 	return "NotFound"
 }
+
+type ConflictServiceError struct {
+	common.ServiceError
+}
+
+func (e *ConflictServiceError) GetHTTPStatusCode() int {
+	return 409
+}
+
+func (e *ConflictServiceError) GetMessage() string {
+	return "Conflict"
+}
+
+func (e *ConflictServiceError) GetCode() string {
+	return "Conflict"
+}
+
+func (e *ConflictServiceError) GetOpcRequestID() string {
+	return "fakeopcrequestid"
+}
+
+func (e *ConflictServiceError) Error() string {
+	return "Conflict"
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -249,7 +249,7 @@ func (lbc *LoadBalancerClient) createRoutingPolicy(
 	klog.Infof("Creating routing policy with request: %s", util.PrettyPrint(createPolicyRequest))
 	resp, err := lbc.LbClient.CreateRoutingPolicy(ctx, createPolicyRequest)
 
-	if isServiceError(err, 409) {
+	if util.IsServiceError(err, 409) {
 		klog.Infof("Create routing policy operation returned code %d for load balancer %s. Routing policy %s may be already present.", 409, lbID, policyName)
 		return nil
 	}
@@ -276,7 +276,7 @@ func (lbc *LoadBalancerClient) DeleteRoutingPolicy(
 	klog.Infof("Delete routing policy with request %s ", util.PrettyPrint(deleteRoutingPolicyRequest))
 	resp, err := lbc.LbClient.DeleteRoutingPolicy(ctx, deleteRoutingPolicyRequest)
 
-	if isServiceError(err, 404) {
+	if util.IsServiceError(err, 404) {
 		klog.Infof("Delete routing policy operation returned code %d for load balancer %s. Routing policy %s may be already deleted.", 404, lbID, policyName)
 		return nil
 	}
@@ -311,7 +311,7 @@ func (lbc *LoadBalancerClient) DeleteBackendSet(ctx context.Context, lbID string
 
 	klog.Infof("Deleting backend set with request %s", util.PrettyPrint(backendSetDeleteRequest))
 	resp, err := lbc.LbClient.DeleteBackendSet(ctx, backendSetDeleteRequest)
-	if isServiceError(err, 404) {
+	if util.IsServiceError(err, 404) {
 		// it was already deleted so nothing to do.
 		klog.Infof("Delete backend set operation returned code %d for load balancer %s. Backend set %s may be already deleted.", 404, lbID, backendSetName)
 		return nil
@@ -347,7 +347,7 @@ func (lbc *LoadBalancerClient) DeleteListener(ctx context.Context, lbID string, 
 
 	klog.Infof("Deleting listener with request %s", util.PrettyPrint(deleteListenerRequest))
 	resp, err := lbc.LbClient.DeleteListener(ctx, deleteListenerRequest)
-	if isServiceError(err, 404) {
+	if util.IsServiceError(err, 404) {
 		// it was already deleted so nothing to do.
 		klog.Infof("Delete listener operation returned code %d for load balancer %s. Listener %s may be already deleted.", 404, lbID, listenerName)
 		return nil
@@ -394,7 +394,7 @@ func (lbc *LoadBalancerClient) CreateBackendSet(
 	klog.Infof("Creating backend set with request: %s", util.PrettyPrint(createBackendSetRequest))
 	resp, err := lbc.LbClient.CreateBackendSet(ctx, createBackendSetRequest)
 
-	if isServiceError(err, 409) {
+	if util.IsServiceError(err, 409) {
 		klog.Infof("Create backend set operation returned code %d for load balancer %s. Backend set %s may be already present.", 409, lbID, backendSetName)
 		return nil
 	}
@@ -714,7 +714,7 @@ func (lbc *LoadBalancerClient) CreateListener(ctx context.Context, lbID string, 
 	klog.Infof("Creating listener with request %s", util.PrettyPrint(createListenerRequest))
 	resp, err := lbc.LbClient.CreateListener(ctx, createListenerRequest)
 
-	if isServiceError(err, 409) {
+	if util.IsServiceError(err, 409) {
 		klog.Infof("Create listener operation returned code %d for load balancer %s. Listener %s may be already present.", 409, lbID, listenerName)
 		return nil
 	}
@@ -751,13 +751,4 @@ func (lbc *LoadBalancerClient) waitForWorkRequest(ctx context.Context, workReque
 
 		time.Sleep(10 * time.Second)
 	}
-}
-
-func isServiceError(err error, statusCode int) bool {
-	svcErr, ok := common.IsServiceError(err)
-	if !ok {
-		return false
-	}
-
-	return svcErr.GetHTTPStatusCode() == statusCode
 }

--- a/pkg/oci/client/certificate.go
+++ b/pkg/oci/client/certificate.go
@@ -37,11 +37,13 @@ type CertificateInterface interface {
 type CertCacheObj struct {
 	Cert *certificatesmanagement.Certificate
 	Age  time.Time
+	Etag string
 }
 
 type CaBundleCacheObj struct {
 	CaBundle *certificatesmanagement.CaBundle
 	Age      time.Time
+	Etag     string
 }
 
 type CertificateClient struct {

--- a/pkg/oci/client/certificatemanagement.go
+++ b/pkg/oci/client/certificatemanagement.go
@@ -10,10 +10,14 @@ type CertificateManagementInterface interface {
 	CreateCertificate(ctx context.Context, request certificatesmanagement.CreateCertificateRequest) (certificatesmanagement.CreateCertificateResponse, error)
 	GetCertificate(ctx context.Context, request certificatesmanagement.GetCertificateRequest) (certificatesmanagement.GetCertificateResponse, error)
 	ListCertificates(ctx context.Context, request certificatesmanagement.ListCertificatesRequest) (certificatesmanagement.ListCertificatesResponse, error)
+	UpdateCertificate(ctx context.Context, request certificatesmanagement.UpdateCertificateRequest) (certificatesmanagement.UpdateCertificateResponse, error)
 	ScheduleCertificateDeletion(ctx context.Context, request certificatesmanagement.ScheduleCertificateDeletionRequest) (certificatesmanagement.ScheduleCertificateDeletionResponse, error)
+	ListCertificateVersions(ctx context.Context, request certificatesmanagement.ListCertificateVersionsRequest) (certificatesmanagement.ListCertificateVersionsResponse, error)
+	ScheduleCertificateVersionDeletion(ctx context.Context, request certificatesmanagement.ScheduleCertificateVersionDeletionRequest) (certificatesmanagement.ScheduleCertificateVersionDeletionResponse, error)
 	CreateCaBundle(ctx context.Context, request certificatesmanagement.CreateCaBundleRequest) (certificatesmanagement.CreateCaBundleResponse, error)
 	GetCaBundle(ctx context.Context, request certificatesmanagement.GetCaBundleRequest) (certificatesmanagement.GetCaBundleResponse, error)
 	ListCaBundles(ctx context.Context, request certificatesmanagement.ListCaBundlesRequest) (certificatesmanagement.ListCaBundlesResponse, error)
+	UpdateCaBundle(ctx context.Context, request certificatesmanagement.UpdateCaBundleRequest) (certificatesmanagement.UpdateCaBundleResponse, error)
 	DeleteCaBundle(ctx context.Context, request certificatesmanagement.DeleteCaBundleRequest) (certificatesmanagement.DeleteCaBundleResponse, error)
 }
 
@@ -42,9 +46,24 @@ func (client CertificateManagementClient) ListCertificates(ctx context.Context,
 	return client.managementClient.ListCertificates(ctx, request)
 }
 
+func (client CertificateManagementClient) UpdateCertificate(ctx context.Context,
+	request certificatesmanagement.UpdateCertificateRequest) (certificatesmanagement.UpdateCertificateResponse, error) {
+	return client.managementClient.UpdateCertificate(ctx, request)
+}
+
 func (client CertificateManagementClient) ScheduleCertificateDeletion(ctx context.Context,
 	request certificatesmanagement.ScheduleCertificateDeletionRequest) (certificatesmanagement.ScheduleCertificateDeletionResponse, error) {
 	return client.managementClient.ScheduleCertificateDeletion(ctx, request)
+}
+
+func (client CertificateManagementClient) ListCertificateVersions(ctx context.Context,
+	request certificatesmanagement.ListCertificateVersionsRequest) (certificatesmanagement.ListCertificateVersionsResponse, error) {
+	return client.managementClient.ListCertificateVersions(ctx, request)
+}
+
+func (client CertificateManagementClient) ScheduleCertificateVersionDeletion(ctx context.Context,
+	request certificatesmanagement.ScheduleCertificateVersionDeletionRequest) (certificatesmanagement.ScheduleCertificateVersionDeletionResponse, error) {
+	return client.managementClient.ScheduleCertificateVersionDeletion(ctx, request)
 }
 
 func (client CertificateManagementClient) CreateCaBundle(ctx context.Context,
@@ -60,6 +79,11 @@ func (client CertificateManagementClient) GetCaBundle(ctx context.Context,
 func (client CertificateManagementClient) ListCaBundles(ctx context.Context,
 	request certificatesmanagement.ListCaBundlesRequest) (certificatesmanagement.ListCaBundlesResponse, error) {
 	return client.managementClient.ListCaBundles(ctx, request)
+}
+
+func (client CertificateManagementClient) UpdateCaBundle(ctx context.Context,
+	request certificatesmanagement.UpdateCaBundleRequest) (certificatesmanagement.UpdateCaBundleResponse, error) {
+	return client.managementClient.UpdateCaBundle(ctx, request)
 }
 
 func (client CertificateManagementClient) DeleteCaBundle(ctx context.Context,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,9 +58,9 @@ func BuildConfig(kubeconfig string) (*rest.Config, error) {
 }
 
 func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginformers.IngressClassInformer,
-	ingressInformer networkinginformers.IngressInformer, k8client kubernetes.Interface,
-	serviceInformer v1.ServiceInformer, endpointInformer v1.EndpointsInformer, podInformer v1.PodInformer, nodeInformer v1.NodeInformer, serviceAccountInformer v1.ServiceAccountInformer, c ctrcache.Cache,
-	reg *prometheus.Registry) func(ctx context.Context) {
+	ingressInformer networkinginformers.IngressInformer, k8client kubernetes.Interface, serviceInformer v1.ServiceInformer, secretInformer v1.SecretInformer,
+	endpointInformer v1.EndpointsInformer, podInformer v1.PodInformer, nodeInformer v1.NodeInformer, serviceAccountInformer v1.ServiceAccountInformer,
+	c ctrcache.Cache, reg *prometheus.Registry) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		klog.Info("Controller loop...")
 
@@ -82,6 +82,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			ingressInformer,
 			serviceAccountInformer,
 			serviceInformer.Lister(),
+			secretInformer,
 			client,
 			reg,
 		)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -828,3 +828,12 @@ func IsIngressProtocolTCP(ingress *networkingv1.Ingress) bool {
 func StringSlicesHaveSameElements(s1 []string, s2 []string) bool {
 	return sets.New(s1...).Equal(sets.New(s2...))
 }
+
+func IsServiceError(err error, statusCode int) bool {
+	svcErr, ok := common.IsServiceError(err)
+	if !ok {
+		return false
+	}
+
+	return svcErr.GetHTTPStatusCode() == statusCode
+}


### PR DESCRIPTION
This resolves #96 and is a derivative of PR #98

- change certificate name created to oci-nic-<secret-uid>
- add watching for secret add/update
- add etag to cabundle and cert cache, start using cabundle cache
- create certificates and cabundles with hashes for secret type TLS
- start updating certs for secret type artifacts
- start updating ca bundles for secret type artifacts
- prune certificates when updating for secret type artifacts