### PR TITLE
Fix typo for certDeletionGracePeriodInDays description in values.yaml

### DIFF
--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -133,5 +133,5 @@ emitEvents: false
 
 # Integer number of days to wait before an unused OCI Certificate service resource managed by NIC is deleted
 # This cleanup is done periodically by NIC
-# If less than 0, certificate resource cleanup is disabled
+# If less than or equal to 0, certificate resource cleanup is disabled
 certDeletionGracePeriodInDays: 0


### PR DESCRIPTION
Fix a typo in the helm `values.yaml` file for the certDeletionGracePeriodInDays flag description