### PR TITLE
feat: add LB session persistence and listener idle timeout features

### DIFF
--- a/api/v1beta1/ingressclassparameters_types.go
+++ b/api/v1beta1/ingressclassparameters_types.go
@@ -40,6 +40,65 @@ type IngressClassParametersSpec struct {
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +kubebuilder:default:=100
 	MaxBandwidthMbps int `json:"maxBandwidthMbps,omitempty"`
+
+	// LbCookieSessionPersistenceConfiguration defines the LB cookie-based session persistence settings.
+	// Note: This is mutually exclusive with SessionPersistenceConfiguration (application cookie stickiness).
+	// +optional
+	LbCookieSessionPersistenceConfiguration *LbCookieSessionPersistenceConfigurationDetails `json:"lbCookieSessionPersistenceConfiguration,omitempty"`
+
+	// DefaultListenerIdleTimeoutInSeconds specifies the default idle timeout in seconds for listeners created for this IngressClass.
+	// If not set, the OCI Load Balancing service default will be used (e.g., 60 seconds for HTTP, 300 for TCP).
+	// Refer to OCI documentation for specific default values and ranges.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=7200
+	// Example: OCI LB allows 1-7200 for TCP listeners. Adjust if needed.
+	// +optional
+	DefaultListenerIdleTimeoutInSeconds *int64 `json:"defaultListenerIdleTimeoutInSeconds,omitempty"`
+}
+
+// LbCookieSessionPersistenceConfigurationDetails defines the configuration for LbCookieSessionPersistence.
+// These fields correspond to the OCI LoadBalancer LbCookieSessionPersistenceConfigurationDetails.
+type LbCookieSessionPersistenceConfigurationDetails struct {
+	// The name of the cookie used to detect a session initiated by the backend server.
+	// If unspecified, the cookie name will be chosen by the OCI Load Balancing service.
+	// Example: `X-Oracle-OCILB-Cookie`
+	// +optional
+	CookieName *string `json:"cookieName,omitempty"`
+
+	// Whether the load balancer is prevented from directing traffic from a persistent session client to
+	// a different backend server if the original server is unavailable. Defaults to false.
+	// Example: `true`
+	// +optional
+	IsDisableFallback *bool `json:"isDisableFallback,omitempty"`
+
+	// The maximum time, in seconds, to independently maintain a session sticking connection.
+	// Access to this server will be prevented after the session timeout occurs.
+	// If unspecified, the OCI Load Balancing service default will be used.
+	// Example: `300`
+	// +optional
+	TimeoutInSeconds *int `json:"timeoutInSeconds,omitempty"`
+
+	// Whether the session cookie should be secure. For a secure cookie, the `Set-Cookie` header
+	// includes the `Secure` attribute.
+	// Example: `true`
+	// +optional
+	IsSecure *bool `json:"isSecure,omitempty"`
+
+	// Whether the session cookie should be HttpOnly. For a HttpOnly cookie, the `Set-Cookie` header
+	// includes the `HttpOnly` attribute.
+	// Example: `true`
+	// +optional
+	IsHttpOnly *bool `json:"isHttpOnly,omitempty"`
+
+	// The domain of the session cookie.
+	// Example: `example.com`
+	// +optional
+	Domain *string `json:"domain,omitempty"`
+
+	// The path of the session cookie.
+	// Example: `/`
+	// +optional
+	Path *string `json:"path,omitempty"`
 }
 
 // IngressClassParametersStatus defines the observed state of IngressClassParameters

--- a/deploy/example/customresource/ingressclassparameter.yaml
+++ b/deploy/example/customresource/ingressclassparameter.yaml
@@ -16,3 +16,15 @@ spec:
   isPrivate: false
   maxBandwidthMbps: 400
   minBandwidthMbps: 100
+  # Example for LB Cookie Session Persistence:
+  # lbCookieSessionPersistenceConfiguration:
+  #   cookieName: "OCI_STICKY_COOKIE" # Optional: if not provided, OCI will generate one
+  #   isDisableFallback: false         # Optional: defaults to false
+  #   timeoutInSeconds: 3600           # Optional: OCI default if not set (e.g., 7200 seconds)
+  #   isSecure: true                   # Optional: defaults to false
+  #   isHttpOnly: true                 # Optional: defaults to false
+  #   domain: "example.com"            # Optional
+  #   path: "/"                        # Optional
+  #
+  # Example for Default Listener Idle Timeout:
+  # defaultListenerIdleTimeoutInSeconds: 60 # Optional: OCI defaults will apply if not set (e.g., 60s for HTTP, 300s for TCP)

--- a/deploy/manifests/oci-native-ingress-controller/crds/ingress.oraclecloud.com_ingressclassparameters.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/crds/ingress.oraclecloud.com_ingressclassparameters.yaml
@@ -1,14 +1,9 @@
 ---
-# Source: oci-native-ingress-controller/crds/ingress.oraclecloud.com_ingressclassparameters.yaml
-#
-# OCI Native Ingress Controller
-#
-# Copyright (c) 2023 Oracle America, Inc. and its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ingressclassparameters.ingress.oraclecloud.com
 spec:
   group: ingress.oraclecloud.com
@@ -23,7 +18,7 @@ spec:
     - jsonPath: .spec.loadBalancerName
       name: LoadBalancerName
       type: string
-    - jsonPath: .spec.compartmentId
+    - jsonPath: .spec.compartmentID
       name: Compartment
       type: string
     - jsonPath: .spec.isPrivate
@@ -35,17 +30,23 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IngressClassParameters is the Schema for the IngressClassParameters API
+        description: IngressClassParameters is the Schema for the IngressClassParameterss
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,8 +57,65 @@ spec:
                 maxLength: 255
                 minLength: 1
                 type: string
+              defaultListenerIdleTimeoutInSeconds:
+                description: |-
+                  DefaultListenerIdleTimeoutInSeconds specifies the default idle timeout in seconds for listeners created for this IngressClass.
+                  If not set, the OCI Load Balancing service default will be used (e.g., 60 seconds for HTTP, 300 for TCP).
+                  Refer to OCI documentation for specific default values and ranges.
+                  Example: OCI LB allows 1-7200 for TCP listeners. Adjust if needed.
+                format: int64
+                maximum: 7200
+                minimum: 1
+                type: integer
               isPrivate:
                 type: boolean
+              lbCookieSessionPersistenceConfiguration:
+                description: |-
+                  LbCookieSessionPersistenceConfiguration defines the LB cookie-based session persistence settings.
+                  Note: This is mutually exclusive with SessionPersistenceConfiguration (application cookie stickiness).
+                properties:
+                  cookieName:
+                    description: |-
+                      The name of the cookie used to detect a session initiated by the backend server.
+                      If unspecified, the cookie name will be chosen by the OCI Load Balancing service.
+                      Example: `X-Oracle-OCILB-Cookie`
+                    type: string
+                  domain:
+                    description: |-
+                      The domain of the session cookie.
+                      Example: `example.com`
+                    type: string
+                  isDisableFallback:
+                    description: |-
+                      Whether the load balancer is prevented from directing traffic from a persistent session client to
+                      a different backend server if the original server is unavailable. Defaults to false.
+                      Example: `true`
+                    type: boolean
+                  isHttpOnly:
+                    description: |-
+                      Whether the session cookie should be HttpOnly. For a HttpOnly cookie, the `Set-Cookie` header
+                      includes the `HttpOnly` attribute.
+                      Example: `true`
+                    type: boolean
+                  isSecure:
+                    description: |-
+                      Whether the session cookie should be secure. For a secure cookie, the `Set-Cookie` header
+                      includes the `Secure` attribute.
+                      Example: `true`
+                    type: boolean
+                  path:
+                    description: |-
+                      The path of the session cookie.
+                      Example: `/`
+                    type: string
+                  timeoutInSeconds:
+                    description: |-
+                      The maximum time, in seconds, to independently maintain a session sticking connection.
+                      Access to this server will be prevented after the session timeout occurs.
+                      If unspecified, the OCI Load Balancing service default will be used.
+                      Example: `300`
+                    type: integer
+                type: object
               loadBalancerName:
                 type: string
               maxBandwidthMbps:
@@ -78,17 +136,11 @@ spec:
                 type: string
             type: object
           status:
-            description: IngressClassParametersStatus defines the observed state of IngressClassParameters
+            description: IngressClassParametersStatus defines the observed state of
+              IngressClassParameters
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -224,7 +224,8 @@ func (c *Controller) ensureRoutingRules(ctx context.Context, ingressClass *netwo
 			listener, listenerFound := lb.Listeners[routingPolicyToDelete]
 			if listenerFound {
 				klog.Infof("Detaching the routing policy %s from listener.", routingPolicyToDelete)
-				err = wrapperClient.GetLbClient().UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol, nil)
+				// Add nil for the new idleTimeoutInSeconds parameter
+				err = wrapperClient.GetLbClient().UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol, nil, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/oci/client/loadbalancer.go
+++ b/pkg/oci/client/loadbalancer.go
@@ -19,6 +19,7 @@ type LoadBalancerInterface interface {
 	CreateBackendSet(ctx context.Context, request loadbalancer.CreateBackendSetRequest) (loadbalancer.CreateBackendSetResponse, error)
 	UpdateBackendSet(ctx context.Context, request loadbalancer.UpdateBackendSetRequest) (loadbalancer.UpdateBackendSetResponse, error)
 	DeleteBackendSet(ctx context.Context, request loadbalancer.DeleteBackendSetRequest) (loadbalancer.DeleteBackendSetResponse, error)
+	GetBackendSet(ctx context.Context, request loadbalancer.GetBackendSetRequest) (loadbalancer.GetBackendSetResponse, error) // Added
 
 	GetBackendSetHealth(ctx context.Context, request loadbalancer.GetBackendSetHealthRequest) (loadbalancer.GetBackendSetHealthResponse, error)
 
@@ -61,6 +62,11 @@ func (client LBClient) UpdateLoadBalancer(ctx context.Context, request loadbalan
 
 func (client LBClient) UpdateNetworkSecurityGroups(ctx context.Context, request loadbalancer.UpdateNetworkSecurityGroupsRequest) (loadbalancer.UpdateNetworkSecurityGroupsResponse, error) {
 	return client.lbClient.UpdateNetworkSecurityGroups(ctx, request)
+}
+
+func (client LBClient) GetBackendSet(ctx context.Context,
+	request loadbalancer.GetBackendSetRequest) (loadbalancer.GetBackendSetResponse, error) {
+	return client.lbClient.GetBackendSet(ctx, request)
 }
 
 func (client LBClient) DeleteLoadBalancer(ctx context.Context,


### PR DESCRIPTION
PS: Still waiting for my OCA agreement to be accepted.

**Subject: feat: Add LB Cookie Session Persistence and Listener Idle Timeout**

**Related Issue:** Fixes #106 + Add LB side Cookie Session Persistence

**Description:**

This pull request introduces two significant enhancements to the OCI Native Ingress Controller, allowing finer-grained control over OCI Load Balancer configurations through `IngressClassParameters`:

1. **Load Balancer (LB) Cookie-Based Session Persistence:**
    - A new `lbCookieSessionPersistenceConfiguration` field can now be defined within `IngressClassParameters`. This allows users to enable and configure LB cookie stickiness (e.g., cookie name, max-age/timeout, path, domain, security attributes) for backend sets.
    - The `ingress` controller now applies this configuration to backend sets created based on `Ingress` rules.
    - The `ingressclass` controller also applies this configuration to the default backend set of the Load Balancer.
2. **Default Listener Idle Timeout:**
    - A new `defaultListenerIdleTimeoutInSeconds` field can be specified in `IngressClassParameters`.
    - The `ingress` controller uses this value to configure the idle timeout on listeners (e.g., HTTP, HTTPS) it provisions for `Ingress` resources.

**Summary of Changes:**

- **API Updated (`api/v1beta1/ingressclassparameters_types.go`):**
    - Added `lbCookieSessionPersistenceConfiguration` (and its `LbCookieSessionPersistenceConfigurationDetails` struct) to `IngressClassParametersSpec`.
    - Added `defaultListenerIdleTimeoutInSeconds` to `IngressClassParametersSpec`.
- **Controller Logic Modified:**
    - **`pkg/controllers/ingressclass/ingressclass.go`:** Updated to handle `lbCookieSessionPersistenceConfiguration` for the default backend set.
    - **`pkg/controllers/ingress/ingress.go`:**
        - Enhanced to apply `defaultListenerIdleTimeoutInSeconds` during listener creation and updates.
        - Refactored `syncBackendSet` to apply `lbCookieSessionPersistenceConfiguration` to Ingress-derived backend sets during creation and updates, ensuring a consolidated update approach.
- **OCI Client & LoadBalancer Helpers Updated:**
    - Modified methods in `pkg/loadbalancer/loadbalancer.go` (`CreateListener`, `UpdateListener`, `CreateBackendSet`, `UpdateBackendSet`) to support the new parameters.
    - Extended `LoadBalancerInterface` in `pkg/oci/client/loadbalancer.go` (e.g., added `GetBackendSet`) and its implementation.
- **Build Error Corrections:** Addressed various compilation issues identified during development, including CRD generation marker fixes, OCI SDK type mismatches, and incorrect function signatures/calls.
- **Examples Updated:** The example `IngressClassParameters` YAML (`deploy/example/customresource/ingressclassparameter.yaml`) has been updated with commented-out sections for the new configurations.

**Documentation Impact:**

- The primary `README.md` or other documentation detailing `IngressClassParameters` fields will need to be updated to describe `lbCookieSessionPersistenceConfiguration` and `defaultListenerIdleTimeoutInSeconds`.

**Validation Steps:**

**Prerequisites:**

1. Ensure the controller is built with these changes.
2. Regenerate the `IngressClassParameters` CRD manifest (e.g., using `controller-gen crd paths=./api/v1beta1/... output:crd:dir=./deploy/manifests/oci-native-ingress-controller/crds`) and apply the updated CRD to your Kubernetes cluster (`kubectl apply -f ...`). (Already commited with this done)
3. Deploy the new controller image.

**1. Validate LB Cookie Session Persistence:**
a. Define an `IngressClassParameters` resource with the `lbCookieSessionPersistenceConfiguration` section (e.g., set `cookieName`, `timeoutInSeconds`).
b. Create an `IngressClass` referencing these parameters.
c. Deploy an application with an `Ingress` using this `IngressClass`.
d. **Verify in OCI Console:** Check the OCI Load Balancer. The backend set corresponding to your Ingress rule should have the specified cookie session persistence settings.
e. **Test Stickiness:** Make multiple requests from a single client to your application's endpoint. Verify requests are routed to the same backend pod and check for the presence of the configured cookie in HTTP responses.

**2. Validate Default Listener Idle Timeout:**
a. Define an `IngressClassParameters` resource setting `defaultListenerIdleTimeoutInSeconds` (e.g., to `120`).
b. Ensure your `IngressClass` uses these parameters.
c. Deploy an `Ingress` that creates listeners.
d. **Verify in OCI Console:** Check the listeners on the OCI Load Balancer. Their "Idle Timeout" should match the value from `defaultListenerIdleTimeoutInSeconds`.