### PR TITLE
Bug-fix: Don't increment ingress_updation_count for regular resync updates

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -131,11 +131,16 @@ func (c *Controller) ingressAdd(obj interface{}) {
 }
 
 func (c *Controller) ingressUpdate(old, new interface{}) {
+	oldIngress := old.(*networkingv1.Ingress)
+	newIngress := new.(*networkingv1.Ingress)
+
+	// Ignore regular resyncs that didn't come from an actual update.
+	if oldIngress.ResourceVersion == newIngress.ResourceVersion {
+		return
+	}
 	if c.metricsCollector != nil {
 		c.metricsCollector.IncrementIngressUpdateOperation()
 	}
-	oldIngress := old.(*networkingv1.Ingress)
-	newIngress := new.(*networkingv1.Ingress)
 
 	klog.V(4).InfoS("Updating ingress", "ingress", klog.KObj(oldIngress))
 	c.enqueueIngress(newIngress)

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -267,8 +267,17 @@ func TestIngressUpdate(t *testing.T) {
 	ingressClassList := util.GetIngressClassList()
 	ingressList := util.ReadResourceAsIngressList(ingressPathWithFinalizer)
 	c := inits(ctx, ingressClassList, ingressList)
+
 	queueSize := c.queue.Len()
 	c.ingressUpdate(&ingressList.Items[0], &ingressList.Items[1])
+	Expect(c.queue.Len()).Should(Equal(queueSize))
+
+	oldIngress := ingressList.Items[0].DeepCopy()
+	newIngress := ingressList.Items[1].DeepCopy()
+	oldIngress.ResourceVersion = "1"
+	newIngress.ResourceVersion = "2"
+
+	c.ingressUpdate(oldIngress, newIngress)
 	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
 }
 func TestIngressDelete(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix for issue https://github.com/oracle/oci-native-ingress-controller/issues/140 

i.e. ignore regular informer resync events when nothing has changed so only real ingress updates trigger reconciliation and metrics.

## Manual verification

Reviewed `/metrics` longer than informer resync interval and verify that `ingress_updation_count` did not increase when there were no ingress changes.