### PR TITLE
Bug-fix: Clear stale listener SSL configuration when an Ingress is updated

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -599,6 +599,9 @@ func syncListener(ctx context.Context, namespace string, stateStore *state.State
 				needsUpdate = true
 			}
 		}
+	} else if listener.SslConfiguration != nil {
+		klog.Infof("SSL config for listener %s needs removal", *listener.Name)
+		needsUpdate = true
 	}
 
 	protocol := stateStore.GetListenerProtocol(int32(*listener.Port))
@@ -616,7 +619,7 @@ func syncListener(ctx context.Context, namespace string, stateStore *state.State
 	}
 
 	if needsUpdate {
-		err := wrapperClient.GetLbClient().UpdateListener(context.TODO(), lbId, etag, listener, listener.RoutingPolicyName, sslConfig, &protocol, &defaultBackendSet)
+		err := wrapperClient.GetLbClient().UpdateListener(context.TODO(), lbId, etag, listener, listener.RoutingPolicyName, sslConfig, &protocol, &defaultBackendSet, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/state"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -211,6 +212,46 @@ func getContextWithClient(c *Controller, ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, util.WrapperClient, wc)
 	return ctx
 }
+
+func TestSyncListenerClearsStaleSSLConfigWhenTLSNotDesired(t *testing.T) {
+	RegisterTestingT(t)
+	port := 10901
+	lbId := "id"
+	listenerName := util.GenerateListenerName(int32(port))
+	defaultBackendSet := util.GenerateBackendSetName(namespace, "testecho1", int32(port))
+	mockClient := &staleSSLLoadBalancerClient{
+		listenerName:      listenerName,
+		port:              port,
+		defaultBackendSet: defaultBackendSet,
+		protocol:          util.ProtocolTCP,
+		certificateIds:    []string{"certificate-id"},
+	}
+	loadBalancerClient := &lb.LoadBalancerClient{
+		LbClient: mockClient,
+		Mu:       sync.Mutex{},
+		Cache:    map[string]*lb.LbCacheObj{},
+	}
+	wrapperClient := client.NewWrapperClient(nil, nil, loadBalancerClient, nil, nil)
+	ctx := context.WithValue(context.Background(), util.WrapperClient, wrapperClient)
+	stateStore := &state.StateStore{
+		IngressGroupState: state.IngressClassState{
+			ListenerProtocolMap: map[int32]string{
+				int32(port): util.ProtocolTCP,
+			},
+			ListenerDefaultBsMap: map[int32]string{
+				int32(port): defaultBackendSet,
+			},
+			ListenerTLSConfigMap: map[int32]state.TlsConfig{},
+		},
+	}
+
+	err := syncListener(ctx, namespace, stateStore, &lbId, listenerName, "", &Controller{})
+
+	Expect(err).To(BeNil())
+	Expect(mockClient.updateListenerRequest).ToNot(BeNil())
+	Expect(mockClient.updateListenerRequest.UpdateListenerDetails.SslConfiguration).To(BeNil())
+}
+
 func TestEnsureLoadBalancerIP(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -445,6 +486,49 @@ func (m MockLoadBalancerClient) CreateListener(ctx context.Context, request ocil
 
 func (m MockLoadBalancerClient) UpdateListener(ctx context.Context, request ociloadbalancer.UpdateListenerRequest) (ociloadbalancer.UpdateListenerResponse, error) {
 	return ociloadbalancer.UpdateListenerResponse{}, nil
+}
+
+type staleSSLLoadBalancerClient struct {
+	MockLoadBalancerClient
+	listenerName          string
+	port                  int
+	defaultBackendSet     string
+	protocol              string
+	certificateIds        []string
+	updateListenerRequest *ociloadbalancer.UpdateListenerRequest
+}
+
+func (m *staleSSLLoadBalancerClient) GetLoadBalancer(ctx context.Context, request ociloadbalancer.GetLoadBalancerRequest) (ociloadbalancer.GetLoadBalancerResponse, error) {
+	lbId := "id"
+	etag := "etag"
+	listener := ociloadbalancer.Listener{
+		Name:                  common.String(m.listenerName),
+		Port:                  common.Int(m.port),
+		Protocol:              common.String(m.protocol),
+		DefaultBackendSetName: common.String(m.defaultBackendSet),
+		SslConfiguration: &ociloadbalancer.SslConfiguration{
+			CertificateIds: m.certificateIds,
+		},
+	}
+	return ociloadbalancer.GetLoadBalancerResponse{
+		LoadBalancer: ociloadbalancer.LoadBalancer{
+			Id: common.String(lbId),
+			Listeners: map[string]ociloadbalancer.Listener{
+				m.listenerName: listener,
+			},
+		},
+		ETag: common.String(etag),
+	}, nil
+}
+
+func (m *staleSSLLoadBalancerClient) UpdateListener(ctx context.Context, request ociloadbalancer.UpdateListenerRequest) (ociloadbalancer.UpdateListenerResponse, error) {
+	m.updateListenerRequest = &request
+	id := "id"
+	return ociloadbalancer.UpdateListenerResponse{
+		RawResponse:      nil,
+		OpcWorkRequestId: &id,
+		OpcRequestId:     &id,
+	}, nil
 }
 
 func (m MockLoadBalancerClient) DeleteListener(ctx context.Context, request ociloadbalancer.DeleteListenerRequest) (ociloadbalancer.DeleteListenerResponse, error) {

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -210,7 +210,7 @@ func (c *Controller) ensureRoutingRules(ctx context.Context, ingressClass *netwo
 			listener, listenerFound := lb.Listeners[routingPolicyToDelete]
 			if listenerFound {
 				klog.Infof("Detaching the routing policy %s from listener.", routingPolicyToDelete)
-				err = wrapperClient.GetLbClient().UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol, nil)
+				err = wrapperClient.GetLbClient().UpdateListener(context.TODO(), lb.Id, etag, listener, nil, nil, listener.Protocol, nil, true)
 				if err != nil {
 					return err
 				}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -691,13 +691,13 @@ func (lbc *LoadBalancerClient) setRoutingPolicyOnListener(
 		return exception.NewTransientError(fmt.Errorf("listener %s not found", routingPolicyName))
 	}
 
-	return lbc.UpdateListener(ctx, lb.Id, etag, l, &routingPolicyName, nil, l.Protocol, nil)
+	return lbc.UpdateListener(ctx, lb.Id, etag, l, &routingPolicyName, nil, l.Protocol, nil, true)
 }
 
 func (lbc *LoadBalancerClient) UpdateListener(ctx context.Context, lbId *string, etag string, l loadbalancer.Listener, routingPolicyName *string,
-	sslConfigurationDetails *loadbalancer.SslConfigurationDetails, protocol *string, defaultBackendSet *string) error {
+	sslConfigurationDetails *loadbalancer.SslConfigurationDetails, protocol *string, defaultBackendSet *string, preserveExistingSslConfig bool) error {
 
-	if sslConfigurationDetails == nil && l.SslConfiguration != nil {
+	if preserveExistingSslConfig && sslConfigurationDetails == nil && l.SslConfiguration != nil {
 		sslConfigurationDetails = &loadbalancer.SslConfigurationDetails{
 			CertificateIds: l.SslConfiguration.CertificateIds,
 		}
@@ -712,6 +712,9 @@ func (lbc *LoadBalancerClient) UpdateListener(ctx context.Context, lbId *string,
 	}
 
 	if *protocol == util.ProtocolHTTP2 {
+		if sslConfigurationDetails == nil {
+			return fmt.Errorf("no TLS configuration provided for a HTTP2 listener at port %d", *l.Port)
+		}
 		sslConfigurationDetails.CipherSuiteName = common.String(util.ProtocolHTTP2DefaultCipherSuite)
 	}
 

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -199,10 +199,71 @@ func TestLoadBalancerClient_UpdateListener(t *testing.T) {
 		RoutingPolicyName: &pname,
 	}
 	ssConfig := getSslConfigurationDetails(id)
-	err := loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, &pname, &ssConfig, &proto, nil)
+	err := loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, &pname, &ssConfig, &proto, nil, true)
 	Expect(err).To(BeNil())
-	err = loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, &pname, &ssConfig, &proto2, nil)
+	err = loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, &pname, &ssConfig, &proto2, nil, true)
 	Expect(err).To(BeNil())
+}
+
+func TestLoadBalancerClient_UpdateListenerPreservesExistingSSLWhenRequested(t *testing.T) {
+	RegisterTestingT(t)
+	mockClient := &captureLoadBalancerClient{}
+	loadBalancerClient := &LoadBalancerClient{
+		LbClient: mockClient,
+		Mu:       sync.Mutex{},
+		Cache:    map[string]*LbCacheObj{},
+	}
+	id := "id"
+	name := "route_10901"
+	proto := util.ProtocolTCP
+	defaultBackendSet := util.DefaultBackendSetName
+	port := 10901
+	listener := ociloadbalancer.Listener{
+		Name:                  &name,
+		Port:                  &port,
+		Protocol:              &proto,
+		DefaultBackendSetName: &defaultBackendSet,
+		SslConfiguration: &ociloadbalancer.SslConfiguration{
+			CertificateIds: []string{"certificate-id"},
+		},
+	}
+
+	err := loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, nil, nil, &proto, &defaultBackendSet, true)
+	Expect(err).To(BeNil())
+	Expect(mockClient.updateListenerRequest).ToNot(BeNil())
+	sslConfig := mockClient.updateListenerRequest.UpdateListenerDetails.SslConfiguration
+	Expect(sslConfig).ToNot(BeNil())
+	Expect(sslConfig.CertificateIds).To(Equal([]string{"certificate-id"}))
+}
+
+func TestLoadBalancerClient_UpdateListenerClearsSSLWhenNotPreserved(t *testing.T) {
+	RegisterTestingT(t)
+	mockClient := &captureLoadBalancerClient{}
+	loadBalancerClient := &LoadBalancerClient{
+		LbClient: mockClient,
+		Mu:       sync.Mutex{},
+		Cache:    map[string]*LbCacheObj{},
+	}
+	id := "id"
+	name := "route_10901"
+	proto := util.ProtocolTCP
+	defaultBackendSet := util.DefaultBackendSetName
+	port := 10901
+	listener := ociloadbalancer.Listener{
+		Name:                  &name,
+		Port:                  &port,
+		Protocol:              &proto,
+		DefaultBackendSetName: &defaultBackendSet,
+		SslConfiguration: &ociloadbalancer.SslConfiguration{
+			CertificateIds: []string{"certificate-id"},
+		},
+	}
+
+	err := loadBalancerClient.UpdateListener(context.TODO(), &id, "", listener, nil, nil, &proto, &defaultBackendSet, false)
+
+	Expect(err).To(BeNil())
+	Expect(mockClient.updateListenerRequest).ToNot(BeNil())
+	Expect(mockClient.updateListenerRequest.UpdateListenerDetails.SslConfiguration).To(BeNil())
 }
 
 func TestLoadBalancerClient_UpdateNetworkSecurityGroups(t *testing.T) {
@@ -385,6 +446,21 @@ func (m MockLoadBalancerClient) UpdateListener(ctx context.Context, request ocil
 		OpcWorkRequestId: &id,
 		OpcRequestId:     &id,
 	}, err
+}
+
+type captureLoadBalancerClient struct {
+	MockLoadBalancerClient
+	updateListenerRequest *ociloadbalancer.UpdateListenerRequest
+}
+
+func (m *captureLoadBalancerClient) UpdateListener(ctx context.Context, request ociloadbalancer.UpdateListenerRequest) (ociloadbalancer.UpdateListenerResponse, error) {
+	m.updateListenerRequest = &request
+	id := "id"
+	return ociloadbalancer.UpdateListenerResponse{
+		RawResponse:      nil,
+		OpcWorkRequestId: &id,
+		OpcRequestId:     &id,
+	}, nil
 }
 
 func (m MockLoadBalancerClient) DeleteListener(ctx context.Context, request ociloadbalancer.DeleteListenerRequest) (ociloadbalancer.DeleteListenerResponse, error) {


### PR DESCRIPTION
## Summary
Fixes #144 issue of stale OCI Load Balancer listener SSL configuration when an Ingress is updated to TCP passthrough.

For TCP ingresses, listener TLS config is ignored by design, but _existing_ OCI listener `SslConfiguration` can be _left_ during an update, which can cause corresponding OCI listeners on the load-balancer remain `use-ssl=true` with a cipher suite even though the desired listener protocol was TCP passthrough e.g.

<img width="3869" height="689" alt="use-ssl-set" src="https://github.com/user-attachments/assets/6a195709-08ae-4e25-a0ae-f663efefe43c" />


```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    oci-native-ingress.oraclecloud.com/http-listener-port: "10901"
    oci-native-ingress.oraclecloud.com/protocol: TCP
  name: sauron-dev-test-thanos-grpc
  namespace: dev-test
spec:
  ingressClassName: dev-test-oci-native
  rules:
  - http:
      paths:
      - backend:
          service:
            name: dev-test1-thanos-query
            port:
              number: 10901
        pathType: ImplementationSpecific
```

## Changes
- Detect listener drift when desired listener TLS config is empty but the actual OCI listener still has `SslConfiguration`.
- Update the listener with SSL preservation disabled in that reconciliation path so OCI receives `sslConfiguration: null`.
- Keep existing default behavior for routing-only listener updates where SSL config should be preserved.
- Add regression coverage for clearing stale SSL config on TCP listeners.


## Manual verification

First, I create an `HTTP2` Ingress resource with `spc.tls` and verified `use-ssl=true` on the OCI load-balancer listener. Then I subsequently updated the protocol Ingress to be `TCP` via `oci-native-ingress.oraclecloud.com/protocol: TCP` and removed `spc.tls` and then re-verified protocol and `use-ssl=false` on the OCI load-balancer. OCI load-balancer was reconciled appropriately. 

I’ve also repeatedly run our product's integration tests in OCI Native mode with this change which creates multiple OCI load balancers with DNS names and certificates across different Ingress configurations, then validates the endpoints end to end. I also reviewed the OCI Load Balancer work requests and OCI Native ingress controller logs during the CI tests. 