### PR TITLE
Enhancement: Count backend reconciliation in ingress sync metrics.

### DIFF
--- a/pkg/controllers/backend/backend.go
+++ b/pkg/controllers/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
 	"k8s.io/klog/v2"
 
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -51,8 +52,9 @@ type Controller struct {
 	saLister           corelisters.ServiceAccountLister
 	eventRecorder      events.EventRecorder
 
-	queue  workqueue.RateLimitingInterface
-	client *client.ClientProvider
+	queue            workqueue.RateLimitingInterface
+	client           *client.ClientProvider
+	metricsCollector *metric.IngressCollector
 }
 
 func NewController(
@@ -64,6 +66,7 @@ func NewController(
 	endpointLister corelisters.EndpointsLister,
 	podLister corelisters.PodLister,
 	client *client.ClientProvider,
+	metricsCollector *metric.IngressCollector,
 	eventRecorder events.EventRecorder,
 ) *Controller {
 
@@ -78,6 +81,7 @@ func NewController(
 		client:             client,
 		eventRecorder:      eventRecorder,
 		queue:              workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
+		metricsCollector:   metricsCollector,
 	}
 
 	return c
@@ -104,6 +108,17 @@ func (c *Controller) processNextItem() bool {
 
 // sync is the business logic of the controller.
 func (c *Controller) sync(key string) error {
+	if c.metricsCollector != nil {
+		c.metricsCollector.IncrementSyncCount()
+	}
+
+	startSyncTime := time.Now()
+	defer func() {
+		if c.metricsCollector != nil {
+			c.metricsCollector.AddIngressBackendSyncTime(time.Since(startSyncTime).Seconds())
+		}
+	}()
+
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)

--- a/pkg/controllers/backend/backend_test.go
+++ b/pkg/controllers/backend/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/events"
 
@@ -15,6 +16,7 @@ import (
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -259,7 +261,8 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 		Cache:               NewMockCacheStore(wrapperClient),
 	}
 	fakeRecorder := events.NewFakeRecorder(10)
-	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, saInformer, serviceLister, endpointLister, podLister, client, fakeRecorder)
+	metricsCollector := metric.NewIngressCollector("oci.oraclecloud.com/native-ingress-controller", prometheus.NewRegistry())
+	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, saInformer, serviceLister, endpointLister, podLister, client, metricsCollector, fakeRecorder)
 	return c
 }
 

--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -23,7 +23,6 @@ import (
 	ctrcache "sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -75,7 +74,7 @@ type Controller struct {
 func NewController(controllerClass string, defaultCompartmentId string,
 	ingressClassInformer networkinginformers.IngressClassInformer, ingressInformer networkinginformers.IngressInformer,
 	saInformer coreinformers.ServiceAccountInformer, serviceLister corelisters.ServiceLister, secretInformer coreinformers.SecretInformer,
-	client *client.ClientProvider, reg *prometheus.Registry, ctrCache ctrcache.Cache, useLbCompartmentForCertificates bool, eventRecorder events.EventRecorder) *Controller {
+	client *client.ClientProvider, metricsCollector *metric.IngressCollector, ctrCache ctrcache.Cache, useLbCompartmentForCertificates bool, eventRecorder events.EventRecorder) *Controller {
 
 	c := &Controller{
 		controllerClass:                 controllerClass,
@@ -88,7 +87,7 @@ func NewController(controllerClass string, defaultCompartmentId string,
 		secretLister:                    secretInformer.Lister(),
 		client:                          client,
 		queue:                           workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
-		metricsCollector:                metric.NewIngressCollector(controllerClass, reg),
+		metricsCollector:                metricsCollector,
 		ctrCache:                        ctrCache,
 		useLbCompartmentForCertificates: useLbCompartmentForCertificates,
 		eventRecorder:                   eventRecorder,

--- a/pkg/controllers/nodeBackend/nodeBackend.go
+++ b/pkg/controllers/nodeBackend/nodeBackend.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
 	"k8s.io/klog/v2"
 
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -47,11 +48,12 @@ type Controller struct {
 
 	queue workqueue.RateLimitingInterface
 
-	client *client.ClientProvider
+	client           *client.ClientProvider
+	metricsCollector *metric.IngressCollector
 }
 
 func NewController(controllerClass string, ingressClassInformer networkinginformers.IngressClassInformer, ingressInformer networkinginformers.IngressInformer, saInformer coreinformers.ServiceAccountInformer, serviceLister corelisters.ServiceLister, endpointLister corelisters.EndpointsLister, podLister corelisters.PodLister, nodeLister corelisters.NodeLister,
-	client *client.ClientProvider, eventRecorder events.EventRecorder) *Controller {
+	client *client.ClientProvider, metricsCollector *metric.IngressCollector, eventRecorder events.EventRecorder) *Controller {
 
 	c := &Controller{
 		controllerClass:    controllerClass,
@@ -65,6 +67,7 @@ func NewController(controllerClass string, ingressClassInformer networkinginform
 		client:             client,
 		eventRecorder:      eventRecorder,
 		queue:              workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 5*time.Minute)),
+		metricsCollector:   metricsCollector,
 	}
 
 	return c
@@ -91,6 +94,17 @@ func (c *Controller) processNextItem() bool {
 
 // sync is the business logic of the controller.
 func (c *Controller) sync(key string) error {
+	if c.metricsCollector != nil {
+		c.metricsCollector.IncrementSyncCount()
+	}
+
+	startSyncTime := time.Now()
+	defer func() {
+		if c.metricsCollector != nil {
+			c.metricsCollector.AddIngressBackendSyncTime(time.Since(startSyncTime).Seconds())
+		}
+	}()
+
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)

--- a/pkg/controllers/nodeBackend/nodeBackend_test.go
+++ b/pkg/controllers/nodeBackend/nodeBackend_test.go
@@ -2,6 +2,7 @@ package nodeBackend
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/events"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	ociloadbalancer "github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
 	lb "github.com/oracle/oci-native-ingress-controller/pkg/loadbalancer"
+	"github.com/oracle/oci-native-ingress-controller/pkg/metric"
 	ociclient "github.com/oracle/oci-native-ingress-controller/pkg/oci/client"
 	"github.com/oracle/oci-native-ingress-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -222,7 +224,8 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 		Cache:               NewMockCacheStore(wrapperClient),
 	}
 	fakeRecorder := events.NewFakeRecorder(10)
-	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, saInformer, serviceLister, endpointLister, podLister, nodeLister, mockClient, fakeRecorder)
+	metricsCollector := metric.NewIngressCollector("oci.oraclecloud.com/native-ingress-controller", prometheus.NewRegistry())
+	c := NewController("oci.oraclecloud.com/native-ingress-controller", ingressClassInformer, ingressInformer, saInformer, serviceLister, endpointLister, podLister, nodeLister, mockClient, metricsCollector, fakeRecorder)
 	return c
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,6 +80,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 		if err != nil {
 			klog.Fatalf("failed to get cluster details: %v", err)
 		}
+		metricsCollector := metric.NewIngressCollector(opts.ControllerClass, reg)
 		ingressController := ingress.NewController(
 			opts.ControllerClass,
 			opts.CompartmentId,
@@ -89,7 +90,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			serviceInformer.Lister(),
 			secretInformer,
 			client,
-			reg,
+			metricsCollector,
 			c,
 			opts.UseLbCompartmentForCertificates,
 			eventRecorder,
@@ -133,6 +134,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				podInformer.Lister(),
 				nodeInformer.Lister(),
 				client,
+				metricsCollector,
 				eventRecorder,
 			)
 			go backendController.Run(3, ctx.Done())
@@ -146,6 +148,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				endpointInformer.Lister(),
 				podInformer.Lister(),
 				client,
+				metricsCollector,
 				eventRecorder,
 			)
 			go backendController.Run(3, ctx.Done())


### PR DESCRIPTION
## Summary

This change updates ingress metrics from the backend sync controllers so backend reconciliation is reflected in `ingress_sync_count` and `ingress_backend_sync_time`.

Specifically, backend reconciliation now:
- increments `ingress_sync_count`
- records duration in `ingress_backend_sync_time`

## Why

In practice, backend synchronization is a meaningful part of ingress reconciliation, but it was not reflected in these metrics. As a result, environments showing backend sync activity could still report no change in ingress_sync_count, which made the metric harder to interpret and alert on.


## Manual verification

Reviewed `/metrics`, `ingress_backend_sync_time{...}`, `ingress_sync_count{...}`, and `ingress_updation_count{...}`. Sampled `ingress_sync_count` over time and verified increase to confirm backend reconciliation is now contributing to `ingress_sync_count`.