### PR TITLE
Enhancement: Create backend sets with their initial backends.

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -52,6 +52,11 @@ import (
 
 var errIngressClassNotReady = errors.New("ingress class not ready")
 
+const (
+	// ToBeDeletedTaint is set by cluster-autoscaler before a node is removed.
+	ToBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+)
+
 // Controller demonstrates how to implement a controller with client-go.
 type Controller struct {
 	controllerClass      string
@@ -60,6 +65,9 @@ type Controller struct {
 	ingressClassLister              networkinglisters.IngressClassLister
 	ingressLister                   networkinglisters.IngressLister
 	serviceLister                   corelisters.ServiceLister
+	endpointLister                  corelisters.EndpointsLister
+	podLister                       corelisters.PodLister
+	nodeLister                      corelisters.NodeLister
 	saLister                        corelisters.ServiceAccountLister
 	secretLister                    corelisters.SecretLister
 	queue                           workqueue.RateLimitingInterface
@@ -68,13 +76,15 @@ type Controller struct {
 	metricsCollector                *metric.IngressCollector
 	ctrCache                        ctrcache.Cache
 	useLbCompartmentForCertificates bool
+	useNodeBackends                 bool
 	eventRecorder                   events.EventRecorder
 }
 
 // NewController creates a new Controller.
 func NewController(controllerClass string, defaultCompartmentId string,
 	ingressClassInformer networkinginformers.IngressClassInformer, ingressInformer networkinginformers.IngressInformer,
-	saInformer coreinformers.ServiceAccountInformer, serviceLister corelisters.ServiceLister, secretInformer coreinformers.SecretInformer,
+	saInformer coreinformers.ServiceAccountInformer, serviceLister corelisters.ServiceLister, endpointLister corelisters.EndpointsLister,
+	podLister corelisters.PodLister, nodeLister corelisters.NodeLister, secretInformer coreinformers.SecretInformer,
 	client *client.ClientProvider, metricsCollector *metric.IngressCollector, ctrCache ctrcache.Cache, useLbCompartmentForCertificates bool, eventRecorder events.EventRecorder) *Controller {
 
 	c := &Controller{
@@ -84,6 +94,9 @@ func NewController(controllerClass string, defaultCompartmentId string,
 		ingressLister:                   ingressInformer.Lister(),
 		informer:                        ingressInformer,
 		serviceLister:                   serviceLister,
+		endpointLister:                  endpointLister,
+		podLister:                       podLister,
+		nodeLister:                      nodeLister,
 		saLister:                        saInformer.Lister(),
 		secretLister:                    secretInformer.Lister(),
 		client:                          client,
@@ -91,6 +104,7 @@ func NewController(controllerClass string, defaultCompartmentId string,
 		metricsCollector:                metricsCollector,
 		ctrCache:                        ctrCache,
 		useLbCompartmentForCertificates: useLbCompartmentForCertificates,
+		useNodeBackends:                 nodeLister != nil,
 		eventRecorder:                   eventRecorder,
 	}
 
@@ -428,6 +442,10 @@ func (c *Controller) ensureIngress(ctx context.Context, ingress *networkingv1.In
 	}
 
 	backendSetsToCreate := backendSetsToStage.Difference(actualBackendSets)
+	initialBackendsByBackendSet, err := c.getInitialBackendsByBackendSet(ingress)
+	if err != nil {
+		return err
+	}
 
 	for _, bsName := range backendSetsToCreate.List() {
 		startBuildTime := util.GetCurrentTimeInUnixMillis()
@@ -450,7 +468,7 @@ func (c *Controller) ensureIngress(ctx context.Context, ingress *networkingv1.In
 		healthChecker := stateStore.GetBackendSetHealthChecker(bsName)
 		policy := stateStore.GetBackendSetPolicy(bsName)
 		appCookie, lbCookie := stateStore.GetBackendSetSessionPersistence(bsName)
-		err = wrapperClient.GetLbClient().CreateBackendSet(context.TODO(), lbId, bsName, policy, healthChecker, backendSetSslConfig, appCookie, lbCookie)
+		err = wrapperClient.GetLbClient().CreateBackendSet(context.TODO(), lbId, bsName, policy, healthChecker, backendSetSslConfig, appCookie, lbCookie, initialBackendsByBackendSet[bsName])
 		if err != nil {
 			return wrapBackendSetTLSPolicyStageError(err, ingressClass.Name, bsName, backendSetPolicy, false)
 		}
@@ -461,10 +479,13 @@ func (c *Controller) ensureIngress(ctx context.Context, ingress *networkingv1.In
 		}
 	}
 
-	if stagedBackendSetPolicy {
+	if backendSetsToCreate.Len() > 0 || stagedBackendSetPolicy {
 		refreshedLb, _, err := wrapperClient.GetLbClient().RefreshLoadBalancer(context.TODO(), lbId)
 		if err != nil {
-			return fmt.Errorf("TLSPolicyBackendStageFailed: ingressClass=%s refresh load balancer after backend-set policy staging: %w", ingressClass.Name, err)
+			if stagedBackendSetPolicy {
+				return fmt.Errorf("TLSPolicyBackendStageFailed: ingressClass=%s refresh load balancer after backend-set policy staging: %w", ingressClass.Name, err)
+			}
+			return err
 		}
 		lb = refreshedLb
 	}
@@ -894,6 +915,153 @@ func wrapBackendSetTLSPolicyStageError(err error, ingressClassName string, backe
 	}
 	return fmt.Errorf("TLSPolicyBackendStageFailed: ingressClass=%s backendSet=%s policy=%s cipherSuite=%s protocols=%v: %w",
 		ingressClassName, backendSetName, policySource, policy.CipherSuiteName, policy.Protocols, err)
+}
+
+func (c *Controller) getInitialBackendsByBackendSet(ingress *networkingv1.Ingress) (map[string][]ociloadbalancer.BackendDetails, error) {
+	backendsByBackendSet := map[string][]ociloadbalancer.BackendDetails{}
+	if c.endpointLister == nil {
+		return backendsByBackendSet, nil
+	}
+
+	for _, rule := range ingress.Spec.Rules {
+		if !util.HasHTTPPaths(rule) {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if !util.HasServiceBackend(path) {
+				continue
+			}
+
+			pSvc, svc, err := util.ExtractServices(path, c.serviceLister, ingress)
+			if err != nil {
+				return nil, err
+			}
+
+			svcName, svcPort, targetPort, err := util.PathToServiceAndTargetPort(c.endpointLister, svc, pSvc, ingress.Namespace, c.useNodeBackends)
+			if err != nil {
+				klog.InfoS("unable to determine initial backend target port, creating backend set without initial backends",
+					"ingress", klog.KObj(ingress), "service", pSvc.Name, "err", err)
+				continue
+			}
+
+			backendSetName := util.GenerateBackendSetName(ingress.Namespace, svcName, svcPort)
+			if _, ok := backendsByBackendSet[backendSetName]; ok {
+				continue
+			}
+
+			backends, err := c.getInitialBackends(ingress.Namespace, svc, svcName, targetPort)
+			if err != nil {
+				klog.InfoS("unable to determine initial backends, creating backend set without initial backends",
+					"ingress", klog.KObj(ingress), "service", svcName, "backendSet", backendSetName, "err", err)
+				backends = nil
+			}
+			backendsByBackendSet[backendSetName] = backends
+		}
+	}
+
+	return backendsByBackendSet, nil
+}
+
+func (c *Controller) getInitialBackends(namespace string, svc *corev1.Service, svcName string, targetPort int32) ([]ociloadbalancer.BackendDetails, error) {
+	if c.useNodeBackends {
+		return c.getInitialNodeBackends(namespace, svc, svcName, targetPort)
+	}
+
+	epAddrs, err := util.GetEndpoints(c.endpointLister, namespace, svcName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch endpoints for %s/%s/%d: %w", namespace, svcName, targetPort, err)
+	}
+
+	backends := []ociloadbalancer.BackendDetails{}
+	for _, epAddr := range epAddrs {
+		backends = append(backends, util.NewBackend(epAddr.IP, targetPort))
+	}
+	return backends, nil
+}
+
+func (c *Controller) getInitialNodeBackends(namespace string, svc *corev1.Service, svcName string, nodePort int32) ([]ociloadbalancer.BackendDetails, error) {
+	if c.nodeLister == nil || c.podLister == nil || svc == nil || svc.Spec.Ports == nil || nodePort == 0 {
+		return nil, nil
+	}
+
+	backends := []ociloadbalancer.BackendDetails{}
+	trafficPolicy := svc.Spec.ExternalTrafficPolicy
+	if trafficPolicy == corev1.ServiceExternalTrafficPolicyTypeCluster {
+		nodes, err := c.filterNodes()
+		if err != nil {
+			return nil, err
+		}
+		for _, node := range nodes {
+			backends = append(backends, util.NewBackend(nodeInternalIP(node), nodePort))
+		}
+		return backends, nil
+	}
+
+	pods, err := util.RetrievePods(c.endpointLister, c.podLister, namespace, svcName)
+	if err != nil {
+		return nil, err
+	}
+	seenBackends := map[string]struct{}{}
+	for _, pod := range pods {
+		node, err := c.nodeLister.Get(pod.Spec.NodeName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Infof("node %s has been deleted, skipping pod", pod.Spec.NodeName)
+				continue
+			}
+			return nil, err
+		}
+		nodeIP := nodeInternalIP(node)
+		backendKey := fmt.Sprintf("%s:%d", nodeIP, nodePort)
+		if _, ok := seenBackends[backendKey]; ok {
+			continue
+		}
+		seenBackends[backendKey] = struct{}{}
+		backends = append(backends, util.NewBackend(nodeIP, nodePort))
+	}
+	return backends, nil
+}
+
+func (c *Controller) filterNodes() ([]*corev1.Node, error) {
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []*corev1.Node
+	for i := range nodes {
+		if isNodeReadyForBackends(nodes[i]) {
+			filtered = append(filtered, nodes[i])
+		}
+	}
+	return filtered, nil
+}
+
+func isNodeReadyForBackends(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == ToBeDeletedTaint {
+			return false
+		}
+	}
+
+	if len(node.Status.Conditions) == 0 {
+		return false
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+			return false
+		}
+	}
+	return true
+}
+
+func nodeInternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
 }
 
 func (c *Controller) deleteIngress(i *networkingv1.Ingress) error {

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const (
@@ -111,7 +112,7 @@ func inits(ctx context.Context, ingressClassList *networkingv1.IngressClassList,
 	}
 	fakeRecorder := events.NewFakeRecorder(10)
 	c := NewController("oci.oraclecloud.com/native-ingress-controller", "", ingressClassInformer,
-		ingressInformer, saInformer, serviceLister, secretInformer, fakeClient, nil, nil, false, fakeRecorder)
+		ingressInformer, saInformer, serviceLister, nil, nil, nil, secretInformer, fakeClient, nil, nil, false, fakeRecorder)
 	return c
 }
 
@@ -154,7 +155,34 @@ func initsWithCustomLBAndServicesSecretsAndCertManager(ctx context.Context, ingr
 	}
 	fakeRecorder := events.NewFakeRecorder(10)
 	return NewController("oci.oraclecloud.com/native-ingress-controller", "", ingressClassInformer,
-		ingressInformer, saInformer, serviceLister, secretInformer, fakeClient, nil, nil, false, fakeRecorder)
+		ingressInformer, saInformer, serviceLister, nil, nil, nil, secretInformer, fakeClient, nil, nil, false, fakeRecorder)
+}
+
+func TestGetInitialBackendsByBackendSetUsesEndpointBackends(t *testing.T) {
+	RegisterTestingT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ingressClassList := util.GetIngressClassList()
+	ingressList := util.ReadResourceAsIngressList(ingressPath)
+	c := inits(ctx, ingressClassList, ingressList)
+	c.serviceLister = getServiceLister(util.GetServiceListResource("default", "testecho1", 80))
+	c.endpointLister = util.GetEndpointsListerResource(util.GetEndpointsResourceList("testecho1", "default", false))
+
+	backendsByBackendSet, err := c.getInitialBackendsByBackendSet(&ingressList.Items[0])
+
+	Expect(err).To(BeNil())
+	backendSetName := util.GenerateBackendSetName("default", "testecho1", 80)
+	Expect(backendsByBackendSet[backendSetName]).To(HaveLen(1))
+	Expect(*backendsByBackendSet[backendSetName][0].IpAddress).To(Equal("6.7.8.9"))
+}
+
+func getServiceLister(services *v1.ServiceList) corelisters.ServiceLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for i := range services.Items {
+		_ = indexer.Add(&services.Items[i])
+	}
+	return corelisters.NewServiceLister(indexer)
 }
 
 func drainControllerQueue(c *Controller, initialIngressCount int) {
@@ -1810,6 +1838,29 @@ func TestDeleteIngress(t *testing.T) {
 	Expect(err == nil).Should(Equal(true))
 }
 
+func drainIngressQueue(c *Controller) []interface{} {
+	var items []interface{}
+	for c.queue.Len() > 0 {
+		item, shutdown := c.queue.Get()
+		if shutdown {
+			return items
+		}
+		items = append(items, item)
+		c.queue.Forget(item)
+		c.queue.Done(item)
+	}
+	return items
+}
+
+func queueItemsContain(items []interface{}, key string) bool {
+	for _, item := range items {
+		if item == key {
+			return true
+		}
+	}
+	return false
+}
+
 func TestIngressAdd(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1820,9 +1871,10 @@ func TestIngressAdd(t *testing.T) {
 	drainControllerQueue(c, len(ingressList.Items))
 	ingress := ingressList.Items[0].DeepCopy()
 	ingress.Name = "ingress-add-unique"
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(ingress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressAdd(ingress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestIngressUpdate(t *testing.T) {
@@ -1837,15 +1889,18 @@ func TestIngressUpdate(t *testing.T) {
 	newIngress := ingressList.Items[1].DeepCopy()
 	oldIngress.Name = "ingress-update-unique"
 	newIngress.Name = oldIngress.Name
-	queueSize := c.queue.Len()
 	c.ingressUpdate(&ingressList.Items[0], &ingressList.Items[1])
-	Expect(c.queue.Len()).Should(Equal(queueSize))
+	Expect(c.queue.Len()).Should(Equal(0))
 
 	oldIngress.ResourceVersion = "1"
 	newIngress.ResourceVersion = "2"
+
+	expectedKey, err := cache.MetaNamespaceKeyFunc(newIngress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressUpdate(oldIngress, newIngress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
+
 func TestIngressDelete(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1856,9 +1911,10 @@ func TestIngressDelete(t *testing.T) {
 	drainControllerQueue(c, len(ingressList.Items))
 	ingress := ingressList.Items[0].DeepCopy()
 	ingress.Name = "ingress-delete-unique"
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(ingress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressDelete(ingress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestSecretAdd(t *testing.T) {
@@ -1869,22 +1925,21 @@ func TestSecretAdd(t *testing.T) {
 	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
 	c := inits(ctx, ingressClassList, ingressList)
 	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(&ingressList.Items[0])
+	Expect(err).ShouldNot(HaveOccurred())
 	c.secretAdd(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}}, false)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestSecretAdd_IsInInitialList(t *testing.T) {
 	RegisterTestingT(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ingressClassList := util.GetIngressClassList()
-	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
-	c := inits(ctx, ingressClassList, ingressList)
-	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	c := &Controller{
+		queue: workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second, time.Second)),
+	}
+	defer c.queue.ShutDown()
+
 	c.secretAdd(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}}, true)
-	Expect(c.queue.Len()).Should(Equal(queueSize))
+	Expect(c.queue.Len()).Should(Equal(0))
 }
 
 func TestSecretUpdate(t *testing.T) {
@@ -1895,9 +1950,10 @@ func TestSecretUpdate(t *testing.T) {
 	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
 	c := inits(ctx, ingressClassList, ingressList)
 	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(&ingressList.Items[0])
+	Expect(err).ShouldNot(HaveOccurred())
 	c.secretUpdate(nil, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}})
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestProcessNextItem(t *testing.T) {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -425,7 +425,8 @@ func (lbc *LoadBalancerClient) CreateBackendSet(
 	healthChecker *loadbalancer.HealthCheckerDetails,
 	sslConfig *loadbalancer.SslConfigurationDetails,
 	appCookie *loadbalancer.SessionPersistenceConfigurationDetails,
-	lbCookie *loadbalancer.LbCookieSessionPersistenceConfigurationDetails) error {
+	lbCookie *loadbalancer.LbCookieSessionPersistenceConfigurationDetails,
+	backends ...[]loadbalancer.BackendDetails) error {
 
 	lb, _, err := lbc.GetLoadBalancer(ctx, lbID)
 	if err != nil {
@@ -448,6 +449,9 @@ func (lbc *LoadBalancerClient) CreateBackendSet(
 			SessionPersistenceConfiguration:         appCookie,
 			LbCookieSessionPersistenceConfiguration: lbCookie,
 		},
+	}
+	if len(backends) > 0 {
+		createBackendSetRequest.CreateBackendSetDetails.Backends = backends[0]
 	}
 
 	klog.Infof("Creating backend set with request: %s", util.PrettyPrint(createBackendSetRequest))

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -481,6 +481,26 @@ func TestLoadBalancerClient_UpdateBackendSet_PassesDesiredTLSPolicy(t *testing.T
 	Expect(capturedSslConfig.Protocols).To(Equal([]string{"TLSv1.2"}))
 }
 
+func TestLoadBalancerClient_CreateBackendSetIncludesInitialBackends(t *testing.T) {
+	RegisterTestingT(t)
+	mockClient := &captureLoadBalancerClient{}
+	loadBalancerClient := &LoadBalancerClient{
+		LbClient: mockClient,
+		Mu:       sync.Mutex{},
+		Cache:    map[string]*LbCacheObj{},
+	}
+
+	backends := []ociloadbalancer.BackendDetails{util.NewBackend("10.0.0.1", 8080)}
+	err := loadBalancerClient.CreateBackendSet(context.TODO(), "id", "new_backend_set", "LEAST_CONNECTIONS",
+		util.GetDefaultHeathChecker(), nil, nil, nil, backends)
+
+	Expect(err).To(BeNil())
+	Expect(mockClient.createBackendSetRequest).ToNot(BeNil())
+	Expect(mockClient.createBackendSetRequest.CreateBackendSetDetails.Backends).To(HaveLen(1))
+	Expect(*mockClient.createBackendSetRequest.CreateBackendSetDetails.Backends[0].IpAddress).To(Equal("10.0.0.1"))
+	Expect(*mockClient.createBackendSetRequest.CreateBackendSetDetails.Backends[0].Port).To(Equal(8080))
+}
+
 func TestLoadBalancerClient_UpdateListener(t *testing.T) {
 	RegisterTestingT(t)
 	loadBalancerClient := setupLBClient()
@@ -1154,7 +1174,18 @@ func (m MockLoadBalancerClient) UpdateListener(ctx context.Context, request ocil
 
 type captureLoadBalancerClient struct {
 	MockLoadBalancerClient
-	updateListenerRequest *ociloadbalancer.UpdateListenerRequest
+	createBackendSetRequest *ociloadbalancer.CreateBackendSetRequest
+	updateListenerRequest   *ociloadbalancer.UpdateListenerRequest
+}
+
+func (m *captureLoadBalancerClient) CreateBackendSet(ctx context.Context, request ociloadbalancer.CreateBackendSetRequest) (ociloadbalancer.CreateBackendSetResponse, error) {
+	m.createBackendSetRequest = &request
+	id := "id"
+	return ociloadbalancer.CreateBackendSetResponse{
+		RawResponse:      nil,
+		OpcWorkRequestId: &id,
+		OpcRequestId:     &id,
+	}, nil
 }
 
 func (m *captureLoadBalancerClient) UpdateListener(ctx context.Context, request ociloadbalancer.UpdateListenerRequest) (ociloadbalancer.UpdateListenerResponse, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/oracle/oci-native-ingress-controller/pkg/types"
 	v1 "k8s.io/client-go/informers/core/v1"
 	networkinginformers "k8s.io/client-go/informers/networking/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -81,6 +82,10 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			klog.Fatalf("failed to get cluster details: %v", err)
 		}
 		metricsCollector := metric.NewIngressCollector(opts.ControllerClass, reg)
+		var initialBackendNodeLister corelisters.NodeLister
+		if cni == string(containerengine.ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay) {
+			initialBackendNodeLister = nodeInformer.Lister()
+		}
 		ingressController := ingress.NewController(
 			opts.ControllerClass,
 			opts.CompartmentId,
@@ -88,6 +93,9 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			ingressInformer,
 			serviceAccountInformer,
 			serviceInformer.Lister(),
+			endpointInformer.Lister(),
+			podInformer.Lister(),
+			initialBackendNodeLister,
 			secretInformer,
 			client,
 			metricsCollector,


### PR DESCRIPTION
## Summary

Create backend sets with their initial backend list when possible, instead of always creating them empty and relying on a later backend reconciliation update.

## Why

Provisioning a new load balancer with many backend sets currently requires an extra `UpdateBackendSet` work request per backend set after creation. Including the initial backends in `CreateBackendSetDetails` can avoid those follow-up update requests when endpoint or node backend data is already available, reducing initial reconcile time for multi-service ingresses.

Initial backend discovery is best-effort: if endpoints, ports, pods, or nodes are not ready yet, the backend set is still created and the existing backend controller can populate it later.

## Manual verification

I’ve repeatedly run our product's integration tests in OCI Native mode with this change which creates multiple OCI load balancers with DNS names and certificates across different Ingress configurations, then validates the endpoints end to end. I also reviewed the OCI Load Balancer work requests and OCI Native ingress controller logs during the CI tests. 

I also added unit coverage for the duplicate node backend case you flagged, so the initial backend list now dedupes by `nodeIP:nodePort`.
