### PR TITLE
Bug-fix: Retry reconciliation on transient errors and stale LB state

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -23,6 +23,7 @@ import (
 	ctrcache "sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -921,6 +922,12 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	}
 
 	if errors.Is(err, errIngressClassNotReady) {
+		c.queue.AddAfter(key, 10*time.Second)
+		return
+	}
+
+	if exception.HasTransientError(err) {
+		klog.Infof("Transient error syncing ingress %v: %v", key, err)
 		c.queue.AddAfter(key, 10*time.Second)
 		return
 	}

--- a/pkg/controllers/ingress/ingress_test.go
+++ b/pkg/controllers/ingress/ingress_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const (
@@ -1810,6 +1811,29 @@ func TestDeleteIngress(t *testing.T) {
 	Expect(err == nil).Should(Equal(true))
 }
 
+func drainIngressQueue(c *Controller) []interface{} {
+	var items []interface{}
+	for c.queue.Len() > 0 {
+		item, shutdown := c.queue.Get()
+		if shutdown {
+			return items
+		}
+		items = append(items, item)
+		c.queue.Forget(item)
+		c.queue.Done(item)
+	}
+	return items
+}
+
+func queueItemsContain(items []interface{}, key string) bool {
+	for _, item := range items {
+		if item == key {
+			return true
+		}
+	}
+	return false
+}
+
 func TestIngressAdd(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1820,9 +1844,10 @@ func TestIngressAdd(t *testing.T) {
 	drainControllerQueue(c, len(ingressList.Items))
 	ingress := ingressList.Items[0].DeepCopy()
 	ingress.Name = "ingress-add-unique"
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(ingress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressAdd(ingress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestIngressUpdate(t *testing.T) {
@@ -1843,9 +1868,14 @@ func TestIngressUpdate(t *testing.T) {
 
 	oldIngress.ResourceVersion = "1"
 	newIngress.ResourceVersion = "2"
+
+	drainIngressQueue(c)
+	expectedKey, err := cache.MetaNamespaceKeyFunc(newIngress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressUpdate(oldIngress, newIngress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
+
 func TestIngressDelete(t *testing.T) {
 	RegisterTestingT(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1856,9 +1886,10 @@ func TestIngressDelete(t *testing.T) {
 	drainControllerQueue(c, len(ingressList.Items))
 	ingress := ingressList.Items[0].DeepCopy()
 	ingress.Name = "ingress-delete-unique"
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(ingress)
+	Expect(err).ShouldNot(HaveOccurred())
 	c.ingressDelete(ingress)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestSecretAdd(t *testing.T) {
@@ -1869,22 +1900,22 @@ func TestSecretAdd(t *testing.T) {
 	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
 	c := inits(ctx, ingressClassList, ingressList)
 	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(&ingressList.Items[0])
+	Expect(err).ShouldNot(HaveOccurred())
 	c.secretAdd(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}}, false)
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestSecretAdd_IsInInitialList(t *testing.T) {
 	RegisterTestingT(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ingressClassList := util.GetIngressClassList()
-	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
-	c := inits(ctx, ingressClassList, ingressList)
-	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	c := &Controller{
+		queue: workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second, time.Second)),
+	}
+	defer c.queue.ShutDown()
+
 	c.secretAdd(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}}, true)
-	Expect(c.queue.Len()).Should(Equal(queueSize))
+
+	Expect(c.queue.Len()).Should(Equal(0))
 }
 
 func TestSecretUpdate(t *testing.T) {
@@ -1895,9 +1926,10 @@ func TestSecretUpdate(t *testing.T) {
 	ingressList := util.ReadResourceAsIngressList(ingressPathWithTlsSecret)
 	c := inits(ctx, ingressClassList, ingressList)
 	drainControllerQueue(c, len(ingressList.Items))
-	queueSize := c.queue.Len()
+	expectedKey, err := cache.MetaNamespaceKeyFunc(&ingressList.Items[0])
+	Expect(err).ShouldNot(HaveOccurred())
 	c.secretUpdate(nil, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"}})
-	Expect(c.queue.Len()).Should(Equal(queueSize + 1))
+	Expect(queueItemsContain(drainIngressQueue(c), expectedKey)).Should(BeTrue())
 }
 
 func TestProcessNextItem(t *testing.T) {

--- a/pkg/controllers/ingressclass/ingressclass_test.go
+++ b/pkg/controllers/ingressclass/ingressclass_test.go
@@ -24,6 +24,7 @@ import (
 	WAF "github.com/oracle/oci-native-ingress-controller/pkg/waf"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	networkinginformers "k8s.io/client-go/informers/networking/v1"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -636,10 +637,18 @@ func initsWithCustomClients(ctx context.Context, ingressClassList *networkingv1.
 }
 
 func setUp(ctx context.Context, ingressClassList *networkingv1.IngressClassList) (networkinginformers.IngressClassInformer, coreinformers.ServiceAccountInformer, *fakeclientset.Clientset) {
-	fakeClient := fakeclientset.NewSimpleClientset()
-
-	util.UpdateFakeClientCall(fakeClient, "list", "ingressclasses", ingressClassList)
-	util.UpdateFakeClientCall(fakeClient, "patch", "ingressclasses", &ingressClassList.Items[0])
+	objects := make([]runtime.Object, 0, len(ingressClassList.Items))
+	hasDeleteFinalizerTestClass := false
+	for i := range ingressClassList.Items {
+		if ingressClassList.Items[i].Name == "name" {
+			hasDeleteFinalizerTestClass = true
+		}
+		objects = append(objects, ingressClassList.Items[i].DeepCopy())
+	}
+	if !hasDeleteFinalizerTestClass {
+		objects = append(objects, (&networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{Name: "name"}}).DeepCopy())
+	}
+	fakeClient := fakeclientset.NewSimpleClientset(objects...)
 
 	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 	ingressClassInformer := informerFactory.Networking().V1().IngressClasses()

--- a/pkg/controllers/routingpolicy/routingpolicy.go
+++ b/pkg/controllers/routingpolicy/routingpolicy.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"github.com/oracle/oci-native-ingress-controller/pkg/client"
+	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
@@ -276,6 +277,12 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	}
 
 	if errors.Is(err, errIngressClassNotReady) {
+		c.queue.AddAfter(key, 10*time.Second)
+		return
+	}
+
+	if exception.HasTransientError(err) {
+		klog.Infof("Transient error syncing routing policy %v: %v", key, err)
 		c.queue.AddAfter(key, 10*time.Second)
 		return
 	}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -274,6 +274,10 @@ func (lbc *LoadBalancerClient) createRoutingPolicy(
 		return nil
 	}
 
+	if err := validateRoutingRuleBackendSets(lb, policyName, rules); err != nil {
+		return err
+	}
+
 	createPolicyRequest := loadbalancer.CreateRoutingPolicyRequest{
 		LoadBalancerId: lb.Id,
 		CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
@@ -455,6 +459,7 @@ func (lbc *LoadBalancerClient) CreateBackendSet(
 
 	if util.IsServiceError(err, 409) {
 		klog.Infof("Create backend set operation returned code %d for load balancer %s. Backend set %s may be already present.", 409, lbID, backendSetName)
+		_, _, _ = lbc.getLoadBalancerBustCache(ctx, lbID)
 		return nil
 	}
 
@@ -535,6 +540,10 @@ func (lbc *LoadBalancerClient) updateRoutingPolicyRules(ctx context.Context, lbI
 		return nil
 	}
 
+	if err := validateRoutingRuleBackendSets(lb, policyName, rules); err != nil {
+		return err
+	}
+
 	klog.Infof("Routing policy %s for lb %s needs update.", policyName, lbID)
 
 	updateRoutingPolicyRequest := loadbalancer.UpdateRoutingPolicyRequest{
@@ -568,6 +577,27 @@ func (lbc *LoadBalancerClient) updateRoutingPolicyRules(ctx context.Context, lbI
 	klog.Infof("Update routing policy response: name: %s, work request id: %s, opc request id: %s.", policyName, *resp.OpcWorkRequestId, *resp.OpcRequestId)
 	_, err = lbc.waitForWorkRequest(ctx, *resp.OpcWorkRequestId)
 	return err
+}
+
+func validateRoutingRuleBackendSets(lb *loadbalancer.LoadBalancer, policyName string, rules []loadbalancer.RoutingRule) error {
+	for _, rule := range rules {
+		for _, action := range rule.Actions {
+			forwardAction, ok := action.(loadbalancer.ForwardToBackendSet)
+			if !ok {
+				continue
+			}
+
+			if forwardAction.BackendSetName == nil {
+				continue
+			}
+
+			backendSetName := *forwardAction.BackendSetName
+			if _, ok := lb.BackendSets[backendSetName]; !ok {
+				return exception.NewTransientError(fmt.Errorf("routing policy %s references backendset %s which does not exist in load balancer %s", policyName, backendSetName, *lb.Id))
+			}
+		}
+	}
+	return nil
 }
 
 // UpdateBackends updates Backends for backendSetName, while preserving sslConfig, policy, and healthChecker details
@@ -675,6 +705,7 @@ func (lbc *LoadBalancerClient) UpdateBackendSet(ctx context.Context, lbID string
 	isTransient, errMsg := util.AsServiceError(err, 409, 412)
 	if isTransient {
 		klog.Errorf("Unable to update BackendSet %s for load balancer %s due to %s", backendSetName, lbID, errMsg)
+		_, _, _ = lbc.getLoadBalancerBustCache(ctx, lbID)
 		return exception.NewTransientError(err)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -42,6 +42,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	"github.com/oracle/oci-native-ingress-controller/pkg/exception"
+
 	"github.com/pkg/errors"
 
 	"github.com/oracle/oci-native-ingress-controller/api/v1beta1"
@@ -127,6 +129,8 @@ const (
 type DefinedTagsType = map[string]map[string]interface{}
 
 var ErrIngressClassNotReady = errors.New("ingress class not ready")
+
+var errIngressClassAnnotationNotApplied = errors.New("ingress class annotation was not applied")
 
 func GetIngressClassParameters(ic *networkingv1.IngressClass, ctrCache ctrcache.Cache) (*v1beta1.IngressClassParameters, error) {
 	icp := &v1beta1.IngressClassParameters{}
@@ -803,9 +807,22 @@ func PatchIngressClassWithAnnotation(client kubernetes.Interface, ic *networking
 	}
 
 	klog.Infof("Will try patching IngressClass %s for annotation %s: %s", ic.Name, annotationName, annotationValue)
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return apierrors.IsConflict(err) || errors.Is(err, errIngressClassAnnotationNotApplied)
+	}, func() error {
 		_, err := client.NetworkingV1().IngressClasses().Patch(context.TODO(), ic.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-		return err
+		if err != nil {
+			return err
+		}
+
+		updated, err := client.NetworkingV1().IngressClasses().Get(context.TODO(), ic.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if updated.Annotations[annotationName] != annotationValue {
+			return errors.Wrapf(errIngressClassAnnotationNotApplied, "IngressClass %s expected %s=%s", ic.Name, annotationName, annotationValue)
+		}
+		return nil
 	})
 
 	if apierrors.IsConflict(err) {
@@ -939,6 +956,12 @@ func HandleErrForBackendController(eventRecorder events.EventRecorder, ingressCl
 	}
 
 	if errors.Is(err, ErrIngressClassNotReady) {
+		queue.AddAfter(key, 10*time.Second)
+		return
+	}
+
+	if exception.HasTransientError(err) {
+		klog.Infof("Transient "+message+" %v: %v", key, err)
 		queue.AddAfter(key, 10*time.Second)
 		return
 	}


### PR DESCRIPTION
## Summary

Harden OCI Native Ingress reconciliation against transient load balancer dependency errors, stale LB state, and IngressClass annotation writes.

## Why

OCI load balancer updates do not become visible all at once. The controller can reconcile related resources before a newly created listener, backend set, updated ETag, or IngressClass annotation is visible. These are temporary convergence states, so the controller should keep retrying instead of treating them as final failures.

## Manual verification

Verified with OCI Native Ingress CI failures where routing policy/backend reconciliation hit missing backend sets, missing route_443, stale ETags, and a missing LB ID annotation while the LB was still converging. Confirmed the controller now treats those dependency and stale-state paths as transient retries, refreshes LB state before subsequent backend update attempts, and verifies IngressClass annotation writes after patching.

I’ve repeatedly run our product's integration tests in OCI Native mode with this change which creates multiple OCI load balancers with DNS names and certificates across different Ingress configurations, then validates the endpoints end to end. I also reviewed the OCI Load Balancer work requests and OCI Native ingress controller logs during the CI tests. All checks look good with this change. 
