### PR TITLE
Enhancement: Make controller worker count configurable

### DIFF
--- a/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
+++ b/deploy/manifests/oci-native-ingress-controller/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
           - --use-lb-compartment-for-certificates=false
           - --emit-events=false
           - --cert-deletion-grace-period-in-days=0
+          - --num-workers=3
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION
               value: "2.2"

--- a/helm/oci-native-ingress-controller/templates/deployment.yaml
+++ b/helm/oci-native-ingress-controller/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
           - --use-lb-compartment-for-certificates={{ .Values.useLbCompartmentForCertificates }}
           - --emit-events={{ .Values.emitEvents }}
           - --cert-deletion-grace-period-in-days={{ .Values.certDeletionGracePeriodInDays }}
+          - --num-workers={{ .Values.numWorkers }}
           env:
             - name: OCI_RESOURCE_PRINCIPAL_VERSION
               value: "2.2"

--- a/helm/oci-native-ingress-controller/values.yaml
+++ b/helm/oci-native-ingress-controller/values.yaml
@@ -139,3 +139,6 @@ emitEvents: false
 # This cleanup is done periodically by NIC
 # If less than or equal to 0, certificate resource cleanup is disabled
 certDeletionGracePeriodInDays: 0
+
+# Number of workers to run for each controller workqueue
+numWorkers: 3

--- a/main.go
+++ b/main.go
@@ -63,6 +63,8 @@ func main() {
 	flag.BoolVar(&opts.EmitEvents, "emit-events", false, "emit kubernetes events for Ingress/IngressClass errors observed during reconciliation")
 	flag.Int64Var(&opts.CertDeletionGracePeriodInDays, "cert-deletion-grace-period-in-days", 0,
 		"number of days before an unused oci certificate service resource is deleted, if non-positive this cleanup is disabled")
+	flag.IntVar(&opts.NumWorkers, "num-workers", types.DefaultNumWorkers,
+		"number of workers to run for each controller workqueue")
 
 	var logFile string
 	flag.StringVar(&logFile, "log-file", "", "absolute path to the file where application logs will be stored")
@@ -113,6 +115,9 @@ func main() {
 
 	if opts.UseLbCompartmentForCertificates {
 		klog.Info("use-lb-compartment-for-certificates flag set to true, will use LB compartment for certificate management")
+	}
+	if opts.NumWorkers <= 0 {
+		klog.Fatal("num-workers must be greater than zero")
 	}
 
 	// leader election uses the Kubernetes API by writing to a

--- a/pkg/loadbalancer/keyed_mutex.go
+++ b/pkg/loadbalancer/keyed_mutex.go
@@ -1,0 +1,49 @@
+/*
+ *
+ * * OCI Native Ingress Controller
+ * *
+ * * Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+ * * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ *
+ */
+
+package loadbalancer
+
+import "sync"
+
+type keyedMutex struct {
+	mu      sync.Mutex
+	entries map[string]*keyedMutexEntry
+}
+
+type keyedMutexEntry struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (m *keyedMutex) lock(key string) func() {
+	m.mu.Lock()
+	if m.entries == nil {
+		m.entries = make(map[string]*keyedMutexEntry)
+	}
+
+	entry := m.entries[key]
+	if entry == nil {
+		entry = &keyedMutexEntry{}
+		m.entries[key] = entry
+	}
+	entry.refs++
+	m.mu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+
+		m.mu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(m.entries, key)
+		}
+		m.mu.Unlock()
+	}
+}

--- a/pkg/loadbalancer/keyed_mutex_test.go
+++ b/pkg/loadbalancer/keyed_mutex_test.go
@@ -1,0 +1,63 @@
+/*
+ *
+ * * OCI Native Ingress Controller
+ * *
+ * * Copyright (c) 2023 Oracle America, Inc. and its affiliates.
+ * * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ *
+ */
+
+package loadbalancer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyedMutexSerializesSameKey(t *testing.T) {
+	var locks keyedMutex
+	unlockFirst := locks.lock("lb-1")
+
+	acquired := make(chan struct{})
+	go func() {
+		unlockSecond := locks.lock("lb-1")
+		close(acquired)
+		unlockSecond()
+	}()
+
+	acquiredEarly := false
+	select {
+	case <-acquired:
+		acquiredEarly = true
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	unlockFirst()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second lock for the same key was not released")
+	}
+	if acquiredEarly {
+		t.Fatal("second lock for the same key acquired before the first was released")
+	}
+}
+
+func TestKeyedMutexAllowsDifferentKeys(t *testing.T) {
+	var locks keyedMutex
+	unlockFirst := locks.lock("lb-1")
+	defer unlockFirst()
+
+	acquired := make(chan struct{})
+	go func() {
+		unlockSecond := locks.lock("lb-2")
+		close(acquired)
+		unlockSecond()
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("lock for a different key was blocked")
+	}
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -36,8 +36,9 @@ type LbCacheObj struct {
 type LoadBalancerClient struct {
 	LbClient client.LoadBalancerInterface
 
-	Mu    sync.Mutex
-	Cache map[string]*LbCacheObj
+	Mu            sync.Mutex
+	Cache         map[string]*LbCacheObj
+	mutationLocks keyedMutex
 }
 
 const multiCertificateCapabilityErrorMessage = "OCI Load Balancer multi-certificate listeners may not be supported in this tenancy or region; verify enablement or use one certificate"
@@ -426,8 +427,12 @@ func (lbc *LoadBalancerClient) CreateBackendSet(
 	sslConfig *loadbalancer.SslConfigurationDetails,
 	appCookie *loadbalancer.SessionPersistenceConfigurationDetails,
 	lbCookie *loadbalancer.LbCookieSessionPersistenceConfigurationDetails) error {
+	unlock := lbc.mutationLocks.lock(lbID)
+	defer unlock()
 
-	lb, _, err := lbc.GetLoadBalancer(ctx, lbID)
+	// Refresh inside the per-LB lock so concurrent workers cannot all act on
+	// the same cached state and submit duplicate create operations.
+	lb, _, err := lbc.getLoadBalancerBustCache(ctx, lbID)
 	if err != nil {
 		return err
 	}
@@ -857,8 +862,12 @@ func (lbc *LoadBalancerClient) updateListener(ctx context.Context, lbId *string,
 
 func (lbc *LoadBalancerClient) CreateListener(ctx context.Context, lbID string, listenerPort int, listenerProtocol string,
 	defaultBackendSet string, sslConfig *loadbalancer.SslConfigurationDetails) error {
+	unlock := lbc.mutationLocks.lock(lbID)
+	defer unlock()
 
-	lb, _, err := lbc.GetLoadBalancer(ctx, lbID)
+	// Backend sets and listeners share this lock because both mutate the same
+	// load balancer configuration and OCI applies them asynchronously.
+	lb, _, err := lbc.getLoadBalancerBustCache(ctx, lbID)
 	if err != nil {
 		return err
 	}

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -479,6 +480,44 @@ func TestLoadBalancerClient_UpdateBackendSet_PassesDesiredTLSPolicy(t *testing.T
 	Expect(capturedSslConfig.TrustedCertificateAuthorityIds).To(Equal([]string{"ca-desired"}))
 	Expect(*capturedSslConfig.CipherSuiteName).To(Equal("desired-backend-cipher"))
 	Expect(capturedSslConfig.Protocols).To(Equal([]string{"TLSv1.2"}))
+}
+
+func TestLoadBalancerClientSerializesCreateOperationsForSameLoadBalancer(t *testing.T) {
+	RegisterTestingT(t)
+	mockClient := &blockingCreateLoadBalancerClient{
+		backendStarted:  make(chan struct{}),
+		releaseBackend:  make(chan struct{}),
+		listenerStarted: make(chan struct{}),
+	}
+	loadBalancerClient := &LoadBalancerClient{
+		LbClient: mockClient,
+		Cache:    map[string]*LbCacheObj{},
+	}
+
+	backendResult := make(chan error, 1)
+	go func() {
+		backendResult <- loadBalancerClient.CreateBackendSet(context.Background(), "id", "new-backend", "", nil, nil, nil, nil)
+	}()
+	<-mockClient.backendStarted
+
+	listenerResult := make(chan error, 1)
+	go func() {
+		listenerResult <- loadBalancerClient.CreateListener(context.Background(), "id", 9443, util.ProtocolHTTP, "new-backend", nil)
+	}()
+
+	listenerStartedEarly := false
+	select {
+	case <-mockClient.listenerStarted:
+		listenerStartedEarly = true
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(mockClient.releaseBackend)
+	Expect(<-backendResult).To(Succeed())
+	Expect(<-listenerResult).To(Succeed())
+	if listenerStartedEarly {
+		t.Fatal("listener creation started while backend-set creation was still running")
+	}
 }
 
 func TestLoadBalancerClient_UpdateListener(t *testing.T) {
@@ -970,6 +1009,24 @@ var capturedUpdateLoadBalancerRequest *ociloadbalancer.UpdateLoadBalancerDetails
 var mockCreateListenerErr error
 var mockLoadBalancerResponseMutator func(*ociloadbalancer.GetLoadBalancerResponse)
 var mockUpdateListenerErr error
+
+type blockingCreateLoadBalancerClient struct {
+	MockLoadBalancerClient
+	backendStarted  chan struct{}
+	releaseBackend  chan struct{}
+	listenerStarted chan struct{}
+}
+
+func (m *blockingCreateLoadBalancerClient) CreateBackendSet(ctx context.Context, request ociloadbalancer.CreateBackendSetRequest) (ociloadbalancer.CreateBackendSetResponse, error) {
+	close(m.backendStarted)
+	<-m.releaseBackend
+	return m.MockLoadBalancerClient.CreateBackendSet(ctx, request)
+}
+
+func (m *blockingCreateLoadBalancerClient) CreateListener(ctx context.Context, request ociloadbalancer.CreateListenerRequest) (ociloadbalancer.CreateListenerResponse, error) {
+	close(m.listenerStarted)
+	return m.MockLoadBalancerClient.CreateListener(ctx, request)
+}
 
 type MockLoadBalancerClient struct {
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,9 +116,9 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			eventRecorder,
 		)
 
-		go ingressClassController.Run(3, ctx.Done())
-		go ingressController.Run(3, ctx.Done())
-		go routingPolicyController.Run(3, ctx.Done())
+		go ingressClassController.Run(opts.NumWorkers, ctx.Done())
+		go ingressController.Run(opts.NumWorkers, ctx.Done())
+		go routingPolicyController.Run(opts.NumWorkers, ctx.Done())
 
 		klog.Infof("CNI Type of given cluster : %s", cni)
 		if cni == string(containerengine.ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay) {
@@ -135,7 +135,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				client,
 				eventRecorder,
 			)
-			go backendController.Run(3, ctx.Done())
+			go backendController.Run(opts.NumWorkers, ctx.Done())
 		} else {
 			backendController := backend.NewController(
 				opts.ControllerClass,
@@ -148,7 +148,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				client,
 				eventRecorder,
 			)
-			go backendController.Run(3, ctx.Done())
+			go backendController.Run(opts.NumWorkers, ctx.Done())
 		}
 
 		if opts.CertDeletionGracePeriodInDays > 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,9 +117,9 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 			eventRecorder,
 		)
 
-		go ingressClassController.Run(3, ctx.Done())
-		go ingressController.Run(3, ctx.Done())
-		go routingPolicyController.Run(3, ctx.Done())
+		go ingressClassController.Run(opts.NumWorkers, ctx.Done())
+		go ingressController.Run(opts.NumWorkers, ctx.Done())
+		go routingPolicyController.Run(opts.NumWorkers, ctx.Done())
 
 		klog.Infof("CNI Type of given cluster : %s", cni)
 		if cni == string(containerengine.ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay) {
@@ -137,7 +137,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				metricsCollector,
 				eventRecorder,
 			)
-			go backendController.Run(3, ctx.Done())
+			go backendController.Run(opts.NumWorkers, ctx.Done())
 		} else {
 			backendController := backend.NewController(
 				opts.ControllerClass,
@@ -151,7 +151,7 @@ func SetUpControllers(opts types.IngressOpts, ingressClassInformer networkinginf
 				metricsCollector,
 				eventRecorder,
 			)
-			go backendController.Run(3, ctx.Done())
+			go backendController.Run(opts.NumWorkers, ctx.Done())
 		}
 
 		if opts.CertDeletionGracePeriodInDays > 0 {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,6 +21,8 @@ const (
 	Instance         OCIPrincipalType = "instance"
 	User             OCIPrincipalType = "user"
 	WorkloadIdentity OCIPrincipalType = "workloadIdentity"
+
+	DefaultNumWorkers = 3
 )
 
 type IngressOpts struct {
@@ -39,6 +41,7 @@ type IngressOpts struct {
 	UseLbCompartmentForCertificates bool
 	EmitEvents                      bool
 	CertDeletionGracePeriodInDays   int64
+	NumWorkers                      int
 }
 
 func MapToPrincipalType(authType string) (OCIPrincipalType, error) {


### PR DESCRIPTION
## Summary

Make the OCI Native Ingress controller worker count configurable with a new `--num-workers` flag, defaulting to 3 to preserve existing behavior.

## Why

The controller currently runs each workqueue with a _hard-coded_ worker count of `3`. During busy reconciliation, long-running OCI load balancer operations can occupy those workers and delay queued ingress, ingress class, routing policy, and backend reconciliation. Exposing `--num-workers` allows deployments to increase controller throughput when needed without changing the default behavior.
